### PR TITLE
feat: legacy intrinsic hints + canonical API examples

### DIFF
--- a/crates/hir-def/src/body/lower.rs
+++ b/crates/hir-def/src/body/lower.rs
@@ -486,13 +486,14 @@ impl BodyLowerCtx<'_> {
             && self.resolve_name(name).is_none()
         {
             let span = self.node_span(pe.syntax());
-            self.diagnostics.push(
-                Diagnostic::error(
-                    format!("unresolved name `{}`", name.resolve(self.interner)),
-                    span,
-                )
-                .with_kind(DiagnosticKind::UnresolvedName),
-            );
+            let name_str = name.resolve(self.interner);
+            let msg = if let Some(hint) = legacy_intrinsic_hint(name_str) {
+                format!("unresolved name `{name_str}`; {hint}")
+            } else {
+                format!("unresolved name `{name_str}`")
+            };
+            self.diagnostics
+                .push(Diagnostic::error(msg, span).with_kind(DiagnosticKind::UnresolvedName));
         }
 
         self.alloc_expr(Expr::Path(path))
@@ -1211,3 +1212,65 @@ impl BodyLowerCtx<'_> {
 // Type aliases for CST types to avoid confusion with HIR types.
 type ExprCst = nodes::Expr;
 type PatCst = nodes::Pat;
+
+/// Return a hint for removed free-function intrinsic names, pointing to the
+/// canonical replacement. Returns `None` if the name is not a known legacy
+/// intrinsic.
+fn legacy_intrinsic_hint(name: &str) -> Option<&'static str> {
+    match name {
+        // io module
+        "print" => Some("use `io.print()` (requires `import io`)"),
+        "println" => Some("use `io.println()` (requires `import io`)"),
+        "read_line" => Some("use `io.read_line()` (requires `import io`)"),
+        "read_stdin" => Some("use `io.read_stdin()` (requires `import io`)"),
+        // fs module
+        "read_file" => Some("use `fs.read_file()` (requires `import fs`)"),
+        // math module
+        "min" => Some("use `math.min()` (requires `import math`)"),
+        "max" => Some("use `math.max()` (requires `import math`)"),
+        "float_min" | "fmin" => Some("use `math.fmin()` (requires `import math`)"),
+        "float_max" | "fmax" => Some("use `math.fmax()` (requires `import math`)"),
+        // constructors
+        "list_new" => Some("use `List.new()`"),
+        "map_new" => Some("use `Map.new()`"),
+        // methods on values
+        "abs" | "float_abs" => Some("use `n.abs()` (method on Int or Float)"),
+        "list_len" => Some("use `xs.len()` (method on List)"),
+        "list_push" => Some("use `xs.push(val)` (method on List)"),
+        "list_pop" => Some("use `xs.pop()` (method on List)"),
+        "list_get" => Some("use `xs.get(i)` (method on List)"),
+        "list_set" => Some("use `xs.set(i, val)` (method on List)"),
+        "list_map" => Some("use `xs.map(f)` (method on List)"),
+        "list_filter" => Some("use `xs.filter(f)` (method on List)"),
+        "list_fold" => Some("use `xs.fold(init, f)` (method on List)"),
+        "list_contains" => Some("use `xs.contains(val)` (method on List)"),
+        "list_reverse" => Some("use `xs.reverse()` (method on List)"),
+        "list_sort" => Some("use `xs.sort()` (method on List)"),
+        "map_insert" => Some("use `m.insert(k, v)` (method on Map)"),
+        "map_get" => Some("use `m.get(k)` (method on Map)"),
+        "map_remove" => Some("use `m.remove(k)` (method on Map)"),
+        "map_contains_key" => Some("use `m.contains_key(k)` (method on Map)"),
+        "map_keys" => Some("use `m.keys()` (method on Map)"),
+        "map_values" => Some("use `m.values()` (method on Map)"),
+        "map_len" => Some("use `m.len()` (method on Map)"),
+        "string_len" => Some("use `s.len()` (method on String)"),
+        "string_concat" => Some("use `s.concat(t)` (method on String)"),
+        "string_slice" => Some("use `s.slice(start, end)` (method on String)"),
+        "string_contains" => Some("use `s.contains(sub)` (method on String)"),
+        "string_starts_with" => Some("use `s.starts_with(prefix)` (method on String)"),
+        "string_ends_with" => Some("use `s.ends_with(suffix)` (method on String)"),
+        "string_to_upper" => Some("use `s.to_upper()` (method on String)"),
+        "string_to_lower" => Some("use `s.to_lower()` (method on String)"),
+        "string_trim" => Some("use `s.trim()` (method on String)"),
+        "string_split" => Some("use `s.split(sep)` (method on String)"),
+        "string_replace" => Some("use `s.replace(from, to)` (method on String)"),
+        "string_chars" => Some("use `s.chars()` (method on String)"),
+        "int_to_string" => Some("use `n.to_string()` (method on Int)"),
+        "char_to_string" => Some("use `c.to_string()` (method on Char)"),
+        "int_to_float" => Some("use `n.to_float()` (method on Int)"),
+        "float_to_int" => Some("use `f.to_int()` (method on Float)"),
+        "parse_int" => Some("use `s.parse_int()` (method on String)"),
+        "parse_float" => Some("use `s.parse_float()` (method on String)"),
+        _ => None,
+    }
+}

--- a/crates/hir-ty/tests/infer_tests.rs
+++ b/crates/hir-ty/tests/infer_tests.rs
@@ -613,6 +613,54 @@ fn err_unresolved_name_in_expr() {
     check_err("fn main() -> Int { foo + 1 }", "unresolved name");
 }
 
+// ── Legacy intrinsic name hints ─────────────────────────────────────
+
+#[test]
+fn err_legacy_println_hints_io_module() {
+    check_err("fn main() -> Unit { println(\"hi\") }", "io.println()");
+}
+
+#[test]
+fn err_legacy_list_len_hints_method() {
+    check_err("fn main() -> Int { list_len(xs) }", "xs.len()");
+}
+
+#[test]
+fn err_legacy_abs_hints_method() {
+    check_err("fn main() -> Int { abs(-5) }", "n.abs()");
+}
+
+#[test]
+fn err_legacy_list_new_hints_static() {
+    check_err("fn main() -> Int { list_new() }", "List.new()");
+}
+
+#[test]
+fn err_legacy_min_hints_math_module() {
+    check_err("fn main() -> Int { min(1, 2) }", "math.min()");
+}
+
+#[test]
+fn err_legacy_parse_int_hints_method() {
+    check_err("fn main() -> Int { parse_int(\"42\") }", "s.parse_int()");
+}
+
+#[test]
+fn err_unknown_name_no_hint() {
+    // Non-legacy names should NOT get a hint.
+    let (result, _) = check("fn main() -> Int { totally_unknown() }");
+    let diag = result
+        .diagnostics
+        .iter()
+        .find(|d| d.message.contains("unresolved name"))
+        .expect("expected unresolved name diagnostic");
+    assert!(
+        !diag.message.contains(';'),
+        "non-legacy name should not have a hint: {:?}",
+        diag.message
+    );
+}
+
 // ── Scope resolution tests ──────────────────────────────────────────
 
 #[test]

--- a/examples/adt_matching.ky
+++ b/examples/adt_matching.ky
@@ -1,3 +1,5 @@
+import io
+
 type Color = | Red | Green | Blue
 
 fn color_name(c: Color) -> String {
@@ -20,7 +22,7 @@ fn area(s: Shape) -> Int {
 }
 
 fn main() -> Unit {
-  println(color_name(Green))
-  println(string_concat("circle area: ", int_to_string(area(Circle(5)))))
-  println(string_concat("rect area: ", int_to_string(area(Rect(4, 6)))))
+  io.println(color_name(Green))
+  io.println("circle area: ".concat(area(Circle(5)).to_string()))
+  io.println("rect area: ".concat(area(Rect(4, 6)).to_string()))
 }

--- a/examples/arithmetic.ky
+++ b/examples/arithmetic.ky
@@ -1,3 +1,5 @@
+import io
+
 fn add(x: Int, y: Int) -> Int { x + y }
 
 fn mul(x: Int, y: Int) -> Int { x * y }
@@ -9,8 +11,8 @@ fn precedence() -> Int {
 fn negate(x: Int) -> Int { -x }
 
 fn main() -> Unit {
-  println(int_to_string(add(10, 20)))
-  println(int_to_string(mul(6, 7)))
-  println(int_to_string(precedence()))
-  println(int_to_string(negate(42)))
+  io.println(add(10, 20).to_string())
+  io.println(mul(6, 7).to_string())
+  io.println(precedence().to_string())
+  io.println(negate(42).to_string())
 }

--- a/examples/booleans.ky
+++ b/examples/booleans.ky
@@ -1,3 +1,5 @@
+import io
+
 fn is_even(n: Int) -> Bool {
   n == 0
 }
@@ -15,9 +17,9 @@ fn show_bool(b: Bool) -> String {
 }
 
 fn main() -> Unit {
-  println(string_concat("is_even(0) = ", show_bool(is_even(0))))
-  println(string_concat("is_even(3) = ", show_bool(is_even(3))))
-  println(string_concat("both(true, false) = ", show_bool(both(true, false))))
-  println(string_concat("either(false, true) = ", show_bool(either(false, true))))
-  println(string_concat("!true = ", show_bool(!true)))
+  io.println("is_even(0) = ".concat(show_bool(is_even(0))))
+  io.println("is_even(3) = ".concat(show_bool(is_even(3))))
+  io.println("both(true, false) = ".concat(show_bool(both(true, false))))
+  io.println("either(false, true) = ".concat(show_bool(either(false, true))))
+  io.println("!true = ".concat(show_bool(!true)))
 }

--- a/examples/capabilities.ky
+++ b/examples/capabilities.ky
@@ -14,7 +14,7 @@ fn log(msg: String) -> Unit with Console {
 fn copy_file(src: String, dst: String) -> Unit with FileSystem, Console {
   let content = read_file(src)
   write_file(dst, content)
-  log(string_concat("Copied ", string_concat(src, string_concat(" to ", dst))))
+  log("Copied ".concat(src.concat(" to ".concat(dst))))
 }
 
 fn pure_transform(x: Int) -> Int {

--- a/examples/composition.ky
+++ b/examples/composition.ky
@@ -1,3 +1,5 @@
+import io
+
 fn abs(x: Int) -> Int {
   if x < 0 { -x } else { x }
 }
@@ -12,9 +14,9 @@ fn clamp(lo: Int, hi: Int, x: Int) -> Int {
 }
 
 fn main() -> Unit {
-  println(string_concat("abs(-42) = ", int_to_string(abs(-42))))
-  println(string_concat("max(3, 7) = ", int_to_string(max(3, 7))))
-  println(string_concat("clamp(0, 10, 15) = ", int_to_string(clamp(0, 10, 15))))
-  println(string_concat("clamp(0, 10, -5) = ", int_to_string(clamp(0, 10, -5))))
-  println(string_concat("clamp(0, 10, 7) = ", int_to_string(clamp(0, 10, 7))))
+  io.println("abs(-42) = ".concat(abs(-42).to_string()))
+  io.println("max(3, 7) = ".concat(max(3, 7).to_string()))
+  io.println("clamp(0, 10, 15) = ".concat(clamp(0, 10, 15).to_string()))
+  io.println("clamp(0, 10, -5) = ".concat(clamp(0, 10, -5).to_string()))
+  io.println("clamp(0, 10, 7) = ".concat(clamp(0, 10, 7).to_string()))
 }

--- a/examples/contracts.ky
+++ b/examples/contracts.ky
@@ -1,3 +1,5 @@
+import io
+
 fn abs(x: Int) -> Int
   ensures result >= 0
 {
@@ -23,10 +25,10 @@ fn clamp(x: Int, lo: Int, hi: Int) -> Int
 }
 
 fn main() -> Unit {
-  println(string_concat("abs(-5) = ", int_to_string(abs(-5))))
-  println(string_concat("abs(3)  = ", int_to_string(abs(3))))
-  println(string_concat("increment(9) = ", int_to_string(increment(9))))
-  println(string_concat("clamp(50, 0, 10) = ", int_to_string(clamp(50, 0, 10))))
-  println(string_concat("clamp(-5, 0, 10) = ", int_to_string(clamp(-5, 0, 10))))
-  println(string_concat("clamp(7, 0, 10)  = ", int_to_string(clamp(7, 0, 10))))
+  io.println("abs(-5) = ".concat(abs(-5).to_string()))
+  io.println("abs(3)  = ".concat(abs(3).to_string()))
+  io.println("increment(9) = ".concat(increment(9).to_string()))
+  io.println("clamp(50, 0, 10) = ".concat(clamp(50, 0, 10).to_string()))
+  io.println("clamp(-5, 0, 10) = ".concat(clamp(-5, 0, 10).to_string()))
+  io.println("clamp(7, 0, 10)  = ".concat(clamp(7, 0, 10).to_string()))
 }

--- a/examples/hello.ky
+++ b/examples/hello.ky
@@ -1,7 +1,9 @@
+import io
+
 fn greet(name: String) -> String {
-  string_concat("Hello, ", name)
+  "Hello, ".concat(name)
 }
 
 fn main() -> Unit {
-  println(greet("world"))
+  io.println(greet("world"))
 }

--- a/examples/higher_order.ky
+++ b/examples/higher_order.ky
@@ -1,3 +1,5 @@
+import io
+
 fn apply(f: fn(Int) -> Int, x: Int) -> Int {
   f(x)
 }
@@ -10,6 +12,6 @@ fn compose(x: Int) -> Int {
 }
 
 fn main() -> Unit {
-  println(string_concat("apply(double, 7) = ", int_to_string(apply(double, 7))))
-  println(string_concat("compose(3) = ", int_to_string(compose(3))))
+  io.println("apply(double, 7) = ".concat(apply(double, 7).to_string()))
+  io.println("compose(3) = ".concat(compose(3).to_string()))
 }

--- a/examples/lists.ky
+++ b/examples/lists.ky
@@ -4,21 +4,21 @@ fn double(x: Int) -> Int { x * 2 }
 
 fn main() -> Int {
   // Build a list [1, 2, 3, 4, 5]
-  let xs = list_push(list_push(list_push(list_push(list_push(list_new(), 1), 2), 3), 4), 5)
+  let xs = List.new().push(1).push(2).push(3).push(4).push(5)
 
   // Map: [2, 4, 6, 8, 10]
-  let doubled = list_map(xs, double)
+  let doubled = xs.map(double)
 
   // Filter: [6, 8, 10]
-  let big = list_filter(doubled, fn(x: Int) => x > 4)
+  let big = doubled.filter(fn(x: Int) => x > 4)
 
   // Fold: 6 + 8 + 10 = 24
-  let total = list_fold(big, 0, fn(acc: Int, x: Int) => acc + x)
+  let total = big.fold(0, fn(acc: Int, x: Int) => acc + x)
 
   // Verify other operations
-  let rev = list_reverse(xs)
-  let combined = list_concat(xs, rev)
+  let rev = xs.reverse()
+  let combined = xs.concat(rev)
 
-  // total (24) + list_len(combined) (10) = 34
-  total + list_len(combined)
+  // total (24) + combined.len() (10) = 34
+  total + combined.len()
 }

--- a/examples/maps.ky
+++ b/examples/maps.ky
@@ -1,25 +1,25 @@
 // Map operations: insert, lookup, keys/values.
 
 fn main() -> Int {
-  let m = map_insert(map_insert(map_insert(map_new(), "x", 10), "y", 20), "z", 30)
+  let m = Map.new().insert("x", 10).insert("y", 20).insert("z", 30)
 
   // Lookup
-  let x_val = match map_get(m, "x") {
+  let x_val = match m.get("x") {
     Some(v) => v
     None => 0
   }
 
   // Overwrite "x" with 99
-  let m2 = map_insert(m, "x", 99)
-  let new_x = match map_get(m2, "x") {
+  let m2 = m.insert("x", 99)
+  let new_x = match m2.get("x") {
     Some(v) => v
     None => 0
   }
 
   // keys and values
-  let keys = map_keys(m2)
-  let vals = map_values(m2)
-  let sum = list_fold(vals, 0, fn(acc: Int, v: Int) => acc + v)
+  let keys = m2.keys()
+  let vals = m2.values()
+  let sum = vals.fold(0, fn(acc: Int, v: Int) => acc + v)
 
   // x_val (10) + new_x (99) + sum (99 + 20 + 30 = 149) = 258
   x_val + new_x + sum

--- a/examples/option_propagation.ky
+++ b/examples/option_propagation.ky
@@ -1,3 +1,5 @@
+import io
+
 fn safe_div(x: Int, y: Int) -> Option<Int> {
   if y == 0 {
     None
@@ -8,13 +10,13 @@ fn safe_div(x: Int, y: Int) -> Option<Int> {
 
 fn show_option(o: Option<Int>) -> String {
   match o {
-    Some(v) => string_concat("Some(", string_concat(int_to_string(v), ")"))
+    Some(v) => "Some(".concat(v.to_string().concat(")"))
     None => "None"
   }
 }
 
 fn main() -> Unit {
-  println(show_option(safe_div(100, 5)))
-  println(show_option(safe_div(100, 0)))
-  println(show_option(safe_div(42, 6)))
+  io.println(show_option(safe_div(100, 5)))
+  io.println(show_option(safe_div(100, 0)))
+  io.println(show_option(safe_div(42, 6)))
 }

--- a/examples/records.ky
+++ b/examples/records.ky
@@ -1,3 +1,5 @@
+import io
+
 type Point = { x: Int, y: Int }
 
 fn distance_sq(p: Point) -> Int {
@@ -7,6 +9,6 @@ fn distance_sq(p: Point) -> Int {
 fn main() -> Unit {
   let origin = Point { x: 0, y: 0 }
   let p = Point { x: 3, y: 4 }
-  println(string_concat("origin dist_sq: ", int_to_string(distance_sq(origin))))
-  println(string_concat("p dist_sq: ", int_to_string(distance_sq(p))))
+  io.println("origin dist_sq: ".concat(distance_sq(origin).to_string()))
+  io.println("p dist_sq: ".concat(distance_sq(p).to_string()))
 }

--- a/examples/recursion.ky
+++ b/examples/recursion.ky
@@ -1,3 +1,5 @@
+import io
+
 fn factorial(n: Int) -> Int {
   if n <= 1 {
     1
@@ -19,6 +21,6 @@ fn fibonacci(n: Int) -> Int {
 }
 
 fn main() -> Unit {
-  println(string_concat("factorial(10) = ", int_to_string(factorial(10))))
-  println(string_concat("fibonacci(10) = ", int_to_string(fibonacci(10))))
+  io.println("factorial(10) = ".concat(factorial(10).to_string()))
+  io.println("fibonacci(10) = ".concat(fibonacci(10).to_string()))
 }

--- a/examples/result_propagation.ky
+++ b/examples/result_propagation.ky
@@ -1,3 +1,5 @@
+import io
+
 fn parse_positive(n: Int) -> Result<Int, String> {
   if n > 0 {
     Ok(n)
@@ -13,12 +15,12 @@ fn double_positive(n: Int) -> Result<Int, String> {
 
 fn show_result(r: Result<Int, String>) -> String {
   match r {
-    Ok(v) => string_concat("Ok(", string_concat(int_to_string(v), ")"))
-    Err(e) => string_concat("Err(", string_concat(e, ")"))
+    Ok(v) => "Ok(".concat(v.to_string().concat(")"))
+    Err(e) => "Err(".concat(e.concat(")"))
   }
 }
 
 fn main() -> Unit {
-  println(show_result(double_positive(5)))
-  println(show_result(double_positive(-3)))
+  io.println(show_result(double_positive(5)))
+  io.println(show_result(double_positive(-3)))
 }

--- a/examples/strings.ky
+++ b/examples/strings.ky
@@ -1,16 +1,18 @@
+import io
+
 fn greet(first: String, last: String) -> String {
-  string_concat("Hello, ", string_concat(first, string_concat(" ", last)))
+  "Hello, ".concat(first.concat(" ".concat(last)))
 }
 
 fn repeat(s: String, n: Int) -> String {
   if n <= 0 {
     ""
   } else {
-    string_concat(s, repeat(s, n - 1))
+    s.concat(repeat(s, n - 1))
   }
 }
 
 fn main() -> Unit {
-  println(greet("Ada", "Lovelace"))
-  println(repeat("ha", 5))
+  io.println(greet("Ada", "Lovelace"))
+  io.println(repeat("ha", 5))
 }


### PR DESCRIPTION
## Summary
- Add diagnostic hints for ~40 removed free-function intrinsic names, pointing users to canonical replacements (e.g. `unresolved name 'println'; use io.println() (requires import io)`)
- Update all 15 example files to use canonical API: method calls, module-qualified calls with explicit imports, static constructors
- Docs/RFC audit confirmed all documentation files are already accurate

Follows up on #249 (RFC 0001 canonical API surface). Tracked in #243.

## Test plan
- [x] 6 tests for legacy name hints (println, list_len, abs, list_new, min, parse_int)
- [x] 1 guard test: non-legacy names produce no hint
- [x] `cargo test --workspace` — all pass
- [x] `cargo clippy --workspace --tests -- -D warnings` — clean
- [x] No old-style intrinsic calls remain in examples/