### PR TITLE
feat(pbt): constrained generation via refinement types

### DIFF
--- a/crates/hir-def/src/body/lower.rs
+++ b/crates/hir-def/src/body/lower.rs
@@ -13,7 +13,7 @@ use kyokara_syntax::ast::AstNode;
 use kyokara_syntax::ast::nodes::{
     self, ArgList, BinaryExpr, BlockExpr, BlockItem, CallExpr, ElseBranch, FieldExpr, FnDef,
     IfExpr, LambdaExpr, LiteralExpr, MatchExpr, NamedArg, OldExpr, PathExpr, PipelineExpr,
-    PropagateExpr, PropertyDef, RecordExpr, ReturnExpr, TypeExpr, UnaryExpr,
+    PropagateExpr, PropertyDef, RecordExpr, RefinedType, ReturnExpr, TypeExpr, UnaryExpr,
 };
 use kyokara_syntax::ast::traits::{HasName, HasTypeParams};
 
@@ -187,6 +187,72 @@ pub fn lower_property_body(
     let root = if let Some(body) = prop_def.body() {
         let range = body.syntax().text_range();
         let idx = ctx.lower_block(&body);
+        ctx.expr_source_map.insert(idx, range);
+        idx
+    } else {
+        ctx.alloc_expr(Expr::Missing)
+    };
+
+    BodyLowerResult {
+        body: Body {
+            exprs: ctx.exprs,
+            pats: ctx.pats,
+            root,
+            requires: None,
+            ensures: None,
+            invariant: None,
+            scopes: ctx.scopes,
+            pat_scopes: ctx.pat_scopes,
+            expr_scopes: ctx.expr_scopes,
+            expr_source_map: ctx.expr_source_map,
+            pat_source_map: ctx.pat_source_map,
+            local_binding_meta: ctx.local_binding_meta,
+        },
+        diagnostics: ctx.diagnostics,
+    }
+}
+
+/// Lower a refinement-type predicate body from CST to HIR.
+///
+/// Creates a synthetic function body for a `{ x: Base | predicate }` refined type:
+/// one parameter (the refinement variable) in scope, body = predicate expression.
+pub fn lower_refinement_body(
+    refined: &RefinedType,
+    module_scope: &ModuleScope,
+    file_id: FileId,
+    interner: &mut Interner,
+) -> BodyLowerResult {
+    let mut ctx = BodyLowerCtx {
+        exprs: Arena::new(),
+        pats: Arena::new(),
+        scopes: ScopeTree::default(),
+        pat_scopes: Vec::new(),
+        expr_scopes: ArenaMap::default(),
+        expr_source_map: ArenaMap::default(),
+        pat_source_map: ArenaMap::default(),
+        local_binding_meta: ArenaMap::default(),
+        diagnostics: Vec::new(),
+        file_id,
+        interner,
+        module_scope,
+        current_scope: None,
+        in_contract: false,
+    };
+
+    // Create root scope.
+    let root_scope = ctx.scopes.new_root();
+    ctx.current_scope = Some(root_scope);
+
+    // Register the refinement variable as Param(0).
+    if let Some(tok) = refined.name_token() {
+        let name = Name::new(ctx.interner, tok.text());
+        ctx.scopes.define(root_scope, name, ScopeDef::Param(0));
+    }
+
+    // Lower predicate expression as the body root.
+    let root = if let Some(pred) = refined.predicate() {
+        let range = pred.syntax().text_range();
+        let idx = ctx.lower_expr(&pred);
         ctx.expr_source_map.insert(idx, range);
         idx
     } else {

--- a/crates/hir-def/src/item_tree.rs
+++ b/crates/hir-def/src/item_tree.rs
@@ -110,6 +110,9 @@ pub struct PropertyItem {
     pub source_range: Option<TextRange>,
     /// Link to the synthetic `FnItem` created for this property's body.
     pub fn_idx: Option<FnItemIdx>,
+    /// Per-param predicate checker: `Some(fn_idx)` when the param has a refined type.
+    /// Length == `params.len()`.
+    pub refine_fns: Vec<Option<FnItemIdx>>,
 }
 
 /// A top-level let binding.

--- a/crates/hir-def/src/item_tree/lower.rs
+++ b/crates/hir-def/src/item_tree/lower.rs
@@ -330,24 +330,81 @@ impl ItemTreeCtx<'_> {
     fn lower_property_def(&mut self, p: &PropertyDef) {
         let name = self.name_of(p);
 
-        let params: Vec<FnParam> = p
-            .param_list()
-            .map(|pl| {
-                pl.params()
-                    .map(|param| {
-                        let pname = param
+        let mut params: Vec<FnParam> = Vec::new();
+        let mut refine_fns: Vec<Option<FnItemIdx>> = Vec::new();
+        let bool_path = Path {
+            segments: vec![Name::new(self.interner, "Bool")],
+        };
+
+        if let Some(pl) = p.param_list() {
+            for param in pl.params() {
+                let pname = param
+                    .name_token()
+                    .map(|tok| Name::new(self.interner, tok.text()))
+                    .unwrap_or_else(|| Name::new(self.interner, "_"));
+
+                match param.type_expr() {
+                    Some(TypeExpr::RefinedType(rt)) => {
+                        // Extract base type from the refined type.
+                        let base_ty = rt
+                            .base_type()
+                            .map(|bt| self.lower_type_ref(&bt))
+                            .unwrap_or(TypeRef::Error);
+
+                        params.push(FnParam {
+                            name: pname,
+                            ty: base_ty.clone(),
+                        });
+
+                        // Create a synthetic FnItem for the predicate checker:
+                        // one param of the base type, returns Bool.
+                        let refine_name = rt
                             .name_token()
                             .map(|tok| Name::new(self.interner, tok.text()))
-                            .unwrap_or_else(|| Name::new(self.interner, "_"));
-                        let ty = param
-                            .type_expr()
-                            .map(|t| self.lower_type_ref(&t))
-                            .unwrap_or(TypeRef::Error);
-                        FnParam { name: pname, ty }
-                    })
-                    .collect()
-            })
-            .unwrap_or_default();
+                            .unwrap_or(pname);
+
+                        let refine_fn_idx = self.tree.functions.alloc(FnItem {
+                            name: Name::new(
+                                self.interner,
+                                &format!(
+                                    "__refine_{}_{}",
+                                    name.resolve(self.interner),
+                                    pname.resolve(self.interner)
+                                ),
+                            ),
+                            is_pub: false,
+                            type_params: vec![],
+                            params: vec![FnParam {
+                                name: refine_name,
+                                ty: base_ty,
+                            }],
+                            ret_type: Some(TypeRef::Path {
+                                path: bool_path.clone(),
+                                args: vec![],
+                            }),
+                            with_caps: vec![],
+                            pipe_caps: vec![],
+                            has_body: true,
+                            source_range: Some(rt.syntax().text_range()),
+                        });
+
+                        refine_fns.push(Some(refine_fn_idx));
+                    }
+                    Some(te) => {
+                        let ty = self.lower_type_ref(&te);
+                        params.push(FnParam { name: pname, ty });
+                        refine_fns.push(None);
+                    }
+                    None => {
+                        params.push(FnParam {
+                            name: pname,
+                            ty: TypeRef::Error,
+                        });
+                        refine_fns.push(None);
+                    }
+                }
+            }
+        }
 
         let has_body = p.body().is_some();
         let source_range = Some(p.syntax().text_range());
@@ -355,9 +412,6 @@ impl ItemTreeCtx<'_> {
         // If the property has a body, create a synthetic FnItem so the body
         // gets lowered and type-checked alongside real functions.
         let fn_idx = if has_body {
-            let bool_path = Path {
-                segments: vec![Name::new(self.interner, "Bool")],
-            };
             let idx = self.tree.functions.alloc(FnItem {
                 name,
                 is_pub: false,
@@ -385,6 +439,7 @@ impl ItemTreeCtx<'_> {
             has_body,
             source_range,
             fn_idx,
+            refine_fns,
         });
     }
 

--- a/crates/hir-ty/src/lib.rs
+++ b/crates/hir-ty/src/lib.rs
@@ -20,7 +20,7 @@ pub mod unify;
 
 use kyokara_diagnostics::Diagnostic;
 use kyokara_hir_def::body::Body;
-use kyokara_hir_def::body::lower::{lower_body, lower_property_body};
+use kyokara_hir_def::body::lower::{lower_body, lower_property_body, lower_refinement_body};
 use kyokara_hir_def::item_tree::{FnItemIdx, ItemTree};
 use kyokara_hir_def::resolver::ModuleScope;
 use kyokara_hir_def::type_ref::TypeRef;
@@ -29,7 +29,7 @@ use kyokara_span::{FileId, Span};
 use kyokara_stdx::FxHashMap;
 use kyokara_syntax::SyntaxNode;
 use kyokara_syntax::ast::AstNode;
-use kyokara_syntax::ast::nodes::{FnDef, PropertyDef};
+use kyokara_syntax::ast::nodes::{FnDef, PropertyDef, RefinedType};
 use kyokara_syntax::ast::traits::HasName;
 
 use kyokara_hir_def::name::Name;
@@ -74,6 +74,8 @@ pub fn check_module(
 
     let fn_defs: Vec<FnDef> = root.descendants().filter_map(FnDef::cast).collect();
     let prop_defs: Vec<PropertyDef> = root.descendants().filter_map(PropertyDef::cast).collect();
+    let refined_types: Vec<RefinedType> =
+        root.descendants().filter_map(RefinedType::cast).collect();
 
     for (fn_idx, fn_item) in item_tree.functions.iter() {
         if !fn_item.has_body {
@@ -93,6 +95,7 @@ pub fn check_module(
 
         // Try FnDef first; if not found, try PropertyDef (synthetic FnItems
         // created for properties point at PropertyDef source ranges).
+        // Finally, try RefinedType (synthetic FnItems for refinement predicates).
         let body_result = if let Some(fd) = fn_def {
             lower_body(fd, module_scope, file_id, interner)
         } else if let Some(pd) = prop_defs.iter().find(|pd| {
@@ -101,6 +104,12 @@ pub fn check_module(
                 .is_some_and(|range| pd.syntax().text_range() == range)
         }) {
             lower_property_body(pd, module_scope, file_id, interner)
+        } else if let Some(rt) = refined_types.iter().find(|rt| {
+            fn_item
+                .source_range
+                .is_some_and(|range| rt.syntax().text_range() == range)
+        }) {
+            lower_refinement_body(rt, module_scope, file_id, interner)
         } else {
             continue;
         };

--- a/crates/pbt/src/runner.rs
+++ b/crates/pbt/src/runner.rs
@@ -55,11 +55,15 @@ struct TestableFunction {
     param_types: Vec<kyokara_hir_def::type_ref::TypeRef>,
 }
 
+/// Maximum number of rejection-sampling attempts for refined types.
+const MAX_REFINEMENT_REJECTIONS: usize = 1000;
+
 /// A property that's eligible for testing.
 struct TestableProperty {
     fn_idx: FnItemIdx,
     name: String,
     param_types: Vec<kyokara_hir_def::type_ref::TypeRef>,
+    refine_fns: Vec<Option<FnItemIdx>>,
 }
 
 /// Parse, type-check, and run property-based tests on a single source file.
@@ -259,6 +263,7 @@ fn discover_properties(
             fn_idx,
             name: prop.name.resolve(interner).to_string(),
             param_types,
+            refine_fns: prop.refine_fns.clone(),
         });
     }
 
@@ -275,8 +280,13 @@ fn run_test_loop(
     let mut results = Vec::new();
     let mut skipped = Vec::new();
 
-    // Collect fn_idxs that are property-backing synthetic functions.
-    let property_fn_idxs: Vec<FnItemIdx> = properties.iter().map(|p| p.fn_idx).collect();
+    // Collect fn_idxs that are property-backing or refinement-checking synthetic functions.
+    let mut property_fn_idxs: Vec<FnItemIdx> = properties.iter().map(|p| p.fn_idx).collect();
+    for prop in properties {
+        for idx in prop.refine_fns.iter().flatten() {
+            property_fn_idxs.push(*idx);
+        }
+    }
 
     // Collect all function names from the item tree for the "skipped" list.
     let all_fn_names: Vec<(String, FnItemIdx)> = {
@@ -438,7 +448,9 @@ fn test_single_property(
     config: &TestConfig,
 ) -> FnTestResult {
     let mut passed = 0usize;
+    let mut discarded = 0usize;
     let mut total = 0usize;
+    let use_refinements = has_refinements(prop);
 
     // Phase 1: Replay corpus entries.
     let corpus_entries = corpus::load_entries(&config.corpus_base, &prop.name);
@@ -447,13 +459,13 @@ fn test_single_property(
         total += 1;
         match run_single_property_test(interp, prop, &seq) {
             TestOutcome::Pass => passed += 1,
-            TestOutcome::Discard => {} // Properties have no preconditions
+            TestOutcome::Discard => discarded += 1,
             TestOutcome::Fail(error, args_display) => {
                 return FnTestResult {
                     name: prop.name.clone(),
                     kind: TestableKind::Property,
                     passed,
-                    discarded: 0,
+                    discarded,
                     total,
                     failure: Some(FailureInfo {
                         error,
@@ -468,57 +480,110 @@ fn test_single_property(
     // Phase 2: Explore (if enabled).
     if config.explore {
         for i in 0..config.num_tests {
-            let seed = config
+            let base_seed = config
                 .seed
                 .wrapping_add(prop.fn_idx.into_raw().into_u32() as u64 * 10000 + i as u64);
-            let mut recorder = ChoiceRecorder::new(seed);
 
-            let args = match generate_property_args(prop, &mut recorder, interp) {
-                Some(a) => a,
-                None => {
-                    total += 1;
-                    continue;
-                }
+            // Rejection sampling loop for refined types.
+            let max_attempts = if use_refinements {
+                MAX_REFINEMENT_REJECTIONS
+            } else {
+                1
             };
 
-            let seq = recorder.into_sequence();
-            total += 1;
+            let mut found = false;
+            for attempt in 0..max_attempts {
+                let seed = base_seed.wrapping_add(attempt as u64 * 7919);
+                let mut recorder = ChoiceRecorder::new(seed);
 
-            match call_and_classify_property(interp, prop.fn_idx, args) {
-                TestOutcome::Pass => passed += 1,
-                TestOutcome::Discard => {}
-                TestOutcome::Fail(error, args_display) => {
-                    // Shrink the failing case.
-                    let shrunk = shrink_property_failure(interp, prop, &seq);
+                let args = match generate_property_args(prop, &mut recorder, interp) {
+                    Some(a) => a,
+                    None => continue,
+                };
 
-                    // Re-run with shrunk sequence to get the display args.
-                    let (shrunk_error, shrunk_args) =
-                        replay_property_for_display(interp, prop, &shrunk)
-                            .unwrap_or((error, args_display));
-
-                    // Save to corpus.
-                    let entry = CorpusEntry {
-                        function: prop.name.clone(),
-                        choices: shrunk.choices.clone(),
-                        maxima: shrunk.maxima.clone(),
-                        error: shrunk_error.clone(),
-                        args_display: shrunk_args.clone(),
-                    };
-                    let _ = corpus::save_entry(&config.corpus_base, &entry);
-
-                    return FnTestResult {
-                        name: prop.name.clone(),
-                        kind: TestableKind::Property,
-                        passed,
-                        discarded: 0,
-                        total,
-                        failure: Some(FailureInfo {
-                            error: shrunk_error,
-                            args_display: shrunk_args,
-                            choices: shrunk,
-                        }),
-                    };
+                // Check refinement predicates.
+                if use_refinements {
+                    match check_refinements(interp, &args, &prop.refine_fns) {
+                        Ok(true) => {}
+                        Ok(false) => continue, // Rejected, try again.
+                        Err(e) => {
+                            total += 1;
+                            return FnTestResult {
+                                name: prop.name.clone(),
+                                kind: TestableKind::Property,
+                                passed,
+                                discarded,
+                                total,
+                                failure: Some(FailureInfo {
+                                    error: format!("refinement error: {e}"),
+                                    args_display: vec![],
+                                    choices: recorder.into_sequence(),
+                                }),
+                            };
+                        }
+                    }
                 }
+
+                let seq = recorder.into_sequence();
+                total += 1;
+                found = true;
+
+                match call_and_classify_property(interp, prop.fn_idx, args) {
+                    TestOutcome::Pass => passed += 1,
+                    TestOutcome::Discard => discarded += 1,
+                    TestOutcome::Fail(error, args_display) => {
+                        // Shrink the failing case.
+                        let shrunk = shrink_property_failure(interp, prop, &seq);
+
+                        // Re-run with shrunk sequence to get the display args.
+                        let (shrunk_error, shrunk_args) =
+                            replay_property_for_display(interp, prop, &shrunk)
+                                .unwrap_or((error, args_display));
+
+                        // Save to corpus.
+                        let entry = CorpusEntry {
+                            function: prop.name.clone(),
+                            choices: shrunk.choices.clone(),
+                            maxima: shrunk.maxima.clone(),
+                            error: shrunk_error.clone(),
+                            args_display: shrunk_args.clone(),
+                        };
+                        let _ = corpus::save_entry(&config.corpus_base, &entry);
+
+                        return FnTestResult {
+                            name: prop.name.clone(),
+                            kind: TestableKind::Property,
+                            passed,
+                            discarded,
+                            total,
+                            failure: Some(FailureInfo {
+                                error: shrunk_error,
+                                args_display: shrunk_args,
+                                choices: shrunk,
+                            }),
+                        };
+                    }
+                }
+                break; // Found a valid input, move on to next test.
+            }
+
+            // If we exhausted all attempts without finding a valid input,
+            // this constraint is unsatisfiable.
+            if !found && use_refinements {
+                return FnTestResult {
+                    name: prop.name.clone(),
+                    kind: TestableKind::Property,
+                    passed,
+                    discarded,
+                    total: total + 1,
+                    failure: Some(FailureInfo {
+                        error: "unsatisfiable refinement constraint: could not generate \
+                                a valid input after 1000 attempts"
+                            .to_string(),
+                        args_display: vec![],
+                        choices: ChoiceSequence::new(vec![], vec![]),
+                    }),
+                };
             }
         }
     }
@@ -527,7 +592,7 @@ fn test_single_property(
         name: prop.name.clone(),
         kind: TestableKind::Property,
         passed,
-        discarded: 0,
+        discarded,
         total,
         failure: None,
     }
@@ -628,6 +693,38 @@ fn replay_for_display(
     }
 }
 
+// ── Refinement checking ────────────────────────────────────────────
+
+/// Check that generated args satisfy all refinement predicates.
+///
+/// Returns `Ok(true)` if all predicates pass, `Ok(false)` if any returns false,
+/// `Err` on runtime error.
+fn check_refinements(
+    interp: &mut Interpreter,
+    args: &Args,
+    refine_fns: &[Option<FnItemIdx>],
+) -> Result<bool, String> {
+    use kyokara_eval::value::Value;
+
+    for (arg, refine_fn) in args.iter().zip(refine_fns.iter()) {
+        if let Some(fn_idx) = refine_fn {
+            let check_args = Args::from(vec![arg.clone()]);
+            match interp.call_fn_by_idx(*fn_idx, check_args) {
+                Ok(Value::Bool(true)) => {}
+                Ok(Value::Bool(false)) => return Ok(false),
+                Ok(_) => return Err("refinement predicate did not return Bool".to_string()),
+                Err(e) => return Err(format!("refinement predicate error: {e}")),
+            }
+        }
+    }
+    Ok(true)
+}
+
+/// Check if this property has any refinement predicates.
+fn has_refinements(prop: &TestableProperty) -> bool {
+    prop.refine_fns.iter().any(|r| r.is_some())
+}
+
 // ── Property-specific helpers ──────────────────────────────────────
 
 /// Generate arguments for a property using a choice source.
@@ -684,10 +781,22 @@ fn run_single_property_test(
         Some(a) => a,
         None => return TestOutcome::Discard,
     };
+    // Check refinement predicates on replayed args.
+    if has_refinements(prop) {
+        match check_refinements(interp, &args, &prop.refine_fns) {
+            Ok(true) => {}
+            Ok(false) => return TestOutcome::Discard,
+            Err(_) => return TestOutcome::Discard,
+        }
+    }
     call_and_classify_property(interp, prop.fn_idx, args)
 }
 
 /// Shrink a failing property choice sequence.
+///
+/// If the property has refinement predicates, candidates that violate the
+/// predicate are treated as `Invalid` (not `Passes`), ensuring the shrunk
+/// counterexample still satisfies the constraint.
 fn shrink_property_failure(
     interp: &mut Interpreter,
     prop: &TestableProperty,
@@ -713,6 +822,14 @@ fn replay_property_for_display(
 
     let mut replayer = ChoiceReplayer::new(seq.clone());
     let args = generate_property_args(prop, &mut replayer, interp)?;
+
+    // Verify refinements still hold on the shrunk sequence.
+    if has_refinements(prop)
+        && let Ok(false) = check_refinements(interp, &args, &prop.refine_fns)
+    {
+        return None; // Discard — refinement violated.
+    }
+
     let args_display: Vec<String> = args.iter().map(|v| v.display(interp.interner())).collect();
 
     match interp.call_fn_by_idx(prop.fn_idx, args) {

--- a/crates/pbt/tests/fixtures/refined_fail.ky
+++ b/crates/pbt/tests/fixtures/refined_fail.ky
@@ -1,0 +1,3 @@
+property bad_bound(x: { x: Int | x > 0 }) {
+    x > 100
+}

--- a/crates/pbt/tests/fixtures/refined_mixed.ky
+++ b/crates/pbt/tests/fixtures/refined_mixed.ky
@@ -1,0 +1,10 @@
+fn clamp(x: Int) -> Int
+  requires x > 0
+  ensures result > 0
+{
+  if x > 100 { 100 } else { x }
+}
+
+property pos_capped(x: { x: Int | x > 0 && x < 1000 }) {
+  x + x > 0
+}

--- a/crates/pbt/tests/fixtures/refined_pass.ky
+++ b/crates/pbt/tests/fixtures/refined_pass.ky
@@ -1,0 +1,3 @@
+property positive_is_positive(x: { x: Int | x > 0 }) {
+    x > 0
+}

--- a/crates/pbt/tests/fixtures/refined_unsatisfiable.ky
+++ b/crates/pbt/tests/fixtures/refined_unsatisfiable.ky
@@ -1,0 +1,3 @@
+property impossible(x: { x: Int | x > 0 && x < 0 }) {
+    true
+}

--- a/crates/pbt/tests/integration.rs
+++ b/crates/pbt/tests/integration.rs
@@ -230,3 +230,204 @@ fn property_type_check() {
         "valid property should have no type errors: {all_diags:?}"
     );
 }
+
+// ── Refined-type tests ────────────────────────────────────────────
+
+#[test]
+fn refined_pass_succeeds() {
+    let source = fixture("refined_pass.ky");
+    let config = test_config();
+    let report = run_tests(&source, &config).unwrap();
+
+    assert!(
+        report.all_passed(),
+        "refined_pass.ky should pass: {}",
+        report.format_human()
+    );
+    assert_eq!(report.results.len(), 1);
+    assert_eq!(report.results[0].name, "positive_is_positive");
+    assert_eq!(report.results[0].kind, TestableKind::Property);
+    assert!(report.results[0].passed > 0);
+}
+
+#[test]
+fn refined_fail_detected() {
+    let source = fixture("refined_fail.ky");
+    let config = test_config();
+    let report = run_tests(&source, &config).unwrap();
+
+    assert!(!report.all_passed(), "refined_fail.ky should fail");
+    assert_eq!(report.failure_count(), 1);
+
+    let result = &report.results[0];
+    assert_eq!(result.name, "bad_bound");
+    assert_eq!(result.kind, TestableKind::Property);
+    let failure = result.failure.as_ref().unwrap();
+    assert!(
+        failure.error.contains("property returned false"),
+        "expected 'property returned false', got: {}",
+        failure.error
+    );
+
+    // Counterexample should still satisfy x > 0 (refinement respected).
+    assert!(!failure.args_display.is_empty());
+    let arg_val: i64 = failure.args_display[0].parse().unwrap();
+    assert!(
+        arg_val > 0,
+        "counterexample should satisfy refinement x > 0, got: {arg_val}"
+    );
+}
+
+#[test]
+fn refined_shrink_respects_predicate() {
+    let source = fixture("refined_fail.ky");
+    let config = test_config();
+    let report = run_tests(&source, &config).unwrap();
+
+    let result = &report.results[0];
+    let failure = result.failure.as_ref().unwrap();
+
+    // After shrinking, the counterexample should still satisfy x > 0.
+    let arg_val: i64 = failure.args_display[0].parse().unwrap();
+    assert!(
+        arg_val > 0,
+        "shrunk counterexample should satisfy refinement: {arg_val}"
+    );
+    // Should be a small positive number (shrunk toward 1).
+    assert!(
+        arg_val <= 100,
+        "shrunk counterexample should be <= 100: {arg_val}"
+    );
+}
+
+#[test]
+fn refined_mixed_discovery() {
+    let source = fixture("refined_mixed.ky");
+    let config = test_config();
+    let report = run_tests(&source, &config).unwrap();
+
+    assert!(
+        report.all_passed(),
+        "refined_mixed.ky should pass: {}",
+        report.format_human()
+    );
+
+    // Should have both a contracted function and a refined property.
+    assert_eq!(
+        report.results.len(),
+        2,
+        "expected 2 results (fn + property)"
+    );
+
+    let fn_result = report
+        .results
+        .iter()
+        .find(|r| r.kind == TestableKind::Function)
+        .expect("should have a function result");
+    assert_eq!(fn_result.name, "clamp");
+    assert!(fn_result.passed > 0);
+
+    let prop_result = report
+        .results
+        .iter()
+        .find(|r| r.kind == TestableKind::Property)
+        .expect("should have a property result");
+    assert_eq!(prop_result.name, "pos_capped");
+    assert!(prop_result.passed > 0);
+}
+
+#[test]
+fn refined_unsatisfiable_reported() {
+    let source = fixture("refined_unsatisfiable.ky");
+    let config = test_config();
+    let report = run_tests(&source, &config).unwrap();
+
+    assert!(
+        !report.all_passed(),
+        "unsatisfiable refinement should report failure"
+    );
+
+    let result = &report.results[0];
+    assert_eq!(result.name, "impossible");
+    let failure = result.failure.as_ref().unwrap();
+    assert!(
+        failure.error.contains("unsatisfiable"),
+        "expected 'unsatisfiable' error, got: {}",
+        failure.error
+    );
+}
+
+#[test]
+fn refined_type_check() {
+    // Valid refined property: should have no type errors.
+    let result = kyokara_hir::check_file("property p(x: { x: Int | x > 0 }) { x > 0 }");
+    let all_diags: Vec<_> = result
+        .type_check
+        .raw_diagnostics
+        .iter()
+        .map(|(d, _)| format!("{d:?}"))
+        .collect();
+    assert!(
+        all_diags.is_empty(),
+        "valid refined property should have no type errors: {all_diags:?}"
+    );
+}
+
+#[test]
+fn refined_non_property_still_rejected() {
+    // Refined type in a regular function param should still be rejected.
+    let result = kyokara_hir::check_file("fn foo(x: { x: Int | x > 0 }) -> Int { x }");
+    let has_refined_error = result
+        .lowering_diagnostics
+        .iter()
+        .any(|d| d.message.contains("refined types are not yet supported"));
+    assert!(
+        has_refined_error,
+        "refined type in regular fn should be rejected, diagnostics: {:?}",
+        result.lowering_diagnostics
+    );
+}
+
+#[test]
+fn refined_corpus_replay() {
+    let source = fixture("refined_fail.ky");
+    let corpus_dir = tempfile::tempdir().unwrap();
+
+    // First run: explore to find and save a failure.
+    let config = TestConfig {
+        num_tests: 50,
+        explore: true,
+        seed: 42,
+        format: "human".to_string(),
+        corpus_base: corpus_dir.path().to_path_buf(),
+    };
+    let report1 = run_tests(&source, &config).unwrap();
+    assert!(!report1.all_passed());
+
+    // Verify the counterexample satisfies the refinement.
+    let failure1 = report1.results[0].failure.as_ref().unwrap();
+    let arg_val: i64 = failure1.args_display[0].parse().unwrap();
+    assert!(arg_val > 0, "corpus entry should satisfy refinement");
+
+    // Second run: corpus-only replay.
+    let config2 = TestConfig {
+        num_tests: 0,
+        explore: false,
+        seed: 0,
+        format: "human".to_string(),
+        corpus_base: corpus_dir.path().to_path_buf(),
+    };
+    let report2 = run_tests(&source, &config2).unwrap();
+    assert!(
+        !report2.all_passed(),
+        "corpus replay should still detect the failure"
+    );
+
+    // Replayed counterexample should also satisfy refinement.
+    let failure2 = report2.results[0].failure.as_ref().unwrap();
+    let arg_val2: i64 = failure2.args_display[0].parse().unwrap();
+    assert!(
+        arg_val2 > 0,
+        "replayed corpus entry should satisfy refinement"
+    );
+}

--- a/docs/design-v0.md
+++ b/docs/design-v0.md
@@ -208,6 +208,16 @@ property add_commutative(a: Int, b: Int) {
 
 Property bodies are lowered and type-checked (must return `Bool`). The PBT runner discovers properties alongside contracted functions and tests them with generated inputs.
 
+Properties support **refined types** on parameters for constrained generation:
+
+```kyokara
+property positive_is_positive(x: { x: Int | x > 0 }) {
+  x > 0
+}
+```
+
+Refined-type predicates are lowered as synthetic checker functions. The PBT runner uses rejection sampling (up to 1000 attempts) to generate values satisfying the predicate, and the shrinker respects refinement constraints. Unsatisfiable constraints are reported as errors. Refined types in non-property contexts (regular functions, type aliases) are still rejected.
+
 ### 2.9 Typed holes + partial compilation
 
 Holes are legal syntax:
@@ -557,7 +567,7 @@ injected as synthetic types before type-checking.
 * Capability enforcement: type-level checking (E0011) ✓ + runtime manifest enforcement (`--caps`, deny-by-default) ✓
 
 **v0.3 — Verification + Codegen + Replay**
-* Property-based test harness ✓ (`pbt` crate: choice-sequence engine, type-driven generators, 4-pass shrinker, corpus persistence; `kyokara test <file> --explore` discovers contract functions and explicit `property` declarations, generates random inputs, checks contracts/properties, shrinks counterexamples)
+* Property-based test harness ✓ (`pbt` crate: choice-sequence engine, type-driven generators, 4-pass shrinker, corpus persistence, refinement-constrained generation via rejection sampling; `kyokara test <file> --explore` discovers contract functions and explicit `property` declarations, generates random inputs, checks contracts/properties, shrinks counterexamples)
 * SMT integration for contract verification (restricted fragment: linear arithmetic + uninterpreted functions, best-effort, never blocks compilation)
 * KyokaraIR data structures ✓ (SSA, block params, text format, validator) + HIR→KIR lowering ✓ + WASM codegen MVP ✓ (scalars, control flow, function calls, ADTs, records via `codegen` crate + `wasm-encoder`; deferred: closures, strings, lists, maps, intrinsics, capabilities)
 * Capability sandbox runtime (host functions + manifest)

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -142,6 +142,16 @@ property sort_idempotent(xs: List[Int]) {
 
 First-class syntax, not a library — integrated with the type checker and contract system. Property bodies are lowered and type-checked (must return `Bool`). The PBT runner discovers properties alongside contracted functions.
 
+Properties support refined-type parameters for constrained generation:
+
+```kyokara
+property positive_is_positive(x: { x: Int | x > 0 }) {
+  x > 0
+}
+```
+
+Refined-type predicates are lowered as synthetic checker functions and enforced via rejection sampling (up to 1000 attempts). The shrinker respects refinement constraints. Unsatisfiable constraints are reported as errors.
+
 ### Typed Holes and Partial Compilation
 
 ```kyokara
@@ -363,7 +373,7 @@ cli             (depends: api, refactor, eval, pbt, fmt, hir, lsp, syntax, diagn
 - **v0.0** (complete): Parser with error recovery (lossless CST) ✓, name resolution with scope chains ✓, item tree collection + body lowering with desugaring ✓, type checker (ADTs, generics, exhaustiveness) ✓, effect/capability checking ✓, typed holes ✓, structured diagnostics ✓, hole specs ✓, symbol graph ✓, patch suggestions ✓
 - **v0.1** (complete): Tree-walking interpreter ✓, intrinsics ✓, canonical formatter ✓, stable symbol IDs ✓, runtime contracts ✓, core stdlib (List, Map, String, Int/Float) ✓
 - **v0.2** (complete): Module system (convention-based layout, `pub` visibility, flat imports) ✓, refactor engine (rename symbol, add missing match cases, add missing capability) ✓, refactor transactions (atomic verify-before-apply, `--force` bypass) ✓, capability enforcement (type-level E0011 + runtime manifest `--caps`, deny-by-default) ✓, LSP server (salsa incrementality, diagnostics, hover, goto-def, references, completion, code actions, formatting) ✓
-- **v0.3** (in progress): KyokaraIR data structures ✓ (SSA, block params, text format, validator), HIR→KIR lowering ✓, WASM codegen MVP ✓, property-based test harness ✓ (`pbt` crate, `kyokara test --explore`, explicit `property` declarations with type-checked bodies), SMT verification (restricted fragment), capability sandbox, deterministic replay
+- **v0.3** (in progress): KyokaraIR data structures ✓ (SSA, block params, text format, validator), HIR→KIR lowering ✓, WASM codegen MVP ✓, property-based test harness ✓ (`pbt` crate, `kyokara test --explore`, explicit `property` declarations with type-checked bodies, refinement-constrained generation via rejection sampling), SMT verification (restricted fragment), capability sandbox, deterministic replay
 
 ## Building
 

--- a/llms.txt
+++ b/llms.txt
@@ -15,7 +15,7 @@
 - Explicit capabilities: `with Net`, `with Db`, `with Clock`, `with Secrets` — deny-by-default, manifest-enforced
 - ADTs and exhaustive pattern matching: `type Result[T, E] = | Ok(value: T) | Err(error: E)`
 - Contracts: `requires`, `ensures`, `old()` — checked at runtime, optionally verified by SMT (restricted fragment, best-effort)
-- Property-based tests: `property name(x: T) { expr }` as first-class syntax, bodies type-checked (must return Bool)
+- Property-based tests: `property name(x: T) { expr }` as first-class syntax, bodies type-checked (must return Bool), refined-type parameters for constrained generation (`x: { x: Int | x > 0 }`)
 - Typed holes: `?name(args)` compiles to structured hole specs with expected type, effects, and constraints
 - Pipeline operator: `x |> f(a=1)` desugars to `f(x, a=1)`
 - Error propagation: `expr?` desugars to early-return match on `Result`
@@ -38,7 +38,7 @@
 - [fmt](https://github.com/kyokaralang/kyokara/tree/main/crates/fmt): Canonical code formatter — Wadler-Lindig Doc IR, 2-space indent, 100-col width, import sorting, comment preservation, verbatim error fallback
 - [refactor](https://github.com/kyokaralang/kyokara/tree/main/crates/refactor): Semantic refactor engine — CST-based rename (function, type, capability, variant), add missing match cases, add missing capability annotation, transactional verification (apply edits in-memory, re-check, return Verified/Failed/Skipped status)
 - [lsp](https://github.com/kyokaralang/kyokara/tree/main/crates/lsp): LSP server with salsa incrementality — diagnostics, hover, go-to-definition, find references, completion, code actions (quickfixes), formatting
-- [pbt](https://github.com/kyokaralang/kyokara/tree/main/crates/pbt): Property-based testing — choice-sequence engine (SplitMix64 RNG, record/replay), type-driven generators (scalars, ADTs, records, Option, Result, List, Map), 4-pass shrinker (zero-suffix, block deletion, binary-search minimize, pair swap), corpus persistence, contract-for-free testing of `requires`/`ensures`/`invariant` functions, explicit `property` declarations (bodies type-checked, must return Bool)
+- [pbt](https://github.com/kyokaralang/kyokara/tree/main/crates/pbt): Property-based testing — choice-sequence engine (SplitMix64 RNG, record/replay), type-driven generators (scalars, ADTs, records, Option, Result, List, Map), 4-pass shrinker (zero-suffix, block deletion, binary-search minimize, pair swap), corpus persistence, contract-for-free testing of `requires`/`ensures`/`invariant` functions, explicit `property` declarations (bodies type-checked, must return Bool), refinement-constrained generation (rejection sampling)
 - [api](https://github.com/kyokaralang/kyokara/tree/main/crates/api): JSON serialization of all compiler outputs (diagnostics, typed AST, symbol graph with stable namespaced IDs, patches, refactor results)
 - [cli](https://github.com/kyokaralang/kyokara/tree/main/crates/cli): `kyokara check`, `kyokara run`, `kyokara fmt`, `kyokara refactor`, `kyokara test`, `kyokara lsp`
 


### PR DESCRIPTION
## Summary

- Refined-type parameters in `property` declarations (`{ x: Int | x > 0 }`) are now lowered, type-checked, and enforced at generation time via rejection sampling
- Predicates are compiled into synthetic checker functions; the PBT runner retries up to 1000 times to find a satisfying value
- Shrinker respects refinement constraints (predicate-violating candidates are treated as invalid)
- Unsatisfiable constraints are detected and reported as errors
- Refined types in non-property contexts (regular functions, type aliases) remain rejected

## Test plan

- [x] 8 new integration tests: `refined_pass_succeeds`, `refined_fail_detected`, `refined_shrink_respects_predicate`, `refined_mixed_discovery`, `refined_unsatisfiable_reported`, `refined_type_check`, `refined_non_property_still_rejected`, `refined_corpus_replay`
- [x] All 10 existing PBT integration tests still pass (18 total)
- [x] All 91 hir-ty tests pass
- [x] All CLI tests pass
- [x] Zero clippy warnings in pbt crate

Closes #205