### PR TITLE
Lane C: Fix project symbol-graph regressions + IO diagnostics

### DIFF
--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -295,25 +295,69 @@ pub fn check_project(entry_file: &std::path::Path) -> CheckOutput {
         }
     }
 
-    // Post-process call edges: build a global fn_name → qualified_id map,
-    // then rewrite any call edge that doesn't match an emitted function ID.
-    let fn_name_to_id: std::collections::HashMap<String, String> = all_functions
-        .iter()
-        .map(|f| (f.name.clone(), f.id.clone()))
-        .collect();
+    // Post-process call edges:
+    // 1) Keep edges that already point at emitted function IDs.
+    // 2) For non-emitted IDs, rewrite by bare function name only when there is
+    //    a unique global target.
+    // 3) Drop unresolved/ambiguous edges instead of misattributing them.
+    let emitted_fn_ids: std::collections::HashSet<String> =
+        all_functions.iter().map(|f| f.id.clone()).collect();
+    let mut fn_name_to_ids: std::collections::HashMap<String, Vec<String>> =
+        std::collections::HashMap::new();
+    for f in &all_functions {
+        fn_name_to_ids
+            .entry(f.name.clone())
+            .or_default()
+            .push(f.id.clone());
+    }
+    for ids in fn_name_to_ids.values_mut() {
+        ids.sort();
+        ids.dedup();
+    }
+
     for func in &mut all_functions {
-        for call in &mut func.calls {
-            // If the call ID doesn't match any emitted function, look up by name.
-            if !fn_name_to_id.values().any(|id| id == call) {
-                // Extract the callee name (last segment after "fn::").
-                let callee_name = call.strip_prefix("fn::").unwrap_or(call);
-                // Strip any module prefix to get the bare name.
-                let bare_name = callee_name.rsplit("::").next().unwrap_or(callee_name);
-                if let Some(qualified) = fn_name_to_id.get(bare_name) {
-                    *call = qualified.clone();
-                }
+        let mut rewritten_calls = Vec::with_capacity(func.calls.len());
+        for call in &func.calls {
+            // Extract bare callee name from IDs like `fn::foo` or `fn::m::foo`.
+            let callee_name = call.strip_prefix("fn::").unwrap_or(call);
+            let bare_name = callee_name.rsplit("::").next().unwrap_or(callee_name);
+
+            let Some(candidates) = fn_name_to_ids.get(bare_name) else {
+                // Unknown callee in project graph.
+                continue;
+            };
+
+            if candidates.len() == 1 {
+                rewritten_calls.push(candidates[0].clone());
+                continue;
+            }
+
+            let qualified: Vec<&String> = candidates
+                .iter()
+                .filter(|id| {
+                    id.strip_prefix("fn::")
+                        .map(|rest| rest.contains("::"))
+                        .unwrap_or(false)
+                })
+                .collect();
+
+            // If we have exactly one qualified target and the current edge is a
+            // bare `fn::name` alias, prefer the qualified definition.
+            let is_bare_fn_id = call
+                .strip_prefix("fn::")
+                .map(|rest| !rest.contains("::"))
+                .unwrap_or(false);
+            if is_bare_fn_id && qualified.len() == 1 {
+                rewritten_calls.push(qualified[0].clone());
+                continue;
+            }
+
+            // Keep already-emitted IDs when no canonical rewrite is available.
+            if emitted_fn_ids.contains(call) {
+                rewritten_calls.push(call.clone());
             }
         }
+        func.calls = rewritten_calls;
         dedupe_call_ids(&mut func.calls);
     }
 
@@ -592,7 +636,7 @@ fn build_module_symbol_graph(
     let fn_names: std::collections::HashSet<&str> = item_tree
         .functions
         .iter()
-        .filter(|(_, f)| f.source_range.is_some())
+        .filter(|(_, f)| f.source_range.is_some() || f.is_pub)
         .map(|(_, f)| f.name.resolve(interner))
         .collect();
 
@@ -618,42 +662,52 @@ fn build_module_symbol_graph(
             .collect();
 
     // Functions (excluding capability members).
-    let functions: Vec<FnNodeDto> = item_tree
-        .functions
-        .iter()
-        .filter(|(_, f)| f.source_range.is_some())
-        .filter(|(idx, _)| !cap_member_fns.contains(idx))
-        .map(|(_, fn_item)| {
-            let name = fn_item.name.resolve(interner).to_owned();
-            let params: Vec<ParamDto> = fn_item
-                .params
-                .iter()
-                .map(|p| ParamDto {
-                    name: p.name.resolve(interner).to_owned(),
-                    ty: display_type_ref(&p.ty, interner),
-                })
-                .collect();
-            let return_type = fn_item
-                .ret_type
-                .as_ref()
-                .map(|t| display_type_ref(t, interner));
-            let effects: Vec<String> = fn_item
-                .with_caps
-                .iter()
-                .filter_map(|tr| type_ref_name(tr, interner))
-                .collect();
-            let calls = call_map.get(&name).cloned().unwrap_or_default();
-            let id = symbol_id("fn", &name, module_prefix);
-            FnNodeDto {
-                id,
-                name,
-                params,
-                return_type,
-                effects,
-                calls,
-            }
-        })
-        .collect();
+    let mut functions: Vec<FnNodeDto> = Vec::new();
+    let mut fn_id_counts: std::collections::HashMap<String, usize> =
+        std::collections::HashMap::new();
+    for (idx, fn_item) in item_tree.functions.iter() {
+        if fn_item.source_range.is_none() || cap_member_fns.contains(&idx) {
+            continue;
+        }
+
+        let name = fn_item.name.resolve(interner).to_owned();
+        let params: Vec<ParamDto> = fn_item
+            .params
+            .iter()
+            .map(|p| ParamDto {
+                name: p.name.resolve(interner).to_owned(),
+                ty: display_type_ref(&p.ty, interner),
+            })
+            .collect();
+        let return_type = fn_item
+            .ret_type
+            .as_ref()
+            .map(|t| display_type_ref(t, interner));
+        let effects: Vec<String> = fn_item
+            .with_caps
+            .iter()
+            .filter_map(|tr| type_ref_name(tr, interner))
+            .collect();
+        let calls = call_map.get(&name).cloned().unwrap_or_default();
+
+        let base_id = symbol_id("fn", &name, module_prefix);
+        let count = fn_id_counts.entry(base_id.clone()).or_insert(0);
+        *count += 1;
+        let id = if *count == 1 {
+            base_id
+        } else {
+            format!("{base_id}#{}", count)
+        };
+
+        functions.push(FnNodeDto {
+            id,
+            name,
+            params,
+            return_type,
+            effects,
+            calls,
+        });
+    }
 
     // Types.
     let types: Vec<TypeNodeDto> = item_tree
@@ -667,6 +721,18 @@ fn build_module_symbol_graph(
                 .map(|n| n.resolve(interner).to_owned())
                 .collect();
             let (kind, fields, variants) = match &type_item.kind {
+                TypeDefKind::Alias(TypeRef::Record {
+                    fields: alias_fields,
+                }) => {
+                    let fs: Vec<ParamDto> = alias_fields
+                        .iter()
+                        .map(|(n, tr)| ParamDto {
+                            name: n.resolve(interner).to_owned(),
+                            ty: display_type_ref(tr, interner),
+                        })
+                        .collect();
+                    ("record".to_owned(), fs, Vec::new())
+                }
                 TypeDefKind::Alias(_) => ("alias".to_owned(), Vec::new(), Vec::new()),
                 TypeDefKind::Record { fields: def_fields } => {
                     let fs: Vec<ParamDto> = def_fields

--- a/crates/api/tests/api_tests.rs
+++ b/crates/api/tests/api_tests.rs
@@ -209,6 +209,32 @@ fn symbol_graph_contains_types() {
 }
 
 #[test]
+fn symbol_graph_alias_to_record_emits_record_kind_with_fields() {
+    let src = "type Point = { x: Int, y: Int }\nfn main() -> Int { 1 }\n";
+    let output = check(src, "test.ky");
+    let point = output
+        .symbol_graph
+        .types
+        .iter()
+        .find(|t| t.name == "Point")
+        .expect("should contain Point type");
+
+    assert_eq!(
+        point.kind, "record",
+        "alias-to-record should be represented as a record node"
+    );
+    assert_eq!(
+        point.fields.len(),
+        2,
+        "record fields should be preserved for alias-to-record types"
+    );
+    assert_eq!(point.fields[0].name, "x");
+    assert_eq!(point.fields[0].ty, "Int");
+    assert_eq!(point.fields[1].name, "y");
+    assert_eq!(point.fields[1].ty, "Int");
+}
+
+#[test]
 fn symbol_graph_contains_capabilities() {
     let src = r#"
         cap IO {
@@ -889,6 +915,33 @@ fn project_symbol_graph_no_duplicate_builtins() {
 }
 
 #[test]
+fn project_symbol_graph_imported_fn_not_duplicated_as_local_alias() {
+    let (_dir, main_path) = write_project(&[
+        ("main.ky", "import a\nfn main() -> Int { foo() }\n"),
+        ("a.ky", "pub fn foo() -> Int { 1 }\n"),
+    ]);
+    let output = check_project(&main_path);
+
+    let foo_nodes: Vec<_> = output
+        .symbol_graph
+        .functions
+        .iter()
+        .filter(|f| f.name == "foo")
+        .collect();
+
+    assert_eq!(
+        foo_nodes.len(),
+        1,
+        "imported function should appear once in project symbol graph, got: {:?}",
+        foo_nodes.iter().map(|f| &f.id).collect::<Vec<_>>()
+    );
+    assert_eq!(
+        foo_nodes[0].id, "fn::a::foo",
+        "imported function should keep source-module-qualified ID"
+    );
+}
+
+#[test]
 fn project_symbol_id_uniqueness() {
     let (_dir, main_path) = write_project(&[
         (
@@ -923,6 +976,30 @@ fn project_symbol_id_uniqueness() {
         ids.len(),
         count,
         "all symbol IDs should be unique, found duplicates in: {ids:?}"
+    );
+}
+
+#[test]
+fn project_symbol_graph_duplicate_fn_defs_use_unique_ids() {
+    let (_dir, main_path) = write_project(&[
+        ("main.ky", "import math\nfn main() -> Int { add(1, 2) }\n"),
+        (
+            "math.ky",
+            "pub fn add(x: Int, y: Int) -> Int { x + y }\npub fn add(x: Int, y: Int) -> Int { x - y }\n",
+        ),
+    ]);
+    let output = check_project(&main_path);
+
+    let mut ids = std::collections::HashSet::new();
+    let mut dups = Vec::new();
+    for f in &output.symbol_graph.functions {
+        if !ids.insert(f.id.clone()) {
+            dups.push(f.id.clone());
+        }
+    }
+    assert!(
+        dups.is_empty(),
+        "duplicate function IDs should be disambiguated even in invalid programs, got: {dups:?}"
     );
 }
 
@@ -1453,6 +1530,29 @@ fn check_project_reports_unresolved_import() {
             .iter()
             .map(|d| &d.message)
             .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn check_project_surfaces_module_read_io_error() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let main_path = dir.path().join("main.ky");
+    std::fs::write(&main_path, "import bad\nfn main() -> Int { 1 }\n").expect("write main");
+
+    let bad_path = dir.path().join("bad.ky");
+    std::fs::write(&bad_path, vec![0xff, 0xfe, 0xfd]).expect("write invalid utf8 module");
+
+    let output = check_project(&main_path);
+    let io_diag = output
+        .diagnostics
+        .iter()
+        .find(|d| d.message.contains("failed to read module"))
+        .expect("expected module read I/O diagnostic");
+
+    assert!(
+        io_diag.message.contains("bad.ky"),
+        "I/O diagnostic should mention failing module path, got: {}",
+        io_diag.message
     );
 }
 
@@ -1991,6 +2091,45 @@ fn project_import_collision_produces_diagnostic() {
             .iter()
             .map(|d| &d.message)
             .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn project_import_collision_does_not_misattribute_call_edge_to_specific_module() {
+    let (_dir, main_path) = write_project(&[
+        ("main.ky", "import a\nimport b\nfn main() -> Int { foo() }"),
+        ("a.ky", "pub fn foo() -> Int { 1 }"),
+        ("b.ky", "pub fn foo() -> Int { 2 }"),
+    ]);
+    let output = check_project(&main_path);
+
+    let collisions: Vec<_> = output
+        .diagnostics
+        .iter()
+        .filter(|d| d.message.contains("foo") && d.message.contains("import"))
+        .collect();
+    assert!(
+        !collisions.is_empty(),
+        "expected conflicting import diagnostic for `foo`, got: {:?}",
+        output
+            .diagnostics
+            .iter()
+            .map(|d| &d.message)
+            .collect::<Vec<_>>()
+    );
+
+    let main_fn = output
+        .symbol_graph
+        .functions
+        .iter()
+        .find(|f| f.name == "main")
+        .expect("should contain main function");
+
+    assert!(
+        !main_fn.calls.contains(&"fn::a::foo".to_string())
+            && !main_fn.calls.contains(&"fn::b::foo".to_string()),
+        "ambiguous collision call should not be attributed to a specific module, got calls: {:?}",
+        main_fn.calls
     );
 }
 

--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -122,12 +122,20 @@ pub fn check_project(entry_file: &std::path::Path) -> ProjectCheckResult {
 
     // 2. Parse each file and build item trees.
     for (mod_path, file_path) in &discovered {
+        let file_id = file_map.insert(file_path.clone());
         let source = match std::fs::read_to_string(file_path) {
             Ok(s) => s,
-            Err(_) => continue,
+            Err(err) => {
+                all_lowering_diagnostics.push(kyokara_diagnostics::Diagnostic::error(
+                    format!("failed to read module `{}`: {}", file_path.display(), err),
+                    kyokara_span::Span {
+                        file: file_id,
+                        range: kyokara_span::TextRange::default(),
+                    },
+                ));
+                continue;
+            }
         };
-
-        let file_id = file_map.insert(file_path.clone());
         let parse = kyokara_syntax::parse(&source);
 
         if !parse.errors.is_empty() {
@@ -265,7 +273,7 @@ fn resolve_project_imports(
         let import_file_id = importing_info.file_id;
         for item in pub_data {
             match item {
-                PubData::Fn(fn_item) => {
+                PubData::Fn(mut fn_item) => {
                     let name = fn_item.name;
                     if importing_info.scope.functions.contains_key(&name) {
                         let name_str = name.resolve(interner);
@@ -277,6 +285,10 @@ fn resolve_project_imports(
                             },
                         ));
                     } else {
+                        // Imported functions are not source-owned by this module.
+                        // Keep them resolvable in scope but prevent duplicate
+                        // symbol-graph function nodes in the importing module.
+                        fn_item.source_range = None;
                         let idx = importing_info.item_tree.functions.alloc(fn_item);
                         importing_info.scope.functions.insert(name, idx);
                     }


### PR DESCRIPTION
## Summary

This PR completes the Lane C project symbol-graph + project-checking fixes with strict TDD (red -> green per issue).

### Fixed issues

- #106: Avoids call-edge misattribution when imports conflict on the same name
- #108: Removes duplicate imported function nodes in project symbol graph
- #67: Ensures unique function IDs even for duplicate definitions in invalid programs
- #136: Emits alias-to-record types as `kind: "record"` with concrete fields
- #62: Surfaces module read I/O failures in `check_project` diagnostics (instead of silent skip)

## Implementation notes

- Project call-edge post-processing now rewrites only when target resolution is unambiguous; ambiguous/unresolved edges are dropped rather than guessed.
- Imported function clones are marked non-source-owned in importing modules to prevent duplicate function node emission.
- Function node ID construction now disambiguates duplicate IDs with deterministic suffixes (`#2`, `#3`, ...), preserving existing IDs for normal cases.
- Alias-to-record definitions are serialized as record nodes with field details.
- File read failures in project discovery/parsing are converted into diagnostics with module path + OS error context.

## Tests

Added regression tests (all red-first):

- `project_import_collision_does_not_misattribute_call_edge_to_specific_module`
- `project_symbol_graph_imported_fn_not_duplicated_as_local_alias`
- `project_symbol_graph_duplicate_fn_defs_use_unique_ids`
- `symbol_graph_alias_to_record_emits_record_kind_with_fields`
- `check_project_surfaces_module_read_io_error`

Validation performed:

- `cargo test -p kyokara-api --test api_tests`
- `cargo test -p kyokara-cli`
- `cargo build -p kyokara-cli`

Closes #62
Closes #67
Closes #106
Closes #108
Closes #136
