### PR TITLE
Freeze WASM/eval integer boundary semantics

### DIFF
--- a/crates/api/tests/api_tests.rs
+++ b/crates/api/tests/api_tests.rs
@@ -1675,6 +1675,28 @@ fn check_project_reports_unresolved_import() {
 }
 
 #[test]
+fn check_project_unresolved_import_reports_real_span() {
+    let (_dir, main_path) =
+        write_project(&[("main.ky", "\nimport nope\nfn main() -> Int { 1 }\n")]);
+    let output = check_project(&main_path);
+    let diag = output
+        .diagnostics
+        .iter()
+        .find(|d| d.message.contains("unresolved import `nope`"))
+        .expect("expected unresolved import diagnostic");
+    assert!(
+        diag.span.end > diag.span.start,
+        "unresolved import diagnostic should have non-empty source span, got: {:?}",
+        diag.span
+    );
+    assert!(
+        diag.span.start > 0,
+        "unresolved import span should point at import statement, not default offset 0: {:?}",
+        diag.span
+    );
+}
+
+#[test]
 fn check_project_surfaces_module_read_io_error() {
     let dir = tempfile::tempdir().expect("tempdir");
     let main_path = dir.path().join("main.ky");
@@ -1740,6 +1762,31 @@ fn check_project_reports_ambiguous_import_last_segment() {
             .iter()
             .map(|d| &d.message)
             .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn check_project_ambiguous_import_reports_real_span() {
+    let (_dir, main_path) = write_project(&[
+        ("main.ky", "\nimport math\nfn main() -> Int { value() }\n"),
+        ("a/math.ky", "pub fn value() -> Int { 1 }\n"),
+        ("b/math.ky", "pub fn value() -> Int { 2 }\n"),
+    ]);
+    let output = check_project(&main_path);
+    let diag = output
+        .diagnostics
+        .iter()
+        .find(|d| d.message.contains("ambiguous import `math`"))
+        .expect("expected ambiguous import diagnostic");
+    assert!(
+        diag.span.end > diag.span.start,
+        "ambiguous import diagnostic should have non-empty source span, got: {:?}",
+        diag.span
+    );
+    assert!(
+        diag.span.start > 0,
+        "ambiguous import span should point at import statement, not default offset 0: {:?}",
+        diag.span
     );
 }
 
@@ -2412,6 +2459,34 @@ fn project_import_collision_does_not_misattribute_call_edge_to_specific_module()
             && !main_fn.calls.contains(&"fn::b::foo".to_string()),
         "ambiguous collision call should not be attributed to a specific module, got calls: {:?}",
         main_fn.calls
+    );
+}
+
+#[test]
+fn project_conflicting_import_reports_real_span() {
+    let (_dir, main_path) = write_project(&[
+        (
+            "main.ky",
+            "\nimport a\nimport b\nfn foo() -> Int { 0 }\nfn main() -> Int { foo() }\n",
+        ),
+        ("a.ky", "pub fn foo() -> Int { 1 }\n"),
+        ("b.ky", "pub fn foo() -> Int { 2 }\n"),
+    ]);
+    let output = check_project(&main_path);
+    let diag = output
+        .diagnostics
+        .iter()
+        .find(|d| d.message.contains("conflicting import") && d.message.contains("foo"))
+        .expect("expected conflicting import diagnostic");
+    assert!(
+        diag.span.end > diag.span.start,
+        "conflicting import diagnostic should have non-empty source span, got: {:?}",
+        diag.span
+    );
+    assert!(
+        diag.span.start > 0,
+        "conflicting import span should point at import statement, not default offset 0: {:?}",
+        diag.span
     );
 }
 

--- a/crates/hir-def/src/item_tree.rs
+++ b/crates/hir-def/src/item_tree.rs
@@ -40,6 +40,7 @@ pub struct ItemTree {
 pub struct Import {
     pub path: Path,
     pub alias: Option<Name>,
+    pub source_range: TextRange,
 }
 
 /// A function item (signature only — body lowered in Pass 2).

--- a/crates/hir-def/src/item_tree/lower.rs
+++ b/crates/hir-def/src/item_tree/lower.rs
@@ -101,7 +101,11 @@ impl ItemTreeCtx<'_> {
             }
         }
 
-        self.tree.imports.push(Import { path, alias });
+        self.tree.imports.push(Import {
+            path,
+            alias,
+            source_range: import.syntax().text_range(),
+        });
     }
 
     fn lower_item(&mut self, item: Item) {

--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -27,7 +27,8 @@ pub use kyokara_hir_ty::{TypeCheckResult, check_module};
 
 use kyokara_intern::Interner;
 use kyokara_parser::ParseError;
-use kyokara_span::{FileId, FileMap};
+use kyokara_span::{FileId, FileMap, TextRange};
+use kyokara_stdx::FxHashMap;
 use kyokara_syntax::SyntaxNode;
 use kyokara_syntax::ast::AstNode;
 use kyokara_syntax::ast::nodes::SourceFile;
@@ -279,6 +280,7 @@ fn resolve_project_imports(
         importing_mod: ModulePath,
         import_path: Path,
         file_id: FileId,
+        import_range: TextRange,
     }
 
     let mut to_resolve: Vec<PendingImport> = Vec::new();
@@ -293,7 +295,18 @@ fn resolve_project_imports(
                 importing_mod: mod_path.clone(),
                 import_path: imp.path.clone(),
                 file_id: info.file_id,
+                import_range: imp.source_range,
             });
+        }
+    }
+
+    let mut modules_by_leaf: FxHashMap<Name, Vec<ModulePath>> = FxHashMap::default();
+    for (mod_path, _) in graph.iter() {
+        if let Some(last) = mod_path.last() {
+            modules_by_leaf
+                .entry(last)
+                .or_default()
+                .push(mod_path.clone());
         }
     }
 
@@ -303,7 +316,13 @@ fn resolve_project_imports(
             importing_mod,
             import_path,
             file_id,
+            import_range,
         } = pending;
+
+        let import_span = kyokara_span::Span {
+            file: file_id,
+            range: import_range,
+        };
 
         // Collect pub items from the target module.
         let pub_data = {
@@ -322,25 +341,16 @@ fn resolve_project_imports(
                 }
             } else {
                 let resolve_name = import_path.segments[0];
-                graph
-                    .iter()
-                    .filter_map(|(mod_path, _)| {
-                        if mod_path.last() == Some(resolve_name) {
-                            Some(mod_path.clone())
-                        } else {
-                            None
-                        }
-                    })
-                    .collect()
+                modules_by_leaf
+                    .get(&resolve_name)
+                    .cloned()
+                    .unwrap_or_default()
             };
 
             if candidates.is_empty() {
                 diagnostics.push(kyokara_diagnostics::Diagnostic::error(
                     format!("unresolved import `{import_name}`"),
-                    kyokara_span::Span {
-                        file: file_id,
-                        range: kyokara_span::TextRange::default(),
-                    },
+                    import_span,
                 ));
                 continue;
             }
@@ -366,10 +376,7 @@ fn resolve_project_imports(
                         "ambiguous import `{import_name}`: matches {}",
                         labels.join(", ")
                     ),
-                    kyokara_span::Span {
-                        file: file_id,
-                        range: kyokara_span::TextRange::default(),
-                    },
+                    import_span,
                 ));
                 continue;
             }
@@ -386,7 +393,6 @@ fn resolve_project_imports(
             continue;
         };
 
-        let import_file_id = importing_info.file_id;
         for item in pub_data {
             match item {
                 PubData::Fn(mut fn_item) => {
@@ -395,10 +401,7 @@ fn resolve_project_imports(
                         let name_str = name.resolve(interner);
                         diagnostics.push(kyokara_diagnostics::Diagnostic::error(
                             format!("conflicting import: `{name_str}` is already defined"),
-                            kyokara_span::Span {
-                                file: import_file_id,
-                                range: kyokara_span::TextRange::default(),
-                            },
+                            import_span,
                         ));
                     } else {
                         // Imported functions are not source-owned by this module.
@@ -415,10 +418,7 @@ fn resolve_project_imports(
                         let name_str = name.resolve(interner);
                         diagnostics.push(kyokara_diagnostics::Diagnostic::error(
                             format!("conflicting import: `{name_str}` is already defined"),
-                            kyokara_span::Span {
-                                file: import_file_id,
-                                range: kyokara_span::TextRange::default(),
-                            },
+                            import_span,
                         ));
                     } else {
                         let variants_info: Vec<(Name, usize)> =
@@ -449,10 +449,7 @@ fn resolve_project_imports(
                         let name_str = name.resolve(interner);
                         diagnostics.push(kyokara_diagnostics::Diagnostic::error(
                             format!("conflicting import: `{name_str}` is already defined"),
-                            kyokara_span::Span {
-                                file: import_file_id,
-                                range: kyokara_span::TextRange::default(),
-                            },
+                            import_span,
                         ));
                     } else {
                         let idx = importing_info.item_tree.caps.alloc(cap_item);


### PR DESCRIPTION
## Summary
- align WASM codegen with interpreter boundary semantics for integer ops
- add tests-first parity coverage for overflow and invalid shift amounts
- trap on boundary violations in WASM lowering for `+`, `-`, `*`, `%`, unary `-`, `<<`, `>>`

## Why
Language-level behavior should not depend on backend. This PR addresses the first freeze blocker tracked in #212.

## Tests
- `cargo test -q -p kyokara-codegen --test codegen_tests`
- `cargo test -q`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`

Closes #212
