### PR TITLE
fix(pbt): gate test command on compile diagnostics

### DIFF
--- a/crates/pbt/src/runner.rs
+++ b/crates/pbt/src/runner.rs
@@ -3,6 +3,7 @@
 use kyokara_eval::error::RuntimeError;
 use kyokara_eval::interpreter::Interpreter;
 use kyokara_eval::intrinsics::Args;
+use kyokara_hir::ModulePath;
 use kyokara_hir::{
     check_module, check_project, collect_item_tree, register_builtin_intrinsics,
     register_builtin_methods, register_builtin_types,
@@ -109,17 +110,13 @@ pub fn run_tests(source: &str, config: &TestConfig) -> Result<TestReport, String
         &mut interner,
     );
 
-    // Reject files with compile errors.
-    if !parse.errors.is_empty() {
-        return Err(format!(
-            "parse errors: {}",
-            parse
-                .errors
-                .iter()
-                .map(|e| format!("{e:?}"))
-                .collect::<Vec<_>>()
-                .join("; ")
-        ));
+    if let Some(err) = collect_compile_errors_single(
+        &parse.errors,
+        &item_result.diagnostics,
+        &type_check.diagnostics,
+        &type_check.body_lowering_diagnostics,
+    ) {
+        return Err(err);
     }
 
     // 7. Discover testable functions and properties.
@@ -145,9 +142,10 @@ pub fn run_project_tests(
     entry_file: &std::path::Path,
     config: &TestConfig,
 ) -> Result<TestReport, String> {
-    use kyokara_hir::ModulePath;
-
     let mut project = check_project(entry_file);
+    if let Some(err) = collect_compile_errors_project(&project.parse_errors, &project) {
+        return Err(err);
+    }
 
     // Find entry module.
     let entry_path = ModulePath::root();
@@ -193,6 +191,100 @@ pub fn run_project_tests(
     );
 
     run_test_loop(&mut interp, &testable, &properties, config)
+}
+
+fn collect_compile_errors_single<T: std::fmt::Debug>(
+    parse_errors: &[T],
+    lowering_diagnostics: &[kyokara_diagnostics::Diagnostic],
+    type_diagnostics: &[kyokara_diagnostics::Diagnostic],
+    body_lowering_diagnostics: &[kyokara_diagnostics::Diagnostic],
+) -> Option<String> {
+    let mut lines = Vec::new();
+
+    if !parse_errors.is_empty() {
+        lines.push(format!(
+            "parse errors: {}",
+            parse_errors
+                .iter()
+                .map(|e| format!("{e:?}"))
+                .collect::<Vec<_>>()
+                .join("; ")
+        ));
+    }
+
+    for d in lowering_diagnostics.iter().filter(is_error) {
+        lines.push(format!("compile error: {}", d.message));
+    }
+    for d in type_diagnostics.iter().filter(is_error) {
+        lines.push(format!("compile error: {}", d.message));
+    }
+    for d in body_lowering_diagnostics.iter().filter(is_error) {
+        lines.push(format!("compile error: {}", d.message));
+    }
+
+    if lines.is_empty() {
+        None
+    } else {
+        Some(lines.join("; "))
+    }
+}
+
+fn collect_compile_errors_project<T: std::fmt::Debug>(
+    parse_errors_by_module: &[(ModulePath, Vec<T>)],
+    project: &kyokara_hir::ProjectCheckResult,
+) -> Option<String> {
+    let mut lines = Vec::new();
+
+    for (module_path, parse_errors) in parse_errors_by_module {
+        if parse_errors.is_empty() {
+            continue;
+        }
+        let module = format_module_path(module_path, &project.interner);
+        lines.push(format!(
+            "module {module}: parse errors: {}",
+            parse_errors
+                .iter()
+                .map(|e| format!("{e:?}"))
+                .collect::<Vec<_>>()
+                .join("; ")
+        ));
+    }
+
+    for d in project.lowering_diagnostics.iter().filter(is_error) {
+        lines.push(format!("compile error: {}", d.message));
+    }
+
+    for (module_path, tc) in &project.type_checks {
+        let module = format_module_path(module_path, &project.interner);
+        for d in tc.diagnostics.iter().filter(is_error) {
+            lines.push(format!("module {module}: compile error: {}", d.message));
+        }
+        for d in tc.body_lowering_diagnostics.iter().filter(is_error) {
+            lines.push(format!("module {module}: compile error: {}", d.message));
+        }
+    }
+
+    if lines.is_empty() {
+        None
+    } else {
+        Some(lines.join("; "))
+    }
+}
+
+fn is_error(d: &&kyokara_diagnostics::Diagnostic) -> bool {
+    d.severity == kyokara_diagnostics::Severity::Error
+}
+
+fn format_module_path(path: &ModulePath, interner: &Interner) -> String {
+    if path.0.is_empty() {
+        "<root>".to_string()
+    } else {
+        path.0
+            .iter()
+            .map(|seg| seg.resolve(interner).to_string())
+            .collect::<Vec<_>>()
+            .join(".")
+    }
 }
 
 /// Discover functions with contracts that have generatable parameter types.

--- a/crates/pbt/tests/integration.rs
+++ b/crates/pbt/tests/integration.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::unwrap_used)]
 
-use kyokara_pbt::{TestConfig, TestableKind, run_tests};
+use kyokara_pbt::{TestConfig, TestableKind, run_project_tests, run_tests};
 use std::path::PathBuf;
 
 fn fixture(name: &str) -> String {
@@ -19,6 +19,19 @@ fn test_config() -> TestConfig {
         format: "human".to_string(),
         corpus_base: tempfile::tempdir().unwrap().keep(),
     }
+}
+
+fn write_project(files: &[(&str, &str)]) -> (tempfile::TempDir, PathBuf) {
+    let dir = tempfile::tempdir().unwrap();
+    for (rel, src) in files {
+        let path = dir.path().join(rel);
+        if let Some(parent) = path.parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+        std::fs::write(&path, src).unwrap();
+    }
+    let main_path = dir.path().join("main.ky");
+    (dir, main_path)
 }
 
 #[test]
@@ -552,6 +565,49 @@ fn property_invalid_gen_method_check() {
         "Gen.unknown() should produce 'invalid generator expression' diagnostic: {:?}",
         result.lowering_diagnostics
     );
+}
+
+#[test]
+fn run_tests_rejects_compile_invalid_property_before_execution() {
+    let config = test_config();
+    let source = "property p(x: Int <- Gen.unknown()) { x > 0 }";
+    let err = run_tests(source, &config).expect_err("compile-invalid source must be rejected");
+    assert!(
+        err.contains("invalid generator expression"),
+        "error should include compile diagnostic, got: {err}"
+    );
+}
+
+#[test]
+fn run_tests_still_executes_compile_valid_property() {
+    let config = test_config();
+    let source = "property p(b: Bool <- Gen.bool()) { b == b }";
+    let report = run_tests(source, &config).expect("compile-valid source should run");
+    assert!(report.all_passed(), "expected passing report");
+    assert_eq!(report.failure_count(), 0);
+}
+
+#[test]
+fn run_project_tests_rejects_compile_invalid_property_before_execution() {
+    let config = test_config();
+    let (_dir, main_path) =
+        write_project(&[("main.ky", "property p(x: Int <- Gen.unknown()) { x > 0 }\n")]);
+    let err = run_project_tests(&main_path, &config)
+        .expect_err("compile-invalid project must be rejected");
+    assert!(
+        err.contains("invalid generator expression"),
+        "error should include compile diagnostic, got: {err}"
+    );
+}
+
+#[test]
+fn run_project_tests_still_executes_compile_valid_property() {
+    let config = test_config();
+    let (_dir, main_path) =
+        write_project(&[("main.ky", "property p(b: Bool <- Gen.bool()) { b == b }\n")]);
+    let report = run_project_tests(&main_path, &config).expect("compile-valid project should run");
+    assert!(report.all_passed(), "expected passing report");
+    assert_eq!(report.failure_count(), 0);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add compile-diagnostic gating to `kyokara_pbt::run_tests`
- add compile-diagnostic gating to `kyokara_pbt::run_project_tests`
- prevent PBT execution when parse/lowering/type errors exist

## Why
Issue #229 reports that `kyokara test` still executes compile-invalid properties (e.g. `Gen.unknown()`) and reports runtime/property failures instead of compile failures.

## Changes
- `crates/pbt/src/runner.rs`
  - added compile error aggregation for single-file runs:
    - parse errors
    - lowering diagnostics (`collect_item_tree`)
    - type diagnostics
    - body-lowering diagnostics
  - added compile error aggregation for project runs:
    - per-module parse errors
    - project lowering diagnostics
    - per-module type + body-lowering diagnostics
  - both paths now return `Err(...)` before interpreter/test loop when compile errors exist
- `crates/pbt/tests/integration.rs`
  - added bug tests:
    - `run_tests_rejects_compile_invalid_property_before_execution`
    - `run_project_tests_rejects_compile_invalid_property_before_execution`
  - added guard tests:
    - `run_tests_still_executes_compile_valid_property`
    - `run_project_tests_still_executes_compile_valid_property`

## Verification
- new bug tests fail before fix and pass after fix
- `cargo test -p kyokara-pbt`
- `cargo clippy -p kyokara-pbt --tests -- -D warnings`
- `cargo test -p kyokara-cli --test parity_fixtures`
- manual CLI repro now returns compile error for both single and `--project`

Closes #229
