### PR TITLE
fix(pbt): reject incompatible property generator specs

### DIFF
--- a/crates/hir-def/src/item_tree/lower.rs
+++ b/crates/hir-def/src/item_tree/lower.rs
@@ -427,6 +427,17 @@ impl ItemTreeCtx<'_> {
                         GenSpec::Auto
                     });
 
+                if !self.is_gen_spec_compatible_with_type(&gen_spec, &ty) {
+                    let span = self.node_span(param.syntax());
+                    self.diagnostics.push(Diagnostic::error(
+                        format!(
+                            "generator spec is incompatible with declared property parameter type: \
+                             generator={gen_spec:?}, type={ty:?}"
+                        ),
+                        span,
+                    ));
+                }
+
                 params.push(PropertyParamSpec {
                     param: FnParam { name: pname, ty },
                     gen_spec,
@@ -550,6 +561,105 @@ impl ItemTreeCtx<'_> {
             }
             _ => None,
         }
+    }
+
+    /// Return true when a generator spec is compatible with the declared type.
+    ///
+    /// This check is conservative for unknown path names (which may be aliases):
+    /// we only report incompatibility when it is definite.
+    fn is_gen_spec_compatible_with_type(&self, spec: &GenSpec, ty: &TypeRef) -> bool {
+        use crate::item_tree::GenSpec;
+
+        match spec {
+            GenSpec::Auto => true,
+            GenSpec::Int | GenSpec::IntRange { .. } => self.primitive_spec_compatible("Int", ty),
+            GenSpec::Float | GenSpec::FloatRange { .. } => {
+                self.primitive_spec_compatible("Float", ty)
+            }
+            GenSpec::Bool => self.primitive_spec_compatible("Bool", ty),
+            GenSpec::String => self.primitive_spec_compatible("String", ty),
+            GenSpec::Char => self.primitive_spec_compatible("Char", ty),
+            GenSpec::List(inner) => match ty {
+                TypeRef::Error => true,
+                TypeRef::Path { path, args } => match self.path_leaf_name(path) {
+                    Some("List") => {
+                        args.len() == 1 && self.is_gen_spec_compatible_with_type(inner, &args[0])
+                    }
+                    Some(name) if Self::is_known_builtin_name(name) => false,
+                    _ => true,
+                },
+                _ => false,
+            },
+            GenSpec::Map(key, val) => match ty {
+                TypeRef::Error => true,
+                TypeRef::Path { path, args } => match self.path_leaf_name(path) {
+                    Some("Map") => {
+                        args.len() == 2
+                            && self.is_gen_spec_compatible_with_type(key, &args[0])
+                            && self.is_gen_spec_compatible_with_type(val, &args[1])
+                    }
+                    Some(name) if Self::is_known_builtin_name(name) => false,
+                    _ => true,
+                },
+                _ => false,
+            },
+            GenSpec::OptionOf(inner) => match ty {
+                TypeRef::Error => true,
+                TypeRef::Path { path, args } => match self.path_leaf_name(path) {
+                    Some("Option") => {
+                        args.len() == 1 && self.is_gen_spec_compatible_with_type(inner, &args[0])
+                    }
+                    Some(name) if Self::is_known_builtin_name(name) => false,
+                    _ => true,
+                },
+                _ => false,
+            },
+            GenSpec::ResultOf(ok, err) => match ty {
+                TypeRef::Error => true,
+                TypeRef::Path { path, args } => match self.path_leaf_name(path) {
+                    Some("Result") => {
+                        args.len() == 2
+                            && self.is_gen_spec_compatible_with_type(ok, &args[0])
+                            && self.is_gen_spec_compatible_with_type(err, &args[1])
+                    }
+                    Some(name) if Self::is_known_builtin_name(name) => false,
+                    _ => true,
+                },
+                _ => false,
+            },
+        }
+    }
+
+    fn primitive_spec_compatible(&self, expected: &str, ty: &TypeRef) -> bool {
+        match ty {
+            TypeRef::Error => true,
+            TypeRef::Path { path, .. } => match self.path_leaf_name(path) {
+                Some(name) if name == expected => true,
+                Some(name) if Self::is_known_builtin_name(name) => false,
+                _ => true,
+            },
+            _ => false,
+        }
+    }
+
+    fn path_leaf_name<'a>(&'a self, path: &'a Path) -> Option<&'a str> {
+        path.last().map(|name| name.resolve(self.interner))
+    }
+
+    fn is_known_builtin_name(name: &str) -> bool {
+        matches!(
+            name,
+            "Int"
+                | "Float"
+                | "Bool"
+                | "String"
+                | "Char"
+                | "Unit"
+                | "List"
+                | "Map"
+                | "Option"
+                | "Result"
+        )
     }
 
     fn extract_int_literal(&self, expr: &kyokara_syntax::ast::nodes::Expr) -> Option<i64> {

--- a/crates/pbt/tests/integration.rs
+++ b/crates/pbt/tests/integration.rs
@@ -497,6 +497,58 @@ fn property_type_check_gen_bool() {
 }
 
 #[test]
+fn property_gen_type_match_has_no_mismatch_diagnostic() {
+    let result = kyokara_hir::check_file("property p(x: Int <- Gen.int()) { x > 0 }");
+    let has_mismatch = result
+        .lowering_diagnostics
+        .iter()
+        .any(|d| d.message.contains("generator") && d.message.contains("incompatible"));
+    assert!(
+        !has_mismatch,
+        "matching Gen.int() with Int should not produce mismatch diagnostic: {:?}",
+        result.lowering_diagnostics
+    );
+}
+
+#[test]
+fn property_gen_type_mismatch_produces_diagnostic() {
+    let result = kyokara_hir::check_file("property p(x: Int <- Gen.bool()) { x > 0 }");
+    let has_mismatch = result
+        .lowering_diagnostics
+        .iter()
+        .any(|d| d.message.contains("generator") && d.message.contains("incompatible"));
+    assert!(
+        has_mismatch,
+        "Gen.bool() for Int parameter should produce mismatch diagnostic: {:?}",
+        result.lowering_diagnostics
+    );
+}
+
+#[test]
+fn run_tests_rejects_gen_spec_type_mismatch_before_execution() {
+    let config = test_config();
+    let source = "property p(x: Int <- Gen.bool()) { x > 0 }";
+    let err = run_tests(source, &config).expect_err("gen/type mismatch must be rejected");
+    assert!(
+        err.contains("generator") && err.contains("incompatible"),
+        "error should include generator/type mismatch, got: {err}"
+    );
+}
+
+#[test]
+fn run_project_tests_rejects_gen_spec_type_mismatch_before_execution() {
+    let config = test_config();
+    let (_dir, main_path) =
+        write_project(&[("main.ky", "property p(x: Int <- Gen.bool()) { x > 0 }\n")]);
+    let err =
+        run_project_tests(&main_path, &config).expect_err("project mismatch must be rejected");
+    assert!(
+        err.contains("generator") && err.contains("incompatible"),
+        "error should include generator/type mismatch, got: {err}"
+    );
+}
+
+#[test]
 fn property_type_check_gen_string() {
     let result =
         kyokara_hir::check_file("property p(s: String <- Gen.string()) { string_len(s) >= 0 }");


### PR DESCRIPTION
## Summary
- add compile-time compatibility checks between property `Gen.*` specs and declared parameter types
- surface a lowering diagnostic when generator/type pairs are definitely incompatible
- prevent `kyokara test` from executing mismatch programs by feeding this diagnostic into the existing compile gate

## TDD
### Bug tests (added first, failed pre-fix)
- `property_gen_type_mismatch_produces_diagnostic`
- `run_tests_rejects_gen_spec_type_mismatch_before_execution`
- `run_project_tests_rejects_gen_spec_type_mismatch_before_execution`

### Guard tests
- `property_gen_type_match_has_no_mismatch_diagnostic`
- existing compile-valid run tests remain green:
  - `run_tests_still_executes_compile_valid_property`
  - `run_project_tests_still_executes_compile_valid_property`

## Implementation
### `crates/hir-def/src/item_tree/lower.rs`
- in `lower_property_def`, after parsing `gen_spec`, validate compatibility against declared `TypeRef`
- emit diagnostic:
  - `generator spec is incompatible with declared property parameter type: ...`
- added helper logic:
  - recursive compatibility checks for `List/Map/Option/Result`
  - primitive checks for `Int/Float/Bool/String/Char`
  - conservative treatment for unknown path names (possible aliases): only report when incompatibility is definite

### `crates/pbt/tests/integration.rs`
- added mismatch bug+guard tests listed above

## Verification
- `cargo test -p kyokara-hir-def --test lower_tests`
- `cargo test -p kyokara-pbt`
- `cargo test -p kyokara-cli --test parity_fixtures`
- `cargo clippy -p kyokara-hir-def -p kyokara-pbt --tests -- -D warnings`
- `cargo fmt --all --check`

Closes #230
