### PR TITLE
Refactor #164/#167: local pattern binders + structured compile gating

### DIFF
--- a/crates/api/tests/api_tests.rs
+++ b/crates/api/tests/api_tests.rs
@@ -2013,6 +2013,46 @@ fn duplicate_bindings_in_constructor_pattern_produce_diagnostic() {
 }
 
 #[test]
+fn duplicate_binding_detection_is_local_to_each_match_arm_pattern() {
+    let src = "type Pair = | Pair(Int, Int)\nfn f(p: Pair) -> Int { match p { Pair(x, x) => x, Pair(x, y) => x } }\nfn main() -> Int { f(Pair(1, 2)) }";
+    let output = check(src, "test.ky");
+    let dup_binding_diags: Vec<_> = output
+        .diagnostics
+        .iter()
+        .filter(|d| d.message.contains("duplicate binding"))
+        .collect();
+    assert_eq!(
+        dup_binding_diags.len(),
+        1,
+        "duplicate-binding detection should not leak across match arms, got: {:?}",
+        dup_binding_diags
+            .iter()
+            .map(|d| &d.message)
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn duplicate_binding_detection_is_local_to_each_let_pattern() {
+    let src = "type Pair = | Pair(Int, Int)\nfn main() -> Int { let Pair(x, x) = Pair(1, 2)\n let Pair(x, y) = Pair(3, 4)\n x + y }";
+    let output = check(src, "test.ky");
+    let dup_binding_diags: Vec<_> = output
+        .diagnostics
+        .iter()
+        .filter(|d| d.message.contains("duplicate binding"))
+        .collect();
+    assert_eq!(
+        dup_binding_diags.len(),
+        1,
+        "duplicate-binding detection should not leak across let patterns, got: {:?}",
+        dup_binding_diags
+            .iter()
+            .map(|d| &d.message)
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
 fn unknown_capability_in_with_clause_produces_diagnostic() {
     let src = "fn main() -> Int with Nope { 1 }";
     let output = check(src, "test.ky");

--- a/crates/eval/src/lib.rs
+++ b/crates/eval/src/lib.rs
@@ -26,6 +26,57 @@ use crate::interpreter::Interpreter;
 use crate::manifest::CapabilityManifest;
 use crate::value::Value;
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CompileErrorClass {
+    Parse,
+    Lowering,
+    Type,
+}
+
+impl CompileErrorClass {
+    fn label(self) -> &'static str {
+        match self {
+            CompileErrorClass::Parse => "compile parse errors",
+            CompileErrorClass::Lowering => "compile lowering errors",
+            CompileErrorClass::Type => "compile type errors",
+        }
+    }
+}
+
+#[derive(Default)]
+struct CompileGateErrors {
+    parse: Vec<String>,
+    lowering: Vec<String>,
+    type_errors: Vec<String>,
+}
+
+impl CompileGateErrors {
+    fn add(&mut self, class: CompileErrorClass, msg: String) {
+        match class {
+            CompileErrorClass::Parse => self.parse.push(msg),
+            CompileErrorClass::Lowering => self.lowering.push(msg),
+            CompileErrorClass::Type => self.type_errors.push(msg),
+        }
+    }
+
+    fn into_runtime_error(self) -> Option<RuntimeError> {
+        let (class, msgs) = if !self.parse.is_empty() {
+            (CompileErrorClass::Parse, self.parse)
+        } else if !self.lowering.is_empty() {
+            (CompileErrorClass::Lowering, self.lowering)
+        } else if !self.type_errors.is_empty() {
+            (CompileErrorClass::Type, self.type_errors)
+        } else {
+            return None;
+        };
+        Some(RuntimeError::TypeError(format!(
+            "{}: {}",
+            class.label(),
+            msgs.join("; ")
+        )))
+    }
+}
+
 /// Result of running a Kyokara program.
 pub struct RunResult {
     pub value: Value,
@@ -55,13 +106,6 @@ pub fn run_with_manifest(
 
     // 1. Parse.
     let parse = kyokara_syntax::parse(source);
-    if !parse.errors.is_empty() {
-        let msgs: Vec<String> = parse.errors.iter().map(|e| format!("{e:?}")).collect();
-        return Err(RuntimeError::TypeError(format!(
-            "parse errors: {}",
-            msgs.join("; ")
-        )));
-    }
 
     // 2. Build CST.
     let root = SyntaxNode::new_root(parse.green);
@@ -70,22 +114,6 @@ pub fn run_with_manifest(
     // 3. Collect item tree.
     let mut interner = Interner::new();
     let mut item_result = collect_item_tree(&sf, file_id, &mut interner);
-
-    if item_result
-        .diagnostics
-        .iter()
-        .any(|d| d.severity == kyokara_diagnostics::Severity::Error)
-    {
-        let msgs: Vec<String> = item_result
-            .diagnostics
-            .iter()
-            .map(|d| d.message.clone())
-            .collect();
-        return Err(RuntimeError::TypeError(format!(
-            "lowering errors: {}",
-            msgs.join("; ")
-        )));
-    }
 
     // 4. Register builtin types (Option, Result) before intrinsics and type-checking.
     register_builtin_types(
@@ -110,40 +138,17 @@ pub fn run_with_manifest(
         &mut interner,
     );
 
-    // Check body_lowering_diagnostics for errors (e.g. unresolved names,
-    // duplicate bindings).
-    let body_errors: Vec<String> = type_check
-        .body_lowering_diagnostics
-        .iter()
-        .filter(|d| d.severity == kyokara_diagnostics::Severity::Error)
-        .map(|d| d.message.clone())
-        .collect();
-    if !body_errors.is_empty() {
-        return Err(RuntimeError::TypeError(format!(
-            "lowering errors: {}",
-            body_errors.join("; ")
-        )));
-    }
-
-    // Check raw_diagnostics for real type errors.
-    if !type_check.raw_diagnostics.is_empty() {
-        let msgs: Vec<String> = type_check
-            .raw_diagnostics
-            .iter()
-            .map(|(data, _span)| {
-                data.clone()
-                    .into_diagnostic(
-                        kyokara_span::Span {
-                            file: file_id,
-                            range: Default::default(),
-                        },
-                        &interner,
-                        &item_result.tree,
-                    )
-                    .message
-            })
-            .collect();
-        return Err(RuntimeError::TypeError(msgs.join("; ")));
+    if let Some(err) = collect_single_file_compile_errors(
+        &parse.errors,
+        &item_result.diagnostics,
+        &type_check.body_lowering_diagnostics,
+        &type_check.raw_diagnostics,
+        &interner,
+        &item_result.tree,
+    )
+    .into_runtime_error()
+    {
+        return Err(err);
     }
 
     // 7. Interpret.
@@ -177,62 +182,8 @@ pub fn run_project_with_manifest(
 ) -> Result<RunResult, RuntimeError> {
     let mut project = check_project(entry_file);
 
-    // Check for parse errors across all modules.
-    if !project.parse_errors.is_empty() {
-        let msgs: Vec<String> = project
-            .parse_errors
-            .iter()
-            .flat_map(|(_mod_path, errs)| errs.iter().map(|e| format!("{e:?}")))
-            .collect();
-        return Err(RuntimeError::TypeError(format!(
-            "parse errors: {}",
-            msgs.join("; ")
-        )));
-    }
-
-    // Check for lowering diagnostics (e.g. duplicate definitions).
-    let lowering_errors: Vec<&kyokara_diagnostics::Diagnostic> = project
-        .lowering_diagnostics
-        .iter()
-        .filter(|d| d.severity == kyokara_diagnostics::Severity::Error)
-        .collect();
-    if !lowering_errors.is_empty() {
-        let msgs: Vec<String> = lowering_errors.iter().map(|d| d.message.clone()).collect();
-        return Err(RuntimeError::TypeError(format!(
-            "lowering errors: {}",
-            msgs.join("; ")
-        )));
-    }
-
-    // Check for body lowering errors (e.g. unresolved names) across all modules.
-    let mut body_lowering_errors = Vec::new();
-    for (_mod_path, tc) in &project.type_checks {
-        for diag in &tc.body_lowering_diagnostics {
-            if diag.severity == kyokara_diagnostics::Severity::Error {
-                body_lowering_errors.push(diag.message.clone());
-            }
-        }
-    }
-    if !body_lowering_errors.is_empty() {
-        return Err(RuntimeError::TypeError(format!(
-            "lowering errors: {}",
-            body_lowering_errors.join("; ")
-        )));
-    }
-
-    // Check for type errors across all modules.
-    let mut type_errors = Vec::new();
-    for (_mod_path, tc) in &project.type_checks {
-        for (data, _span) in &tc.raw_diagnostics {
-            let msg = format!("{data:?}");
-            type_errors.push(msg);
-        }
-    }
-    if !type_errors.is_empty() {
-        return Err(RuntimeError::TypeError(format!(
-            "type error at compile time: {}",
-            type_errors.join("; ")
-        )));
+    if let Some(err) = collect_project_compile_errors(&project).into_runtime_error() {
+        return Err(err);
     }
 
     // Find the entry module.
@@ -306,4 +257,80 @@ pub fn run_project_with_manifest(
     let value = interp.run_main()?;
     let interner = interp.into_interner();
     Ok(RunResult { value, interner })
+}
+
+fn collect_single_file_compile_errors(
+    parse_errors: &[impl std::fmt::Debug],
+    lowering_diagnostics: &[kyokara_diagnostics::Diagnostic],
+    body_lowering_diagnostics: &[kyokara_diagnostics::Diagnostic],
+    type_diagnostics: &[(kyokara_hir::TyDiagnosticData, kyokara_span::Span)],
+    interner: &Interner,
+    item_tree: &kyokara_hir::ItemTree,
+) -> CompileGateErrors {
+    let mut errors = CompileGateErrors::default();
+
+    for err in parse_errors {
+        errors.add(CompileErrorClass::Parse, format!("{err:?}"));
+    }
+
+    for diag in lowering_diagnostics {
+        if diag.severity == kyokara_diagnostics::Severity::Error {
+            errors.add(CompileErrorClass::Lowering, diag.message.clone());
+        }
+    }
+
+    for diag in body_lowering_diagnostics {
+        if diag.severity == kyokara_diagnostics::Severity::Error {
+            errors.add(CompileErrorClass::Lowering, diag.message.clone());
+        }
+    }
+
+    for (data, span) in type_diagnostics {
+        let msg = data
+            .clone()
+            .into_diagnostic(*span, interner, item_tree)
+            .message;
+        errors.add(CompileErrorClass::Type, msg);
+    }
+
+    errors
+}
+
+fn collect_project_compile_errors(project: &kyokara_hir::ProjectCheckResult) -> CompileGateErrors {
+    let mut errors = CompileGateErrors::default();
+
+    for (_mod_path, errs) in &project.parse_errors {
+        for err in errs {
+            errors.add(CompileErrorClass::Parse, format!("{err:?}"));
+        }
+    }
+
+    for diag in &project.lowering_diagnostics {
+        if diag.severity == kyokara_diagnostics::Severity::Error {
+            errors.add(CompileErrorClass::Lowering, diag.message.clone());
+        }
+    }
+
+    for (_mod_path, tc) in &project.type_checks {
+        for diag in &tc.body_lowering_diagnostics {
+            if diag.severity == kyokara_diagnostics::Severity::Error {
+                errors.add(CompileErrorClass::Lowering, diag.message.clone());
+            }
+        }
+    }
+
+    for (mod_path, tc) in &project.type_checks {
+        let Some(mod_info) = project.module_graph.get(mod_path) else {
+            continue;
+        };
+        for (data, span) in &tc.raw_diagnostics {
+            let msg = data
+                .clone()
+                .into_diagnostic(*span, &project.interner, &mod_info.item_tree)
+                .message;
+            errors.add(CompileErrorClass::Type, msg);
+        }
+    }
+
+    errors
 }

--- a/crates/eval/tests/eval_tests.rs
+++ b/crates/eval/tests/eval_tests.rs
@@ -2076,6 +2076,122 @@ fn run_rejects_compile_invalid_programs_detected_by_check() {
 }
 
 #[test]
+fn run_compile_gating_uses_structured_error_classes() {
+    struct Case<'a> {
+        name: &'a str,
+        src: &'a str,
+        class_prefix: &'a str,
+    }
+
+    let cases = [
+        Case {
+            name: "parse",
+            src: "fn main( -> Int { 1 }",
+            class_prefix: "compile parse errors:",
+        },
+        Case {
+            name: "lowering item",
+            src: "fn foo() -> Int { 1 }\nfn foo() -> Int { 2 }\nfn main() -> Int { foo() }",
+            class_prefix: "compile lowering errors:",
+        },
+        Case {
+            name: "lowering body",
+            src: "fn main() -> Int { unknown_name }",
+            class_prefix: "compile lowering errors:",
+        },
+        Case {
+            name: "type",
+            src: "fn main() -> Int { \"x\" }",
+            class_prefix: "compile type errors:",
+        },
+    ];
+
+    for case in cases {
+        let err = run_err(case.src);
+        assert!(
+            err.contains(case.class_prefix),
+            "run should classify `{}` as `{}`; got: {}",
+            case.name,
+            case.class_prefix,
+            err
+        );
+    }
+}
+
+#[test]
+fn run_project_compile_gating_uses_structured_error_classes() {
+    use std::io::Write;
+
+    struct Case<'a> {
+        name: &'a str,
+        files: Vec<(&'a str, &'a str)>,
+        class_prefix: &'a str,
+    }
+
+    let cases = [
+        Case {
+            name: "parse",
+            files: vec![
+                ("main.ky", "fn main() -> Int { 42 }\n"),
+                ("bad.ky", "pub fn bad( -> Int { 42 }\n"),
+            ],
+            class_prefix: "compile parse errors:",
+        },
+        Case {
+            name: "lowering item",
+            files: vec![
+                ("main.ky", "fn main() -> Int { 42 }\n"),
+                (
+                    "dup.ky",
+                    "pub fn foo() -> Int { 1 }\npub fn foo() -> Int { 2 }\n",
+                ),
+            ],
+            class_prefix: "compile lowering errors:",
+        },
+        Case {
+            name: "lowering body",
+            files: vec![
+                ("main.ky", "fn main() -> Int { 42 }\n"),
+                ("bad.ky", "pub fn oops() -> Int { unknown_name }\n"),
+            ],
+            class_prefix: "compile lowering errors:",
+        },
+        Case {
+            name: "type",
+            files: vec![
+                ("main.ky", "import util\nfn main() -> Int { util() }\n"),
+                ("util.ky", "pub fn util() -> Int { true }\n"),
+            ],
+            class_prefix: "compile type errors:",
+        },
+    ];
+
+    for case in cases {
+        let dir = tempfile::tempdir().unwrap();
+        for (rel, src) in &case.files {
+            let path = dir.path().join(rel);
+            let mut file = std::fs::File::create(&path).unwrap();
+            write!(file, "{}", src).unwrap();
+        }
+        let main_path = dir.path().join("main.ky");
+        let err = match kyokara_eval::run_project(&main_path) {
+            Ok(result) => panic!(
+                "expected compile-time rejection for `{}`, got {:?}",
+                case.name, result.value
+            ),
+            Err(e) => e.to_string(),
+        };
+        assert!(
+            err.contains(case.class_prefix),
+            "run_project should classify `{}` as `{}`; got: {}",
+            case.name,
+            case.class_prefix,
+            err
+        );
+    }
+}
+
+#[test]
 fn run_accepts_compile_valid_let_rebinding_programs() {
     struct Case<'a> {
         name: &'a str,

--- a/crates/hir-def/src/body/lower.rs
+++ b/crates/hir-def/src/body/lower.rs
@@ -54,7 +54,6 @@ pub fn lower_body(
         module_scope,
         current_scope: None,
         in_contract: false,
-        pattern_bindings: std::collections::HashSet::new(),
     };
 
     // Create root scope
@@ -158,10 +157,6 @@ struct BodyLowerCtx<'a> {
     module_scope: &'a ModuleScope,
     current_scope: Option<ScopeIdx>,
     in_contract: bool,
-    /// Names bound within the current pattern tree, used to detect
-    /// duplicate bindings like `Pair(x, x)` without flagging sequential
-    /// let-rebindings like `let x = 1; let x = 2`.
-    pattern_bindings: std::collections::HashSet<Name>,
 }
 
 impl BodyLowerCtx<'_> {
@@ -546,7 +541,6 @@ impl BodyLowerCtx<'_> {
                 al.arms()
                     .map(|arm| {
                         self.push_scope();
-                        self.pattern_bindings.clear();
                         let pat = arm
                             .pat()
                             .map(|p| self.lower_pat(&p, LocalBindingOrigin::MatchArmPattern))
@@ -599,7 +593,6 @@ impl BodyLowerCtx<'_> {
             let is_last = i == items.len() - 1;
             match item {
                 BlockItem::LetBinding(lb) => {
-                    self.pattern_bindings.clear();
                     let pat = lb
                         .pat()
                         .map(|p| self.lower_pat(&p, LocalBindingOrigin::LetPattern))
@@ -747,6 +740,16 @@ impl BodyLowerCtx<'_> {
     // ── Pattern lowering ───────────────────────────────────────────
 
     fn lower_pat(&mut self, pat_cst: &PatCst, origin: LocalBindingOrigin) -> PatIdx {
+        let mut binders = std::collections::HashSet::new();
+        self.lower_pat_with_binders(pat_cst, origin, &mut binders)
+    }
+
+    fn lower_pat_with_binders(
+        &mut self,
+        pat_cst: &PatCst,
+        origin: LocalBindingOrigin,
+        binders: &mut std::collections::HashSet<Name>,
+    ) -> PatIdx {
         match pat_cst {
             PatCst::Ident(ip) => {
                 let name = ip
@@ -784,7 +787,7 @@ impl BodyLowerCtx<'_> {
                     let pat_idx = self.alloc_pat(pat::Pat::Bind { name });
                     self.pat_source_map
                         .insert(pat_idx, ip.syntax().text_range());
-                    if !self.pattern_bindings.insert(name) {
+                    if !binders.insert(name) {
                         let span = self.node_span(ip.syntax());
                         self.diagnostics.push(Diagnostic::error(
                             format!(
@@ -806,7 +809,10 @@ impl BodyLowerCtx<'_> {
 
                 // No push_scope/pop_scope — sub-pattern bindings must stay in the
                 // current (arm) scope so the arm body can resolve them.
-                let args: Vec<PatIdx> = cp.args().map(|a| self.lower_pat(&a, origin)).collect();
+                let args: Vec<PatIdx> = cp
+                    .args()
+                    .map(|a| self.lower_pat_with_binders(&a, origin, binders))
+                    .collect();
 
                 let pat_idx = self.alloc_pat(pat::Pat::Constructor { path, args });
                 self.pat_source_map


### PR DESCRIPTION
## Summary

This PR implements the remaining scope/shadowing robustness refactors:

- #164: replace mutable cross-context pattern binder state with per-pattern binder validation
- #167: formalize structured compile-time gating contract for `run`/`run_project`

## #164 — Pattern binder refactor

### What changed

- Removed ambient mutable `pattern_bindings` state from `BodyLowerCtx`.
- Reworked pattern lowering to use a **local binder set per pattern tree**:
  - `lower_pat(...)` now creates a fresh binder set.
  - recursive lowering passes the same set via `lower_pat_with_binders(...)`.
- Eliminated `pattern_bindings.clear()` choreography from `lower_match` and `lower_block`.

### Why

This removes fragile cross-context state coupling and makes duplicate-binding detection local and deterministic by construction.

### New regression guards

In `crates/api/tests/api_tests.rs`:
- `duplicate_binding_detection_is_local_to_each_match_arm_pattern`
- `duplicate_binding_detection_is_local_to_each_let_pattern`

These ensure duplicate-binding checks do not leak across sibling pattern contexts.

## #167 — Structured compile-time gating contract

### What changed

In `crates/eval/src/lib.rs`:

- Introduced explicit compile classes:
  - `CompileErrorClass::{Parse, Lowering, Type}`
- Added shared collector/report type:
  - `CompileGateErrors`
- Added centralized collectors:
  - `collect_single_file_compile_errors(...)`
  - `collect_project_compile_errors(...)`
- Both `run_with_manifest` and `run_project_with_manifest` now use the same structured preflight gate.
- Error output class prefixes are now explicit and consistent:
  - `compile parse errors:`
  - `compile lowering errors:`
  - `compile type errors:`

No message-text suppression is used for gating; classification is structural.

### New regression tests

In `crates/eval/tests/eval_tests.rs`:
- `run_compile_gating_uses_structured_error_classes`
- `run_project_compile_gating_uses_structured_error_classes`

These were added red-first and verify single-file/project class parity.

## Validation

Passed:
- `cargo test -p kyokara-api --test api_tests duplicate_binding_detection -- --nocapture`
- `cargo test -p kyokara-eval --test eval_tests compile_gating_uses_structured_error_classes -- --nocapture`
- `cargo test -p kyokara-eval --test eval_tests run_rejects_compile_invalid_programs_detected_by_check -- --nocapture`
- `cargo test -p kyokara-cli`
- `cargo build -p kyokara-cli`

Note:
- `cargo test -p kyokara-eval --test eval_tests` has a **pre-existing baseline failure** on current main:
  - `eval_record_literal` (`multi-segment value path p.x/p.y is not supported`)
  - Reproduced on `main` outside this branch as well.

Closes #164
Closes #167
