### PR TITLE
freeze blockers: evaluator safety, import diagnostics, and wasm int parity

### DIFF
--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -183,7 +183,7 @@ pub fn check_project(entry_file: &std::path::Path) -> CheckOutput {
 
     // Lowering diagnostics.
     for diag in &result.lowering_diagnostics {
-        let code = kyokara_hir::lowering_diagnostic_code(&diag.message);
+        let code = kyokara_hir::lowering_diagnostic_code(diag);
         let file_name = result
             .file_map
             .path(diag.span.file)
@@ -205,7 +205,7 @@ pub fn check_project(entry_file: &std::path::Path) -> CheckOutput {
 
         // Body lowering diagnostics (unresolved names, duplicates).
         for diag in &tc.body_lowering_diagnostics {
-            let code = kyokara_hir::lowering_diagnostic_code(&diag.message);
+            let code = kyokara_hir::lowering_diagnostic_code(diag);
             diagnostics.push(convert_lowering_diagnostic(diag, code, &file_name));
         }
 
@@ -390,13 +390,13 @@ fn convert_result(result: &CheckResult, file_name: &str) -> CheckOutput {
 
     // Lowering diagnostics → E0101 (unresolved name) / E0102 (duplicate definition).
     for diag in &result.lowering_diagnostics {
-        let code = kyokara_hir::lowering_diagnostic_code(&diag.message);
+        let code = kyokara_hir::lowering_diagnostic_code(diag);
         diagnostics.push(convert_lowering_diagnostic(diag, code, file_name));
     }
 
     // Body lowering diagnostics (unresolved names, duplicates from body lowering).
     for diag in &result.type_check.body_lowering_diagnostics {
-        let code = kyokara_hir::lowering_diagnostic_code(&diag.message);
+        let code = kyokara_hir::lowering_diagnostic_code(diag);
         diagnostics.push(convert_lowering_diagnostic(diag, code, file_name));
     }
 

--- a/crates/api/tests/api_tests.rs
+++ b/crates/api/tests/api_tests.rs
@@ -1670,17 +1670,15 @@ fn api_io_error_produces_error_status() {
 #[test]
 fn check_project_reports_unresolved_import() {
     let output = check_project_from_files(&[("main.ky", "import nope\nfn main() -> Int { 1 }\n")]);
+    let diag = output
+        .diagnostics
+        .iter()
+        .find(|d| d.message.contains("nope"))
+        .expect("expected unresolved import diagnostic for `nope`");
     assert!(
-        output
-            .diagnostics
-            .iter()
-            .any(|d| d.message.contains("nope")),
-        "expected a diagnostic about unresolved import `nope`, got: {:?}",
-        output
-            .diagnostics
-            .iter()
-            .map(|d| &d.message)
-            .collect::<Vec<_>>()
+        diag.span.end > diag.span.start,
+        "expected unresolved import span to target source range, got: {:?}",
+        diag.span
     );
 }
 
@@ -1737,17 +1735,15 @@ fn check_project_reports_ambiguous_import_last_segment() {
         ("a/math.ky", "pub fn value() -> Int { 1 }\n"),
         ("b/math.ky", "pub fn value() -> Int { 2 }\n"),
     ]);
+    let diag = output
+        .diagnostics
+        .iter()
+        .find(|d| d.message.contains("ambiguous import"))
+        .expect("expected ambiguous import diagnostic");
     assert!(
-        output
-            .diagnostics
-            .iter()
-            .any(|d| d.message.contains("ambiguous import")),
-        "expected ambiguous import diagnostic, got: {:?}",
-        output
-            .diagnostics
-            .iter()
-            .map(|d| &d.message)
-            .collect::<Vec<_>>()
+        diag.span.end > diag.span.start,
+        "expected ambiguous import span to target source range, got: {:?}",
+        diag.span
     );
 }
 
@@ -2377,6 +2373,11 @@ fn project_import_collision_produces_diagnostic() {
             .iter()
             .map(|d| &d.message)
             .collect::<Vec<_>>()
+    );
+    assert!(
+        collisions[0].span.end > collisions[0].span.start,
+        "expected conflicting import span to target source range, got: {:?}",
+        collisions[0].span
     );
 }
 

--- a/crates/codegen/src/wasm/func.rs
+++ b/crates/codegen/src/wasm/func.rs
@@ -26,6 +26,10 @@ pub struct FuncCodegen<'a> {
     local_types: Vec<ValType>,
     /// Next available local index.
     next_local: u32,
+    /// Scratch i64 local for checked integer codegen.
+    scratch_i64: u32,
+    /// Scratch i32 local for checked integer codegen.
+    scratch_i32: u32,
 }
 
 impl<'a> FuncCodegen<'a> {
@@ -36,6 +40,8 @@ impl<'a> FuncCodegen<'a> {
             local_map: FxHashMap::default(),
             local_types: Vec::new(),
             next_local: kir_func.params.len() as u32,
+            scratch_i64: 0,
+            scratch_i32: 0,
         }
     }
 
@@ -81,6 +87,15 @@ impl<'a> FuncCodegen<'a> {
             self.local_types.push(wasm_ty);
             self.local_map.insert(vid, local_idx);
         }
+
+        // Scratch locals for checked integer operations.
+        self.scratch_i64 = self.next_local;
+        self.next_local += 1;
+        self.local_types.push(ValType::I64);
+
+        self.scratch_i32 = self.next_local;
+        self.next_local += 1;
+        self.local_types.push(ValType::I32);
 
         Ok(())
     }
@@ -711,6 +726,122 @@ impl<'a> FuncCodegen<'a> {
         }
     }
 
+    fn emit_trap_if_true(&self, func: &mut Function) {
+        func.instruction(&Instruction::If(BlockType::Empty));
+        func.instruction(&Instruction::Unreachable);
+        func.instruction(&Instruction::End);
+    }
+
+    fn emit_checked_int_add(&self, func: &mut Function, lhs: ValueId, rhs: ValueId) {
+        self.emit_get(func, lhs);
+        self.emit_get(func, rhs);
+        func.instruction(&Instruction::I64Add);
+        func.instruction(&Instruction::LocalSet(self.scratch_i64));
+
+        // Overflow iff ((lhs ^ result) & (rhs ^ result)) < 0.
+        self.emit_get(func, lhs);
+        func.instruction(&Instruction::LocalGet(self.scratch_i64));
+        func.instruction(&Instruction::I64Xor);
+        self.emit_get(func, rhs);
+        func.instruction(&Instruction::LocalGet(self.scratch_i64));
+        func.instruction(&Instruction::I64Xor);
+        func.instruction(&Instruction::I64And);
+        func.instruction(&Instruction::I64Const(0));
+        func.instruction(&Instruction::I64LtS);
+        self.emit_trap_if_true(func);
+
+        func.instruction(&Instruction::LocalGet(self.scratch_i64));
+    }
+
+    fn emit_checked_int_sub(&self, func: &mut Function, lhs: ValueId, rhs: ValueId) {
+        self.emit_get(func, lhs);
+        self.emit_get(func, rhs);
+        func.instruction(&Instruction::I64Sub);
+        func.instruction(&Instruction::LocalSet(self.scratch_i64));
+
+        // Overflow iff ((lhs ^ rhs) & (lhs ^ result)) < 0.
+        self.emit_get(func, lhs);
+        self.emit_get(func, rhs);
+        func.instruction(&Instruction::I64Xor);
+        self.emit_get(func, lhs);
+        func.instruction(&Instruction::LocalGet(self.scratch_i64));
+        func.instruction(&Instruction::I64Xor);
+        func.instruction(&Instruction::I64And);
+        func.instruction(&Instruction::I64Const(0));
+        func.instruction(&Instruction::I64LtS);
+        self.emit_trap_if_true(func);
+
+        func.instruction(&Instruction::LocalGet(self.scratch_i64));
+    }
+
+    fn emit_checked_int_mul(&self, func: &mut Function, lhs: ValueId, rhs: ValueId) {
+        self.emit_get(func, lhs);
+        self.emit_get(func, rhs);
+        func.instruction(&Instruction::I64Mul);
+        func.instruction(&Instruction::LocalSet(self.scratch_i64));
+
+        // Overflow check:
+        // if lhs != 0 && (result / lhs) != rhs => trap
+        self.emit_get(func, lhs);
+        func.instruction(&Instruction::I64Eqz);
+        func.instruction(&Instruction::If(BlockType::Empty));
+        func.instruction(&Instruction::Else);
+        func.instruction(&Instruction::LocalGet(self.scratch_i64));
+        self.emit_get(func, lhs);
+        func.instruction(&Instruction::I64DivS);
+        self.emit_get(func, rhs);
+        func.instruction(&Instruction::I64Ne);
+        self.emit_trap_if_true(func);
+        func.instruction(&Instruction::End);
+
+        func.instruction(&Instruction::LocalGet(self.scratch_i64));
+    }
+
+    fn emit_checked_int_mod(&self, func: &mut Function, lhs: ValueId, rhs: ValueId) {
+        // Match interpreter semantics: MIN % -1 is overflow.
+        self.emit_get(func, lhs);
+        func.instruction(&Instruction::I64Const(i64::MIN));
+        func.instruction(&Instruction::I64Eq);
+        self.emit_get(func, rhs);
+        func.instruction(&Instruction::I64Const(-1));
+        func.instruction(&Instruction::I64Eq);
+        func.instruction(&Instruction::I32And);
+        self.emit_trap_if_true(func);
+
+        self.emit_get(func, lhs);
+        self.emit_get(func, rhs);
+        func.instruction(&Instruction::I64RemS);
+    }
+
+    fn emit_checked_int_shift(
+        &self,
+        func: &mut Function,
+        lhs: ValueId,
+        rhs: ValueId,
+        op: BinaryOp,
+    ) {
+        // Shift amount must be within 0..63 inclusive.
+        self.emit_get(func, rhs);
+        func.instruction(&Instruction::I64Const(0));
+        func.instruction(&Instruction::I64LtS);
+        func.instruction(&Instruction::LocalSet(self.scratch_i32));
+
+        self.emit_get(func, rhs);
+        func.instruction(&Instruction::I64Const(64));
+        func.instruction(&Instruction::I64GeS);
+        func.instruction(&Instruction::LocalGet(self.scratch_i32));
+        func.instruction(&Instruction::I32Or);
+        self.emit_trap_if_true(func);
+
+        self.emit_get(func, lhs);
+        self.emit_get(func, rhs);
+        match op {
+            BinaryOp::Shl => func.instruction(&Instruction::I64Shl),
+            BinaryOp::Shr => func.instruction(&Instruction::I64ShrS),
+            _ => unreachable!("emit_checked_int_shift called with non-shift op"),
+        };
+    }
+
     // ── Binary operations ─────────────────────────────────────────
 
     fn emit_binary(
@@ -743,20 +874,40 @@ impl<'a> FuncCodegen<'a> {
             return Ok(());
         }
 
+        if matches!(lhs_ty, Ty::Int) {
+            match op {
+                BinaryOp::Add => {
+                    self.emit_checked_int_add(func, lhs, rhs);
+                    return Ok(());
+                }
+                BinaryOp::Sub => {
+                    self.emit_checked_int_sub(func, lhs, rhs);
+                    return Ok(());
+                }
+                BinaryOp::Mul => {
+                    self.emit_checked_int_mul(func, lhs, rhs);
+                    return Ok(());
+                }
+                BinaryOp::Mod => {
+                    self.emit_checked_int_mod(func, lhs, rhs);
+                    return Ok(());
+                }
+                BinaryOp::Shl | BinaryOp::Shr => {
+                    self.emit_checked_int_shift(func, lhs, rhs, op);
+                    return Ok(());
+                }
+                _ => {}
+            }
+        }
+
         self.emit_get(func, lhs);
         self.emit_get(func, rhs);
 
         match (op, lhs_ty) {
-            (BinaryOp::Add, Ty::Int) => func.instruction(&Instruction::I64Add),
-            (BinaryOp::Sub, Ty::Int) => func.instruction(&Instruction::I64Sub),
-            (BinaryOp::Mul, Ty::Int) => func.instruction(&Instruction::I64Mul),
             (BinaryOp::Div, Ty::Int) => func.instruction(&Instruction::I64DivS),
-            (BinaryOp::Mod, Ty::Int) => func.instruction(&Instruction::I64RemS),
             (BinaryOp::BitAnd, Ty::Int) => func.instruction(&Instruction::I64And),
             (BinaryOp::BitOr, Ty::Int) => func.instruction(&Instruction::I64Or),
             (BinaryOp::BitXor, Ty::Int) => func.instruction(&Instruction::I64Xor),
-            (BinaryOp::Shl, Ty::Int) => func.instruction(&Instruction::I64Shl),
-            (BinaryOp::Shr, Ty::Int) => func.instruction(&Instruction::I64ShrS),
 
             (BinaryOp::Add, Ty::Float) => func.instruction(&Instruction::F64Add),
             (BinaryOp::Sub, Ty::Float) => func.instruction(&Instruction::F64Sub),
@@ -808,6 +959,11 @@ impl<'a> FuncCodegen<'a> {
 
         match (op, operand_ty) {
             (UnaryOp::Neg, Ty::Int) => {
+                self.emit_get(func, operand);
+                func.instruction(&Instruction::I64Const(i64::MIN));
+                func.instruction(&Instruction::I64Eq);
+                self.emit_trap_if_true(func);
+
                 func.instruction(&Instruction::I64Const(0));
                 self.emit_get(func, operand);
                 func.instruction(&Instruction::I64Sub);

--- a/crates/codegen/tests/codegen_tests.rs
+++ b/crates/codegen/tests/codegen_tests.rs
@@ -1435,26 +1435,30 @@ fn test_int_mod_by_zero_traps() {
 }
 
 #[test]
-fn test_int_overflow_add_wraps() {
-    // WASM i64.add wraps: i64::MAX + 1 = i64::MIN.
-    assert_eq!(
-        run_main_i64("fn main() -> Int { 9223372036854775807 + 1 }"),
-        i64::MIN
-    );
+fn test_int_overflow_add_traps() {
+    assert!(run_main_traps(
+        "fn main() -> Int { 9223372036854775807 + 1 }"
+    ));
 }
 
 #[test]
-fn test_int_overflow_sub_wraps() {
-    // i64::MIN - 1 wraps to i64::MAX.
-    assert_eq!(
-        run_main_i64(
-            "fn main() -> Int {\n\
-               let min = -(9223372036854775807) - 1\n\
-               min - 1\n\
-             }"
-        ),
-        i64::MAX
-    );
+fn test_int_overflow_sub_traps() {
+    assert!(run_main_traps(
+        "fn main() -> Int {\n\
+           let min = -(9223372036854775807) - 1\n\
+           min - 1\n\
+         }"
+    ));
+}
+
+#[test]
+fn test_int_overflow_mul_traps() {
+    assert!(run_main_traps(
+        "fn main() -> Int {\n\
+           let a = 4611686018427387904\n\
+           a * 4\n\
+         }"
+    ));
 }
 
 #[test]
@@ -1466,6 +1470,29 @@ fn test_int_min_div_neg_one_traps() {
            min / -1\n\
          }"
     ));
+}
+
+#[test]
+fn test_int_min_mod_neg_one_traps() {
+    assert!(run_main_traps(
+        "fn main() -> Int {\n\
+           let min = -(9223372036854775807) - 1\n\
+           min % -1\n\
+         }"
+    ));
+}
+
+#[test]
+fn test_unary_neg_min_traps() {
+    assert!(run_main_traps(
+        "fn main() -> Int { -(-(9223372036854775807) - 1) }"
+    ));
+}
+
+#[test]
+fn test_shift_amount_out_of_range_traps() {
+    assert!(run_main_traps("fn main() -> Int { 1 << 64 }"));
+    assert!(run_main_traps("fn main() -> Int { 1 >> -1 }"));
 }
 
 #[test]

--- a/crates/diagnostics/src/lib.rs
+++ b/crates/diagnostics/src/lib.rs
@@ -14,6 +14,14 @@ pub enum Severity {
     Hint,
 }
 
+/// Structured classification for diagnostics.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum DiagnosticKind {
+    General,
+    DuplicateDefinition,
+    UnresolvedName,
+}
+
 /// A suggested fix for a diagnostic.
 #[derive(Debug, Clone)]
 pub struct Fix {
@@ -26,6 +34,7 @@ pub struct Fix {
 #[derive(Debug, Clone)]
 pub struct Diagnostic {
     pub severity: Severity,
+    pub kind: DiagnosticKind,
     pub message: String,
     pub span: Span,
     pub fixes: Vec<Fix>,
@@ -33,8 +42,13 @@ pub struct Diagnostic {
 
 impl Diagnostic {
     pub fn error(message: impl Into<String>, span: Span) -> Self {
+        Self::error_with_kind(message, span, DiagnosticKind::General)
+    }
+
+    pub fn error_with_kind(message: impl Into<String>, span: Span, kind: DiagnosticKind) -> Self {
         Self {
             severity: Severity::Error,
+            kind,
             message: message.into(),
             span,
             fixes: Vec::new(),
@@ -44,10 +58,16 @@ impl Diagnostic {
     pub fn warning(message: impl Into<String>, span: Span) -> Self {
         Self {
             severity: Severity::Warning,
+            kind: DiagnosticKind::General,
             message: message.into(),
             span,
             fixes: Vec::new(),
         }
+    }
+
+    pub fn with_kind(mut self, kind: DiagnosticKind) -> Self {
+        self.kind = kind;
+        self
     }
 
     pub fn with_fix(mut self, fix: Fix) -> Self {

--- a/crates/eval/src/error.rs
+++ b/crates/eval/src/error.rs
@@ -48,6 +48,13 @@ pub enum RuntimeError {
     #[error("integer overflow")]
     IntegerOverflow,
 
+    #[error("arity mismatch for {callee}: expected {expected}, found {actual}")]
+    ArityMismatch {
+        callee: String,
+        expected: usize,
+        actual: usize,
+    },
+
     #[error("index out of bounds: index {index}, length {len}")]
     IndexOutOfBounds { index: i64, len: i64 },
 

--- a/crates/eval/src/interpreter.rs
+++ b/crates/eval/src/interpreter.rs
@@ -248,90 +248,84 @@ impl Interpreter {
         let body = self
             .fn_bodies
             .get(&fn_idx)
-            .ok_or_else(|| RuntimeError::UnresolvedName("function body not found".into()))?
-            as *const Body;
-        // SAFETY: we hold &mut self but only mutate interner/env/old_env, not fn_bodies.
-        let body = unsafe { &*body };
+            .cloned()
+            .ok_or_else(|| RuntimeError::UnresolvedName("function body not found".into()))?;
 
-        let fn_item = &self.item_tree.functions[fn_idx];
+        let (params, fn_name) = {
+            let fn_item = &self.item_tree.functions[fn_idx];
+            self.ensure_user_fn_caps_allowed(fn_item)?;
+            (fn_item.params.clone(), fn_item.name)
+        };
 
-        self.ensure_user_fn_caps_allowed(fn_item)?;
+        self.ensure_arity(
+            &format!("function `{}`", fn_name.resolve(&self.interner)),
+            params.len(),
+            args.len(),
+        )?;
 
-        // Use the shared environment with a new scope instead of allocating a fresh Env.
         self.env.push_scope();
 
-        // Bind parameters directly from the item tree (no intermediate Vec allocation).
-        let params = &fn_item.params;
-        for (i, param) in params.iter().enumerate() {
-            if let Some(val) = args.get(i) {
-                self.env.bind(param.name, val.clone());
-            }
+        for (param, val) in params.iter().zip(args.into_iter()) {
+            self.env.bind(param.name, val);
         }
 
-        // Fast path: skip contract checks when no contracts are present.
         let has_requires = body.requires.is_some();
         let has_ensures = body.ensures.is_some();
         let has_invariant = body.invariant.is_some();
 
-        if !has_requires && !has_ensures && !has_invariant {
-            // Hot path: no contracts — just evaluate the body.
-            let result = self.eval_expr_shared(body, body.root);
-            self.env.pop_scope();
-            let return_val = match result? {
-                ControlFlow::Value(v) | ControlFlow::Return(v) => v,
-            };
-            return Ok(return_val);
-        }
+        let mut prev_old_env = None;
+        let mut swapped_old_env = false;
+        let fn_name_str = fn_name.resolve(&self.interner).to_string();
 
-        // Slow path: full contract checking.
-        let fn_name_str = fn_item.name.resolve(&self.interner).to_string();
+        let result = (|| -> Result<Value, RuntimeError> {
+            if !has_requires && !has_ensures && !has_invariant {
+                let return_val = match self.eval_expr_shared(&body, body.root)? {
+                    ControlFlow::Value(v) | ControlFlow::Return(v) => v,
+                };
+                Ok(return_val)
+            } else {
+                if let Some(req_idx) = body.requires {
+                    let val = self.eval_expr_shared(&body, req_idx)?.into_value();
+                    if !matches!(val, Value::Bool(true)) {
+                        Err(RuntimeError::PreconditionFailed(fn_name_str.clone()))?;
+                    }
+                }
 
-        // Check precondition.
-        if let Some(req_idx) = body.requires {
-            let val = self.eval_expr_shared(body, req_idx)?.into_value();
-            if !matches!(val, Value::Bool(true)) {
-                self.env.pop_scope();
-                return Err(RuntimeError::PreconditionFailed(fn_name_str));
+                if has_ensures {
+                    prev_old_env = self.old_env.replace(self.env.clone());
+                    swapped_old_env = true;
+                }
+
+                let return_val = match self.eval_expr_shared(&body, body.root)? {
+                    ControlFlow::Value(v) | ControlFlow::Return(v) => v,
+                };
+
+                if let Some(inv_idx) = body.invariant {
+                    let val = self.eval_expr_shared(&body, inv_idx)?.into_value();
+                    if !matches!(val, Value::Bool(true)) {
+                        Err(RuntimeError::InvariantViolated(fn_name_str.clone()))?;
+                    }
+                }
+
+                if let Some(ens_idx) = body.ensures {
+                    let result_name = Name::new(&mut self.interner, "result");
+                    self.env.bind(result_name, return_val.clone());
+                    let val = self.eval_expr_shared(&body, ens_idx)?.into_value();
+                    if !matches!(val, Value::Bool(true)) {
+                        Err(RuntimeError::PostconditionFailed(fn_name_str.clone()))?;
+                    }
+                }
+
+                Ok(return_val)
             }
-        }
+        })();
 
-        // Snapshot env for old() before evaluating the body.
-        let prev_old_env = self.old_env.take();
-        if has_ensures {
-            self.old_env = Some(self.env.clone());
-        }
-
-        // Evaluate the function body.
-        let return_val = match self.eval_expr_shared(body, body.root)? {
-            ControlFlow::Value(v) | ControlFlow::Return(v) => v,
-        };
-
-        // Check invariant.
-        if let Some(inv_idx) = body.invariant {
-            let val = self.eval_expr_shared(body, inv_idx)?.into_value();
-            if !matches!(val, Value::Bool(true)) {
-                self.env.pop_scope();
-                self.old_env = prev_old_env;
-                return Err(RuntimeError::InvariantViolated(fn_name_str));
-            }
-        }
-
-        // Check postcondition.
-        if let Some(ens_idx) = body.ensures {
-            let result_name = Name::new(&mut self.interner, "result");
-            self.env.bind(result_name, return_val.clone());
-            let val = self.eval_expr_shared(body, ens_idx)?.into_value();
-            self.env.pop_scope();
-            self.old_env = prev_old_env;
-            if !matches!(val, Value::Bool(true)) {
-                return Err(RuntimeError::PostconditionFailed(fn_name_str));
-            }
-        } else {
-            self.env.pop_scope();
+        self.env.pop_scope();
+        if swapped_old_env {
             self.old_env = prev_old_env;
         }
 
-        Ok(return_val)
+        result
     }
 
     fn eval_expr(
@@ -653,62 +647,14 @@ impl Interpreter {
                         .map(ControlFlow::Value);
                 }
 
-                // Note: args borrows body.exprs[idx] immutably, which is compatible
-                // with passing body to eval_expr_shared (also immutable).
-                // The &mut self in eval_expr_shared doesn't conflict because body
-                // is not borrowed from self (it comes from a raw pointer).
                 let callee_val = eval_propagate_shared!(self, body, callee_idx);
 
-                // Fast path: direct user function call — evaluate args directly
-                // into the shared env, avoiding Vec<Value> allocation entirely.
+                // Direct user-function call path.
                 if let Value::Fn(ref fv) = callee_val
                     && let FnValue::User(fn_idx) = **fv
                 {
-                    let fn_body = self.fn_bodies.get(&fn_idx).ok_or_else(|| {
-                        RuntimeError::UnresolvedName("function body not found".into())
-                    })? as *const Body;
-                    let fn_body = unsafe { &*fn_body };
-                    let fn_item = &self.item_tree.functions[fn_idx];
-
-                    self.ensure_user_fn_caps_allowed(fn_item)?;
-
-                    // Reorder args when named args are present so values match
-                    // parameter order instead of call-site order.
-                    let reordered = self.reorder_args_for_fn(args, &fn_item.params);
-
-                    let has_contracts = fn_body.requires.is_some()
-                        || fn_body.ensures.is_some()
-                        || fn_body.invariant.is_some();
-
-                    if !has_contracts {
-                        // Hot path: push scope, bind args directly, evaluate body.
-                        // We use a raw pointer to fn_item.params to avoid holding
-                        // an immutable borrow on self.item_tree across eval calls.
-                        // SAFETY: eval_expr_shared never mutates item_tree.
-                        let params_ptr = &fn_item.params as *const Vec<FnParam>;
-                        let params = unsafe { &*params_ptr };
-                        let prev_fn = self.current_fn.replace(fn_idx);
-                        let fast_result = (|| -> Result<ControlFlow, RuntimeError> {
-                            self.env.push_scope();
-                            for (i, arg_idx) in reordered.iter().enumerate() {
-                                let val = eval_propagate_shared!(self, body, *arg_idx);
-                                if let Some(param) = params.get(i) {
-                                    self.env.bind(param.name, val);
-                                }
-                            }
-
-                            let result = self.eval_expr_shared(fn_body, fn_body.root);
-                            self.env.pop_scope();
-                            let return_val = match result? {
-                                ControlFlow::Value(v) | ControlFlow::Return(v) => v,
-                            };
-                            Ok(ControlFlow::Value(return_val))
-                        })();
-                        self.current_fn = prev_fn;
-                        return fast_result;
-                    }
-
-                    // Slow path: contracts present — collect args into SmallVec.
+                    let params = self.item_tree.functions[fn_idx].params.clone();
+                    let reordered = self.reorder_args_for_fn(args, &params);
                     let mut args_vec = Args::with_capacity(reordered.len());
                     for arg_idx in &reordered {
                         let v = eval_propagate_shared!(self, body, *arg_idx);
@@ -1064,6 +1010,23 @@ impl Interpreter {
         }
     }
 
+    fn ensure_arity(
+        &self,
+        callee: &str,
+        expected: usize,
+        actual: usize,
+    ) -> Result<(), RuntimeError> {
+        if expected == actual {
+            Ok(())
+        } else {
+            Err(RuntimeError::ArityMismatch {
+                callee: callee.to_string(),
+                expected,
+                actual,
+            })
+        }
+    }
+
     fn call_value(&mut self, callee: Value, args: Args) -> Result<Value, RuntimeError> {
         match callee {
             Value::Fn(fv) => match *fv {
@@ -1082,6 +1045,7 @@ impl Interpreter {
                     body,
                     env: captured_env,
                 } => {
+                    self.ensure_arity("lambda", params.len(), args.len())?;
                     let mut env = captured_env;
                     env.push_scope();
                     for (pat_idx, val) in params.iter().zip(args) {
@@ -1093,11 +1057,18 @@ impl Interpreter {
                 FnValue::Constructor {
                     type_idx,
                     variant_idx,
+                    arity,
                     ..
                 } => Ok(Value::Adt {
+                    // Constructor calls must match declared field count.
+                    // Type checking should guarantee this, but runtime calls
+                    // can also happen through values and API entrypoints.
                     type_idx,
                     variant: variant_idx,
-                    fields: args.into_vec(),
+                    fields: {
+                        self.ensure_arity("constructor", arity, args.len())?;
+                        args.into_vec()
+                    },
                 }),
             },
             _ => Err(RuntimeError::TypeError(
@@ -1529,15 +1500,30 @@ impl Interpreter {
         for stmt in stmts {
             match stmt {
                 Stmt::Let { pat, init, .. } => {
-                    let result = self.eval_expr(env, body, *init)?;
+                    let result = match self.eval_expr(env, body, *init) {
+                        Ok(result) => result,
+                        Err(err) => {
+                            env.pop_scope();
+                            return Err(err);
+                        }
+                    };
                     if let ControlFlow::Return(_) = &result {
                         env.pop_scope();
                         return Ok(result);
                     }
-                    self.bind_pat(body, *pat, &result.into_value(), env)?;
+                    if let Err(err) = self.bind_pat(body, *pat, &result.into_value(), env) {
+                        env.pop_scope();
+                        return Err(err);
+                    }
                 }
                 Stmt::Expr(idx) => {
-                    let result = self.eval_expr(env, body, *idx)?;
+                    let result = match self.eval_expr(env, body, *idx) {
+                        Ok(result) => result,
+                        Err(err) => {
+                            env.pop_scope();
+                            return Err(err);
+                        }
+                    };
                     if let ControlFlow::Return(_) = &result {
                         env.pop_scope();
                         return Ok(result);
@@ -1550,10 +1536,8 @@ impl Interpreter {
         } else {
             Ok(ControlFlow::Value(Value::Unit))
         };
-        // If the tail is a Return, we need to propagate it.
-        let r = result?;
         env.pop_scope();
-        Ok(r)
+        result
     }
 
     fn bind_pat(
@@ -1652,15 +1636,30 @@ impl Interpreter {
         for stmt in stmts {
             match stmt {
                 Stmt::Let { pat, init, .. } => {
-                    let result = self.eval_expr_shared(body, *init)?;
+                    let result = match self.eval_expr_shared(body, *init) {
+                        Ok(result) => result,
+                        Err(err) => {
+                            self.env.pop_scope();
+                            return Err(err);
+                        }
+                    };
                     if let ControlFlow::Return(_) = &result {
                         self.env.pop_scope();
                         return Ok(result);
                     }
-                    self.bind_pat_shared(body, *pat, &result.into_value())?;
+                    if let Err(err) = self.bind_pat_shared(body, *pat, &result.into_value()) {
+                        self.env.pop_scope();
+                        return Err(err);
+                    }
                 }
                 Stmt::Expr(idx) => {
-                    let result = self.eval_expr_shared(body, *idx)?;
+                    let result = match self.eval_expr_shared(body, *idx) {
+                        Ok(result) => result,
+                        Err(err) => {
+                            self.env.pop_scope();
+                            return Err(err);
+                        }
+                    };
                     if let ControlFlow::Return(_) = &result {
                         self.env.pop_scope();
                         return Ok(result);
@@ -1673,9 +1672,8 @@ impl Interpreter {
         } else {
             Ok(ControlFlow::Value(Value::Unit))
         };
-        let r = result?;
         self.env.pop_scope();
-        Ok(r)
+        result
     }
 
     fn bind_pat_shared(
@@ -1733,10 +1731,12 @@ impl Interpreter {
 mod tests {
     #![allow(clippy::unwrap_used)]
 
+    use kyokara_hir::check_file;
     use kyokara_hir_def::item_tree::{TypeDefKind, TypeItem, VariantDef};
     use kyokara_hir_def::path::Path;
     use kyokara_hir_def::type_ref::TypeRef;
     use la_arena::{Arena, ArenaMap};
+    use smallvec::smallvec;
 
     use super::*;
 
@@ -1847,5 +1847,210 @@ mod tests {
             matched,
             "single-segment constructor pattern should match corresponding ADT value"
         );
+    }
+
+    fn make_checked_interpreter(source: &str) -> Interpreter {
+        let checked = check_file(source);
+        assert!(
+            checked.parse_errors.is_empty(),
+            "parse errors: {:?}",
+            checked.parse_errors
+        );
+        assert!(
+            checked.lowering_diagnostics.is_empty(),
+            "lowering diagnostics: {:?}",
+            checked.lowering_diagnostics
+        );
+        assert!(
+            checked.type_check.body_lowering_diagnostics.is_empty(),
+            "body lowering diagnostics: {:?}",
+            checked.type_check.body_lowering_diagnostics
+        );
+        assert!(
+            checked.type_check.raw_diagnostics.is_empty(),
+            "type diagnostics: {:?}",
+            checked.type_check.raw_diagnostics
+        );
+
+        Interpreter::new(
+            checked.item_tree,
+            checked.module_scope,
+            checked.type_check.fn_bodies,
+            FxHashMap::default(),
+            checked.interner,
+            None,
+        )
+    }
+
+    fn fn_idx_by_name(interp: &mut Interpreter, name: &str) -> FnItemIdx {
+        let name = Name::new(interp.interner_mut(), name);
+        *interp
+            .module_scope
+            .functions
+            .get(&name)
+            .expect("function should exist")
+    }
+
+    #[test]
+    fn user_function_call_reports_arity_mismatch() {
+        let mut interp = make_checked_interpreter(
+            "fn add(x: Int, y: Int) -> Int { x + y } fn main() -> Int { 0 }",
+        );
+        let add_idx = fn_idx_by_name(&mut interp, "add");
+
+        let err = interp
+            .call_fn_by_idx(add_idx, smallvec![Value::Int(1)])
+            .expect_err("too-few args should fail");
+        assert!(
+            err.to_string().contains("arity mismatch"),
+            "expected arity mismatch error, got: {err}"
+        );
+
+        let err = interp
+            .call_fn_by_idx(
+                add_idx,
+                smallvec![Value::Int(1), Value::Int(2), Value::Int(3)],
+            )
+            .expect_err("too-many args should fail");
+        assert!(
+            err.to_string().contains("arity mismatch"),
+            "expected arity mismatch error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn lambda_call_reports_arity_mismatch() {
+        let (mut interp, mut body, _type_idx, _a_name, _some_name) =
+            make_test_interpreter_and_body();
+
+        let x = Name::new(interp.interner_mut(), "x");
+        let x_pat = body.pats.alloc(Pat::Bind { name: x });
+        let root = body.exprs.alloc(Expr::Literal(Literal::Int(42)));
+        body.root = root;
+
+        let lambda = Value::Fn(Box::new(FnValue::Lambda {
+            params: vec![x_pat],
+            body_expr: root,
+            body: Rc::new(body),
+            env: Env::new(),
+        }));
+
+        let err = interp
+            .call_value(lambda.clone(), Args::new())
+            .expect_err("too-few lambda args should fail");
+        assert!(
+            err.to_string().contains("arity mismatch"),
+            "expected arity mismatch error, got: {err}"
+        );
+
+        let err = interp
+            .call_value(lambda, smallvec![Value::Int(1), Value::Int(2)])
+            .expect_err("too-many lambda args should fail");
+        assert!(
+            err.to_string().contains("arity mismatch"),
+            "expected arity mismatch error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn constructor_call_reports_arity_mismatch() {
+        let (mut interp, _body, type_idx, _a_name, _some_name) = make_test_interpreter_and_body();
+
+        let ctor = Value::Fn(Box::new(FnValue::Constructor {
+            type_idx,
+            variant_idx: 0,
+            arity: 1,
+        }));
+
+        let err = interp
+            .call_value(ctor.clone(), Args::new())
+            .expect_err("too-few constructor args should fail");
+        assert!(
+            err.to_string().contains("arity mismatch"),
+            "expected arity mismatch error, got: {err}"
+        );
+
+        let err = interp
+            .call_value(ctor, smallvec![Value::Int(1), Value::Int(2)])
+            .expect_err("too-many constructor args should fail");
+        assert!(
+            err.to_string().contains("arity mismatch"),
+            "expected arity mismatch error, got: {err}"
+        );
+    }
+
+    fn assert_no_leaked_call_state(interp: &mut Interpreter) {
+        assert!(
+            interp.old_env.is_none(),
+            "old_env should be restored on call failure"
+        );
+        let x_name = Name::new(interp.interner_mut(), "x");
+        let result_name = Name::new(interp.interner_mut(), "result");
+        assert!(
+            interp.env.lookup(x_name).is_none(),
+            "parameter `x` leaked into shared env after call failure: {:?}",
+            interp.env
+        );
+        assert!(
+            interp.env.lookup(result_name).is_none(),
+            "`result` leaked into shared env after call failure: {:?}",
+            interp.env
+        );
+    }
+
+    #[test]
+    fn contract_requires_error_does_not_leak_env_or_old_snapshot() {
+        let mut interp = make_checked_interpreter(
+            "fn bad(x: Int) -> Int requires x / 0 > 0 ensures old(x) == x { x }\n\
+             fn main() -> Int { 0 }",
+        );
+        let bad_idx = fn_idx_by_name(&mut interp, "bad");
+        let err = interp
+            .call_fn_by_idx(bad_idx, smallvec![Value::Int(1)])
+            .expect_err("requires expression should fail at runtime");
+        assert!(matches!(err, RuntimeError::DivisionByZero));
+        assert_no_leaked_call_state(&mut interp);
+    }
+
+    #[test]
+    fn contract_body_error_does_not_leak_env_or_old_snapshot() {
+        let mut interp = make_checked_interpreter(
+            "fn bad(x: Int) -> Int ensures old(x) == x { x / 0 }\n\
+             fn main() -> Int { 0 }",
+        );
+        let bad_idx = fn_idx_by_name(&mut interp, "bad");
+        let err = interp
+            .call_fn_by_idx(bad_idx, smallvec![Value::Int(1)])
+            .expect_err("body should fail at runtime");
+        assert!(matches!(err, RuntimeError::DivisionByZero));
+        assert_no_leaked_call_state(&mut interp);
+    }
+
+    #[test]
+    fn contract_invariant_error_does_not_leak_env_or_old_snapshot() {
+        let mut interp = make_checked_interpreter(
+            "fn bad(x: Int) -> Int ensures old(x) == x invariant x / 0 > 0 { x }\n\
+             fn main() -> Int { 0 }",
+        );
+        let bad_idx = fn_idx_by_name(&mut interp, "bad");
+        let err = interp
+            .call_fn_by_idx(bad_idx, smallvec![Value::Int(1)])
+            .expect_err("invariant expression should fail at runtime");
+        assert!(matches!(err, RuntimeError::DivisionByZero));
+        assert_no_leaked_call_state(&mut interp);
+    }
+
+    #[test]
+    fn contract_ensures_error_does_not_leak_env_or_old_snapshot() {
+        let mut interp = make_checked_interpreter(
+            "fn bad(x: Int) -> Int ensures old(x) / 0 > 0 { x }\n\
+             fn main() -> Int { 0 }",
+        );
+        let bad_idx = fn_idx_by_name(&mut interp, "bad");
+        let err = interp
+            .call_fn_by_idx(bad_idx, smallvec![Value::Int(1)])
+            .expect_err("ensures expression should fail at runtime");
+        assert!(matches!(err, RuntimeError::DivisionByZero));
+        assert_no_leaked_call_state(&mut interp);
     }
 }

--- a/crates/hir-def/src/body/lower.rs
+++ b/crates/hir-def/src/body/lower.rs
@@ -5,7 +5,7 @@
 
 use la_arena::{Arena, ArenaMap};
 
-use kyokara_diagnostics::Diagnostic;
+use kyokara_diagnostics::{Diagnostic, DiagnosticKind};
 use kyokara_intern::Interner;
 use kyokara_span::{FileId, Span, TextRange};
 use kyokara_syntax::SyntaxKind;
@@ -486,10 +486,13 @@ impl BodyLowerCtx<'_> {
             && self.resolve_name(name).is_none()
         {
             let span = self.node_span(pe.syntax());
-            self.diagnostics.push(Diagnostic::error(
-                format!("unresolved name `{}`", name.resolve(self.interner)),
-                span,
-            ));
+            self.diagnostics.push(
+                Diagnostic::error(
+                    format!("unresolved name `{}`", name.resolve(self.interner)),
+                    span,
+                )
+                .with_kind(DiagnosticKind::UnresolvedName),
+            );
         }
 
         self.alloc_expr(Expr::Path(path))
@@ -818,10 +821,13 @@ impl BodyLowerCtx<'_> {
                     let name = tok.text();
                     if !seen.insert(name.to_string()) {
                         let span = self.node_span(f.syntax());
-                        self.diagnostics.push(Diagnostic::error(
-                            format!("duplicate field `{name}` in record literal"),
-                            span,
-                        ));
+                        self.diagnostics.push(
+                            Diagnostic::error(
+                                format!("duplicate field `{name}` in record literal"),
+                                span,
+                            )
+                            .with_kind(DiagnosticKind::DuplicateDefinition),
+                        );
                     }
                 }
             }
@@ -880,10 +886,10 @@ impl BodyLowerCtx<'_> {
                     let name = tok.text();
                     if !seen.insert(name.to_string()) {
                         let span = self.node_span(p.syntax());
-                        self.diagnostics.push(Diagnostic::error(
-                            format!("duplicate parameter `{name}`"),
-                            span,
-                        ));
+                        self.diagnostics.push(
+                            Diagnostic::error(format!("duplicate parameter `{name}`"), span)
+                                .with_kind(DiagnosticKind::DuplicateDefinition),
+                        );
                     }
                 }
             }
@@ -977,13 +983,16 @@ impl BodyLowerCtx<'_> {
                         .insert(pat_idx, ip.syntax().text_range());
                     if !binders.insert(name) {
                         let span = self.node_span(ip.syntax());
-                        self.diagnostics.push(Diagnostic::error(
-                            format!(
-                                "duplicate binding `{}` in pattern",
-                                name.resolve(self.interner)
-                            ),
-                            span,
-                        ));
+                        self.diagnostics.push(
+                            Diagnostic::error(
+                                format!(
+                                    "duplicate binding `{}` in pattern",
+                                    name.resolve(self.interner)
+                                ),
+                                span,
+                            )
+                            .with_kind(DiagnosticKind::DuplicateDefinition),
+                        );
                     }
                     self.register_local_binding(name, pat_idx, ip.syntax().text_range(), origin);
                     pat_idx
@@ -1085,10 +1094,13 @@ impl BodyLowerCtx<'_> {
                                 file: self.file_id,
                                 range: tok.text_range(),
                             };
-                            self.diagnostics.push(Diagnostic::error(
-                                format!("duplicate field `{name}` in record pattern"),
-                                span,
-                            ));
+                            self.diagnostics.push(
+                                Diagnostic::error(
+                                    format!("duplicate field `{name}` in record pattern"),
+                                    span,
+                                )
+                                .with_kind(DiagnosticKind::DuplicateDefinition),
+                            );
                         }
                     }
                 }

--- a/crates/hir-def/src/item_tree.rs
+++ b/crates/hir-def/src/item_tree.rs
@@ -40,6 +40,7 @@ pub struct ItemTree {
 pub struct Import {
     pub path: Path,
     pub alias: Option<Name>,
+    pub source_range: Option<TextRange>,
 }
 
 /// A function item (signature only — body lowered in Pass 2).

--- a/crates/hir-def/src/item_tree/lower.rs
+++ b/crates/hir-def/src/item_tree/lower.rs
@@ -2,7 +2,7 @@
 //!
 //! Walks top-level CST items to build `ItemTree` + `ModuleScope`.
 
-use kyokara_diagnostics::Diagnostic;
+use kyokara_diagnostics::{Diagnostic, DiagnosticKind};
 use kyokara_intern::Interner;
 use kyokara_span::{FileId, Span};
 use kyokara_syntax::ast::AstNode;
@@ -91,14 +91,21 @@ impl ItemTreeCtx<'_> {
                 e.insert(import_idx);
             } else {
                 let span = self.node_span(import.syntax());
-                self.diagnostics.push(Diagnostic::error(
-                    format!("duplicate import `{}`", name.resolve(self.interner)),
-                    span,
-                ));
+                self.diagnostics.push(
+                    Diagnostic::error(
+                        format!("duplicate import `{}`", name.resolve(self.interner)),
+                        span,
+                    )
+                    .with_kind(DiagnosticKind::DuplicateDefinition),
+                );
             }
         }
 
-        self.tree.imports.push(Import { path, alias });
+        self.tree.imports.push(Import {
+            path,
+            alias,
+            source_range: Some(import.syntax().text_range()),
+        });
     }
 
     fn lower_item(&mut self, item: Item) {
@@ -173,10 +180,10 @@ impl ItemTreeCtx<'_> {
                     let name = tok.text();
                     if !seen.insert(name.to_string()) {
                         let span = self.node_span(p.syntax());
-                        self.diagnostics.push(Diagnostic::error(
-                            format!("duplicate parameter `{name}`"),
-                            span,
-                        ));
+                        self.diagnostics.push(
+                            Diagnostic::error(format!("duplicate parameter `{name}`"), span)
+                                .with_kind(DiagnosticKind::DuplicateDefinition),
+                        );
                     }
                 }
             }
@@ -292,10 +299,13 @@ impl ItemTreeCtx<'_> {
             e.insert(idx);
         } else {
             let span = self.node_span(t.syntax());
-            self.diagnostics.push(Diagnostic::error(
-                format!("duplicate type `{}`", name.resolve(self.interner)),
-                span,
-            ));
+            self.diagnostics.push(
+                Diagnostic::error(
+                    format!("duplicate type `{}`", name.resolve(self.interner)),
+                    span,
+                )
+                .with_kind(DiagnosticKind::DuplicateDefinition),
+            );
         }
 
         // Register constructors for ADTs
@@ -307,13 +317,16 @@ impl ItemTreeCtx<'_> {
                     e.insert((idx, vi));
                 } else {
                     let span = self.node_span(t.syntax());
-                    self.diagnostics.push(Diagnostic::error(
-                        format!(
-                            "duplicate constructor `{}`",
-                            variant.name.resolve(self.interner)
-                        ),
-                        span,
-                    ));
+                    self.diagnostics.push(
+                        Diagnostic::error(
+                            format!(
+                                "duplicate constructor `{}`",
+                                variant.name.resolve(self.interner)
+                            ),
+                            span,
+                        )
+                        .with_kind(DiagnosticKind::DuplicateDefinition),
+                    );
                 }
             }
         }
@@ -334,10 +347,15 @@ impl ItemTreeCtx<'_> {
                 let fn_name_str = fn_name.resolve(self.interner);
                 let cap_name_str = name.resolve(self.interner);
                 let span = self.node_span(c.syntax());
-                self.diagnostics.push(Diagnostic::error(
-                    format!("duplicate function `{fn_name_str}` in capability `{cap_name_str}`"),
-                    span,
-                ));
+                self.diagnostics.push(
+                    Diagnostic::error(
+                        format!(
+                            "duplicate function `{fn_name_str}` in capability `{cap_name_str}`"
+                        ),
+                        span,
+                    )
+                    .with_kind(DiagnosticKind::DuplicateDefinition),
+                );
             }
         }
 
@@ -353,10 +371,13 @@ impl ItemTreeCtx<'_> {
             e.insert(idx);
         } else {
             let span = self.node_span(c.syntax());
-            self.diagnostics.push(Diagnostic::error(
-                format!("duplicate capability `{}`", name.resolve(self.interner)),
-                span,
-            ));
+            self.diagnostics.push(
+                Diagnostic::error(
+                    format!("duplicate capability `{}`", name.resolve(self.interner)),
+                    span,
+                )
+                .with_kind(DiagnosticKind::DuplicateDefinition),
+            );
         }
     }
 
@@ -626,10 +647,13 @@ impl ItemTreeCtx<'_> {
                         let text = tok.text();
                         if !seen.insert(text.to_string()) {
                             let span = self.node_span(tp.syntax());
-                            self.diagnostics.push(Diagnostic::error(
-                                format!("duplicate type parameter `{text}`"),
-                                span,
-                            ));
+                            self.diagnostics.push(
+                                Diagnostic::error(
+                                    format!("duplicate type parameter `{text}`"),
+                                    span,
+                                )
+                                .with_kind(DiagnosticKind::DuplicateDefinition),
+                            );
                         }
                         Some(Name::new(self.interner, text))
                     })
@@ -645,10 +669,13 @@ impl ItemTreeCtx<'_> {
             e.insert(idx);
         } else {
             let span = self.node_span(syntax);
-            self.diagnostics.push(Diagnostic::error(
-                format!("duplicate function `{}`", name.resolve(self.interner)),
-                span,
-            ));
+            self.diagnostics.push(
+                Diagnostic::error(
+                    format!("duplicate function `{}`", name.resolve(self.interner)),
+                    span,
+                )
+                .with_kind(DiagnosticKind::DuplicateDefinition),
+            );
         }
     }
 
@@ -670,10 +697,10 @@ impl ItemTreeCtx<'_> {
                 let name = tok.text();
                 if !seen.insert(name.to_string()) {
                     let span = self.node_span(f.syntax());
-                    self.diagnostics.push(Diagnostic::error(
-                        format!("duplicate field `{name}` in record type"),
-                        span,
-                    ));
+                    self.diagnostics.push(
+                        Diagnostic::error(format!("duplicate field `{name}` in record type"), span)
+                            .with_kind(DiagnosticKind::DuplicateDefinition),
+                    );
                 }
             }
         }

--- a/crates/hir-def/src/module_graph.rs
+++ b/crates/hir-def/src/module_graph.rs
@@ -57,6 +57,7 @@ impl std::fmt::Debug for ModuleInfo {
 #[derive(Debug, Default)]
 pub struct ModuleGraph {
     modules: FxHashMap<ModulePath, ModuleInfo>,
+    modules_by_leaf: FxHashMap<Name, Vec<ModulePath>>,
     /// Which module is the entry point (contains `main`).
     pub entry: Option<ModulePath>,
 }
@@ -67,6 +68,12 @@ impl ModuleGraph {
     }
 
     pub fn insert(&mut self, path: ModulePath, info: ModuleInfo) {
+        if let Some(last) = path.last() {
+            self.modules_by_leaf
+                .entry(last)
+                .or_default()
+                .push(path.clone());
+        }
         self.modules.insert(path, info);
     }
 
@@ -81,13 +88,10 @@ impl ModuleGraph {
     /// Resolve an import from a module. Looks up by the single-segment
     /// import name (e.g., `import math` → look for module path `["math"]`).
     pub fn resolve_import(&self, target: &Name) -> Option<&ModuleInfo> {
-        // Try single-segment module path first.
-        for (mod_path, info) in &self.modules {
-            if mod_path.last() == Some(*target) {
-                return Some(info);
-            }
-        }
-        None
+        self.modules_by_leaf
+            .get(target)
+            .and_then(|paths| paths.first())
+            .and_then(|path| self.modules.get(path))
     }
 
     pub fn iter(&self) -> impl Iterator<Item = (&ModulePath, &ModuleInfo)> {

--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -26,9 +26,12 @@ pub use kyokara_hir_ty::infer::InferenceResult;
 pub use kyokara_hir_ty::ty::{Ty, display_ty, display_ty_with_tree};
 pub use kyokara_hir_ty::{TypeCheckResult, check_module};
 
+use std::collections::HashMap;
+
+use kyokara_diagnostics::{Diagnostic, DiagnosticKind};
 use kyokara_intern::Interner;
 use kyokara_parser::ParseError;
-use kyokara_span::{FileId, FileMap};
+use kyokara_span::{FileId, FileMap, TextRange};
 use kyokara_syntax::SyntaxNode;
 use kyokara_syntax::ast::AstNode;
 use kyokara_syntax::ast::nodes::SourceFile;
@@ -47,14 +50,12 @@ pub struct CheckResult {
 
 /// Map lowering/body-lowering diagnostics to stable public diagnostic codes.
 ///
-/// This is intentionally conservative until lowering diagnostics become
-/// structured enums: duplicate-definition style diagnostics map to `E0102`,
-/// and other lowering diagnostics map to `E0101`.
-pub fn lowering_diagnostic_code(message: &str) -> &'static str {
-    if message.contains("duplicate") {
-        "E0102"
-    } else {
-        "E0101"
+/// Duplicate-definition diagnostics map to `E0102`; unresolved-name and
+/// all other lowering diagnostics map to `E0101`.
+pub fn lowering_diagnostic_code(diag: &Diagnostic) -> &'static str {
+    match diag.kind {
+        DiagnosticKind::DuplicateDefinition => "E0102",
+        DiagnosticKind::UnresolvedName | DiagnosticKind::General => "E0101",
     }
 }
 
@@ -288,9 +289,20 @@ fn resolve_project_imports(
         importing_mod: ModulePath,
         import_path: Path,
         file_id: FileId,
+        import_range: TextRange,
     }
 
     let mut to_resolve: Vec<PendingImport> = Vec::new();
+    let mut single_segment_index: HashMap<Name, Vec<ModulePath>> = HashMap::new();
+
+    for (mod_path, _) in graph.iter() {
+        if let Some(last) = mod_path.last() {
+            single_segment_index
+                .entry(last)
+                .or_default()
+                .push(mod_path.clone());
+        }
+    }
 
     for (mod_path, info) in graph.iter() {
         for imp in &info.item_tree.imports {
@@ -302,6 +314,7 @@ fn resolve_project_imports(
                 importing_mod: mod_path.clone(),
                 import_path: imp.path.clone(),
                 file_id: info.file_id,
+                import_range: imp.source_range.unwrap_or_default(),
             });
         }
     }
@@ -312,6 +325,7 @@ fn resolve_project_imports(
             importing_mod,
             import_path,
             file_id,
+            import_range,
         } = pending;
 
         // Collect pub items from the target module.
@@ -331,16 +345,10 @@ fn resolve_project_imports(
                 }
             } else {
                 let resolve_name = import_path.segments[0];
-                graph
-                    .iter()
-                    .filter_map(|(mod_path, _)| {
-                        if mod_path.last() == Some(resolve_name) {
-                            Some(mod_path.clone())
-                        } else {
-                            None
-                        }
-                    })
-                    .collect()
+                single_segment_index
+                    .get(&resolve_name)
+                    .cloned()
+                    .unwrap_or_default()
             };
 
             if candidates.is_empty() {
@@ -348,7 +356,7 @@ fn resolve_project_imports(
                     format!("unresolved import `{import_name}`"),
                     kyokara_span::Span {
                         file: file_id,
-                        range: kyokara_span::TextRange::default(),
+                        range: import_range,
                     },
                 ));
                 continue;
@@ -357,17 +365,7 @@ fn resolve_project_imports(
             if candidates.len() > 1 {
                 let mut labels: Vec<String> = candidates
                     .iter()
-                    .map(|path| {
-                        if path.0.is_empty() {
-                            "<root>".to_string()
-                        } else {
-                            path.0
-                                .iter()
-                                .map(|seg| seg.resolve(interner).to_owned())
-                                .collect::<Vec<_>>()
-                                .join(".")
-                        }
-                    })
+                    .map(|path| module_path_label(path, interner))
                     .collect();
                 labels.sort();
                 diagnostics.push(kyokara_diagnostics::Diagnostic::error(
@@ -377,7 +375,7 @@ fn resolve_project_imports(
                     ),
                     kyokara_span::Span {
                         file: file_id,
-                        range: kyokara_span::TextRange::default(),
+                        range: import_range,
                     },
                 ));
                 continue;
@@ -406,7 +404,7 @@ fn resolve_project_imports(
                             format!("conflicting import: `{name_str}` is already defined"),
                             kyokara_span::Span {
                                 file: import_file_id,
-                                range: kyokara_span::TextRange::default(),
+                                range: import_range,
                             },
                         ));
                     } else {
@@ -426,7 +424,7 @@ fn resolve_project_imports(
                             format!("conflicting import: `{name_str}` is already defined"),
                             kyokara_span::Span {
                                 file: import_file_id,
-                                range: kyokara_span::TextRange::default(),
+                                range: import_range,
                             },
                         ));
                     } else {
@@ -460,7 +458,7 @@ fn resolve_project_imports(
                             format!("conflicting import: `{name_str}` is already defined"),
                             kyokara_span::Span {
                                 file: import_file_id,
-                                range: kyokara_span::TextRange::default(),
+                                range: import_range,
                             },
                         ));
                     } else {
@@ -478,6 +476,18 @@ enum PubData {
     Fn(FnItem),
     Type(TypeItem),
     Cap(CapItem),
+}
+
+fn module_path_label(path: &ModulePath, interner: &Interner) -> String {
+    if path.0.is_empty() {
+        "<root>".to_string()
+    } else {
+        path.0
+            .iter()
+            .map(|seg| seg.resolve(interner).to_owned())
+            .collect::<Vec<_>>()
+            .join(".")
+    }
 }
 
 /// Collect clones of all pub items from a module's item tree.
@@ -511,15 +521,37 @@ mod tests {
 
     #[test]
     fn lowering_diagnostic_code_maps_duplicate() {
-        assert_eq!(
-            lowering_diagnostic_code("duplicate function `foo`"),
-            "E0102"
+        let diag = kyokara_diagnostics::Diagnostic::error_with_kind(
+            "duplicate function `foo`",
+            kyokara_span::Span {
+                file: FileId(0),
+                range: kyokara_span::TextRange::default(),
+            },
+            DiagnosticKind::DuplicateDefinition,
         );
+        assert_eq!(lowering_diagnostic_code(&diag), "E0102");
     }
 
     #[test]
     fn lowering_diagnostic_code_maps_non_duplicate() {
-        assert_eq!(lowering_diagnostic_code("unresolved name `foo`"), "E0101");
+        let unresolved = kyokara_diagnostics::Diagnostic::error_with_kind(
+            "unresolved name `foo`",
+            kyokara_span::Span {
+                file: FileId(0),
+                range: kyokara_span::TextRange::default(),
+            },
+            DiagnosticKind::UnresolvedName,
+        );
+        assert_eq!(lowering_diagnostic_code(&unresolved), "E0101");
+
+        let fallback = kyokara_diagnostics::Diagnostic::error(
+            "some other lowering diagnostic",
+            kyokara_span::Span {
+                file: FileId(0),
+                range: kyokara_span::TextRange::default(),
+            },
+        );
+        assert_eq!(lowering_diagnostic_code(&fallback), "E0101");
     }
 
     #[test]

--- a/crates/kir/src/validate.rs
+++ b/crates/kir/src/validate.rs
@@ -538,6 +538,7 @@ fn error(message: String) -> Diagnostic {
     Diagnostic {
         message,
         severity: Severity::Error,
+        kind: kyokara_diagnostics::DiagnosticKind::General,
         span: dummy_span(),
         fixes: Vec::new(),
     }

--- a/crates/refactor/src/transaction.rs
+++ b/crates/refactor/src/transaction.rs
@@ -214,7 +214,7 @@ fn collect_single_verification(check: &kyokara_hir::CheckResult) -> Verification
         });
     }
     for d in &check.lowering_diagnostics {
-        let code = kyokara_hir::lowering_diagnostic_code(&d.message);
+        let code = kyokara_hir::lowering_diagnostic_code(d);
         diags.push(VerificationDiagnostic {
             message: d.message.clone(),
             span: Some(d.span),
@@ -222,7 +222,7 @@ fn collect_single_verification(check: &kyokara_hir::CheckResult) -> Verification
         });
     }
     for d in &check.type_check.body_lowering_diagnostics {
-        let code = kyokara_hir::lowering_diagnostic_code(&d.message);
+        let code = kyokara_hir::lowering_diagnostic_code(d);
         diags.push(VerificationDiagnostic {
             message: d.message.clone(),
             span: Some(d.span),
@@ -261,7 +261,7 @@ fn collect_project_verification(check: &kyokara_hir::ProjectCheckResult) -> Veri
         }
     }
     for d in &check.lowering_diagnostics {
-        let code = kyokara_hir::lowering_diagnostic_code(&d.message);
+        let code = kyokara_hir::lowering_diagnostic_code(d);
         diags.push(VerificationDiagnostic {
             message: d.message.clone(),
             span: Some(d.span),
@@ -270,7 +270,7 @@ fn collect_project_verification(check: &kyokara_hir::ProjectCheckResult) -> Veri
     }
     for (mod_path, tc) in &check.type_checks {
         for d in &tc.body_lowering_diagnostics {
-            let code = kyokara_hir::lowering_diagnostic_code(&d.message);
+            let code = kyokara_hir::lowering_diagnostic_code(d);
             diags.push(VerificationDiagnostic {
                 message: d.message.clone(),
                 span: Some(d.span),


### PR DESCRIPTION
## Summary
- harden evaluator call paths for freeze-critical safety and correctness
- remove `unsafe` raw-pointer aliasing from interpreter call dispatch
- enforce runtime arity checks for user functions, lambdas, and constructors
- make contract call cleanup error-safe across requires/body/invariant/ensures failure paths
- replace string-based lowering code mapping with structured diagnostic kinds
- improve project import resolution with indexed lookup and precise import source spans
- align WASM Int boundary behavior with interpreter failure semantics (overflow and shift bounds)

## Issue Coverage
- #187
- #212
- #213
- #214
- #215
- #216

## Tests Added/Updated
- evaluator regression tests for arity mismatch and cleanup state leaks
- API regression assertions for unresolved/ambiguous/conflicting import spans
- codegen regression tests for int boundary traps (`+`, `-`, `*`, `%`, unary `-`, shift range)

## Validation
- `cargo fmt --all`
- `cargo test -q`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
