### PR TITLE
Lane B: Fix parser record-context and block semicolon bugs

### DIFF
--- a/crates/parser/src/grammar/expressions.rs
+++ b/crates/parser/src/grammar/expressions.rs
@@ -133,7 +133,13 @@ fn hole_expr(p: &mut Parser<'_>) -> CompletedMarker {
 fn paren_expr(p: &mut Parser<'_>) -> CompletedMarker {
     let m = p.open();
     p.bump(); // (
+    // `expr_no_record` disables `Path { .. }` at the immediate parse site to
+    // avoid ambiguity with blocks, but parenthesized expressions should still
+    // be able to contain record literals.
+    let old = p.no_record_expr;
+    p.no_record_expr = false;
     expr(p);
+    p.no_record_expr = old;
     p.expect(RParen);
     m.complete(p, ParenExpr)
 }
@@ -145,9 +151,11 @@ pub(super) fn block_expr(p: &mut Parser<'_>) -> CompletedMarker {
     while !p.at(RBrace) && !p.at_eof() {
         if p.at(LetKw) {
             super::items::let_binding(p);
+            while p.eat(Semicolon) {}
         } else if expr(p).is_some() {
             // Expression statement — optionally followed by semicolons
             // (we don't require semicolons in the grammar)
+            while p.eat(Semicolon) {}
         } else {
             // Couldn't parse expression or let — skip one token for recovery
             break;

--- a/crates/parser/tests/parser_tests.rs
+++ b/crates/parser/tests/parser_tests.rs
@@ -235,6 +235,31 @@ fn match_expr() {
 }
 
 #[test]
+fn match_expr_parenthesized_record_scrutinee() {
+    // let x = match (Point { x: 1 }) { _ => 0 }
+    let (events, errors) = parse_tokens(&[
+        LetKw, Ident, Eq, MatchKw, LParen, Ident, LBrace, Ident, Colon, IntLiteral, RBrace, RParen,
+        LBrace, Underscore, FatArrow, IntLiteral, RBrace,
+    ]);
+    assert!(has_no_errors(&errors));
+    assert!(has_node(&events, MatchExpr));
+    assert!(has_node(&events, RecordExpr));
+}
+
+#[test]
+fn if_expr_parenthesized_record_condition() {
+    // let x = if (Point { x: 1 }) == (Point { x: 1 }) { 1 } else { 0 }
+    let (events, errors) = parse_tokens(&[
+        LetKw, Ident, Eq, IfKw, LParen, Ident, LBrace, Ident, Colon, IntLiteral, RBrace, RParen,
+        EqEq, LParen, Ident, LBrace, Ident, Colon, IntLiteral, RBrace, RParen, LBrace, IntLiteral,
+        RBrace, ElseKw, LBrace, IntLiteral, RBrace,
+    ]);
+    assert!(has_no_errors(&errors));
+    assert!(has_node(&events, IfExpr));
+    assert_eq!(count_start_nodes(&events, RecordExpr), 2);
+}
+
+#[test]
 fn return_expr() {
     // fn foo() { return 42 }
     let (events, errors) = parse_tokens(&[
@@ -272,6 +297,18 @@ fn old_expr() {
     assert!(has_no_errors(&errors));
     assert!(has_node(&events, OldExpr));
     assert!(has_node(&events, EnsuresClause));
+}
+
+#[test]
+fn block_expr_allows_semicolon_separators() {
+    // fn main() -> Int { let x = 1; x; }
+    let (events, errors) = parse_tokens(&[
+        FnKw, Ident, LParen, RParen, Arrow, Ident, LBrace, LetKw, Ident, Eq, IntLiteral, Semicolon,
+        Ident, Semicolon, RBrace,
+    ]);
+    assert!(has_no_errors(&errors));
+    assert!(has_node(&events, FnDef));
+    assert!(has_node(&events, BlockExpr));
 }
 
 // ── Patterns ────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Lane B parser/syntax fixes with strict TDD for:

- #117: parenthesized record expressions in `match`/`if`/contract expression positions
- #124: semicolon separators in block expressions

## What changed

### `crates/parser/src/grammar/expressions.rs`

- `paren_expr` now temporarily clears `no_record_expr` while parsing inside parentheses.
  - This keeps the existing top-level ambiguity guard while allowing `(Path { ... })` in `expr_no_record` contexts.
- `block_expr` now consumes optional trailing semicolons after:
  - `let` bindings
  - expression statements

### `crates/parser/tests/parser_tests.rs`

Added regression tests (red-first):

- `match_expr_parenthesized_record_scrutinee`
- `if_expr_parenthesized_record_condition`
- `block_expr_allows_semicolon_separators`

## Validation

- `cargo test -p kyokara-parser`
- `cargo test -p kyokara-cli`
- `cargo build -p kyokara-cli`

Closes #117
Closes #124
