### PR TITLE
fix(pbt): distinguish generator failures from where-unsat

### DIFF
--- a/crates/pbt/src/runner.rs
+++ b/crates/pbt/src/runner.rs
@@ -604,11 +604,26 @@ fn test_single_property(
             let mut recorder = ChoiceRecorder::new(seed);
 
             let args = match generate_property_args(prop, &mut recorder, interp) {
-                Some(a) => a,
-                None => {
+                PropertyArgsResult::Ready(args) => args,
+                PropertyArgsResult::Exhausted => {
                     discarded += 1;
                     total += 1;
                     continue;
+                }
+                PropertyArgsResult::Unsupported => {
+                    total += 1;
+                    return FnTestResult {
+                        name: prop.name.clone(),
+                        kind: TestableKind::Property,
+                        passed,
+                        discarded,
+                        total,
+                        failure: Some(FailureInfo {
+                            error: "invalid or unsupported generator configuration".to_string(),
+                            args_display: vec![],
+                            choices: ChoiceSequence::new(vec![], vec![]),
+                        }),
+                    };
                 }
             };
 
@@ -782,12 +797,18 @@ fn replay_for_display(
 
 // ── Property-specific helpers ──────────────────────────────────────
 
+enum PropertyArgsResult {
+    Ready(Args),
+    Exhausted,
+    Unsupported,
+}
+
 /// Generate arguments for a property using its generator specs.
 fn generate_property_args(
     prop: &TestableProperty,
     source: &mut dyn crate::choice::ChoiceSource,
     interp: &Interpreter,
-) -> Option<Args> {
+) -> PropertyArgsResult {
     let item_tree = interp.item_tree();
     let module_scope = interp.module_scope();
     let interner = interp.interner();
@@ -796,10 +817,11 @@ fn generate_property_args(
     for (ty, spec) in prop.param_types.iter().zip(prop.gen_specs.iter()) {
         match generate::generate_from_spec(spec, ty, source, item_tree, module_scope, interner) {
             GenResult::Ok(val) => args.push(val),
-            GenResult::Unsupported | GenResult::Exhausted => return None,
+            GenResult::Unsupported => return PropertyArgsResult::Unsupported,
+            GenResult::Exhausted => return PropertyArgsResult::Exhausted,
         }
     }
-    Some(args)
+    PropertyArgsResult::Ready(args)
 }
 
 /// Call a property and classify the result.
@@ -833,11 +855,14 @@ fn run_single_property_test(
     seq: &ChoiceSequence,
 ) -> TestOutcome {
     let mut replayer = ChoiceReplayer::new(seq.clone());
-    let args = match generate_property_args(prop, &mut replayer, interp) {
-        Some(a) => a,
-        None => return TestOutcome::Discard,
-    };
-    call_and_classify_property(interp, prop.fn_idx, args)
+    match generate_property_args(prop, &mut replayer, interp) {
+        PropertyArgsResult::Ready(args) => call_and_classify_property(interp, prop.fn_idx, args),
+        PropertyArgsResult::Exhausted => TestOutcome::Discard,
+        PropertyArgsResult::Unsupported => TestOutcome::Fail(
+            "invalid or unsupported generator configuration".to_string(),
+            vec![],
+        ),
+    }
 }
 
 /// Shrink a failing property choice sequence.
@@ -869,7 +894,16 @@ fn replay_property_for_display(
     use kyokara_eval::value::Value;
 
     let mut replayer = ChoiceReplayer::new(seq.clone());
-    let args = generate_property_args(prop, &mut replayer, interp)?;
+    let args = match generate_property_args(prop, &mut replayer, interp) {
+        PropertyArgsResult::Ready(args) => args,
+        PropertyArgsResult::Exhausted => return None,
+        PropertyArgsResult::Unsupported => {
+            return Some((
+                "invalid or unsupported generator configuration".to_string(),
+                vec![],
+            ));
+        }
+    };
 
     let args_display: Vec<String> = args.iter().map(|v| v.display(interp.interner())).collect();
 

--- a/crates/pbt/tests/integration.rs
+++ b/crates/pbt/tests/integration.rs
@@ -820,3 +820,82 @@ where
     assert!(result.passed > 0, "should have passing tests");
     assert!(result.discarded > 0, "should have some discards");
 }
+
+#[test]
+fn property_invalid_range_reports_generator_error_not_where_unsat() {
+    let source = "property p(x: Int <- Gen.int_range(10, 1)) { x > 0 }";
+    let config = test_config();
+    let report = run_tests(source, &config).unwrap();
+    assert!(!report.all_passed(), "invalid range should fail");
+
+    let failure = report.results[0]
+        .failure
+        .as_ref()
+        .expect("must have failure");
+    assert!(
+        failure
+            .error
+            .contains("invalid or unsupported generator configuration"),
+        "expected generator-specific failure, got: {}",
+        failure.error
+    );
+    assert!(
+        !failure.error.contains("where"),
+        "invalid generator should not be reported as where-unsat: {}",
+        failure.error
+    );
+}
+
+#[test]
+fn project_invalid_range_reports_generator_error_not_where_unsat() {
+    let config = test_config();
+    let (_dir, main_path) = write_project(&[(
+        "main.ky",
+        "property p(x: Int <- Gen.int_range(10, 1)) { x > 0 }\n",
+    )]);
+    let report = run_project_tests(&main_path, &config).unwrap();
+    assert!(
+        !report.all_passed(),
+        "invalid range should fail in project mode"
+    );
+
+    let failure = report.results[0]
+        .failure
+        .as_ref()
+        .expect("must have failure");
+    assert!(
+        failure
+            .error
+            .contains("invalid or unsupported generator configuration"),
+        "expected generator-specific failure, got: {}",
+        failure.error
+    );
+    assert!(
+        !failure.error.contains("where"),
+        "invalid generator should not be reported as where-unsat: {}",
+        failure.error
+    );
+}
+
+#[test]
+fn where_unsat_still_reports_where_unsatisfiable() {
+    let source = "property impossible(x: Int <- Gen.int()) where x > 0 && x < 0 { true }";
+    let config = test_config();
+    let report = run_tests(source, &config).unwrap();
+    assert!(!report.all_passed(), "unsatisfiable where should fail");
+
+    let failure = report.results[0]
+        .failure
+        .as_ref()
+        .expect("must have failure");
+    assert!(
+        failure.error.contains("unsatisfiable"),
+        "expected unsatisfiable failure, got: {}",
+        failure.error
+    );
+    assert!(
+        failure.error.contains("where"),
+        "expected where-unsat message, got: {}",
+        failure.error
+    );
+}


### PR DESCRIPTION
## Summary
- fix property runner classification so generator failures are not reported as `where` unsatisfiable
- keep true `where` unsatisfiable reporting unchanged
- add explicit bug + guard tests for single-file and project mode

## TDD
### Bug tests (added first, failed pre-fix)
- `property_invalid_range_reports_generator_error_not_where_unsat`
- `project_invalid_range_reports_generator_error_not_where_unsat`

### Guard test
- `where_unsat_still_reports_where_unsatisfiable`

Pre-fix failures showed invalid range (`Gen.int_range(10, 1)`) was incorrectly surfaced as:
`unsatisfiable or overly restrictive \`where\` constraint ...`

## Implementation
### `crates/pbt/src/runner.rs`
- introduced `PropertyArgsResult` with explicit outcomes:
  - `Ready(Args)`
  - `Exhausted`
  - `Unsupported`
- `generate_property_args` now distinguishes `Unsupported` from `Exhausted`
- property execution paths now treat `Unsupported` as an immediate test failure with clear message:
  - `invalid or unsupported generator configuration`
- `where` unsatisfiable check remains tied to actual discard path, preserving semantics for precondition/where filtering

### `crates/pbt/tests/integration.rs`
- added 3 tests listed above

## Verification
- `cargo test -p kyokara-pbt`
- `cargo clippy -p kyokara-pbt --tests -- -D warnings`
- `cargo test -p kyokara-cli --test parity_fixtures`
- `cargo fmt --all --check`

Closes #231
