### PR TITLE
lang: canonicalize effect keyword in surface syntax

### DIFF
--- a/crates/fmt/src/format.rs
+++ b/crates/fmt/src/format.rs
@@ -593,7 +593,7 @@ fn format_invariant_clause(node: &SyntaxNode) -> Doc {
 // ── Cap / Property ──────────────────────────────────────────────────
 
 fn format_cap_def(node: &SyntaxNode) -> Doc {
-    let mut parts = vec![Doc::text("cap"), Doc::text(" ")];
+    let mut parts = vec![Doc::text("effect"), Doc::text(" ")];
 
     if let Some(name) = find_ident(node) {
         parts.push(format_token(&name));

--- a/crates/fmt/tests/fmt_tests.rs
+++ b/crates/fmt/tests/fmt_tests.rs
@@ -373,13 +373,13 @@ fn fmt_fn_with_type_params() {
     );
 }
 
-// ── Capability definitions ──────────────────────────────────────────
+// ── Effect definitions ──────────────────────────────────────────────
 
 #[test]
-fn fmt_cap_def() {
+fn fmt_effect_def() {
     assert_fmt(
-        "cap IO { fn read() -> String { _ }\nfn write(s: String) -> Unit { _ } }",
-        "cap IO {\n  fn read() -> String {\n    _\n  }\n\n  fn write(s: String) -> Unit {\n    _\n  }\n}\n",
+        "effect IO { fn read() -> String { _ }\nfn write(s: String) -> Unit { _ } }",
+        "effect IO {\n  fn read() -> String {\n    _\n  }\n\n  fn write(s: String) -> Unit {\n    _\n  }\n}\n",
     );
 }
 

--- a/crates/parser/src/grammar/items.rs
+++ b/crates/parser/src/grammar/items.rs
@@ -1,7 +1,7 @@
 //! Top-level item parsing.
 //!
 //! Handles module declarations, imports, type definitions, function
-//! definitions, capability definitions, property definitions, and
+//! definitions, effect definitions, property definitions, and
 //! let bindings.
 
 use crate::SyntaxKind::*;
@@ -10,11 +10,11 @@ use crate::token_set::TokenSet;
 
 /// Tokens that can start an item — used for error recovery.
 pub(super) const ITEM_RECOVERY: TokenSet = TokenSet::new(&[
-    ModuleKw, ImportKw, TypeKw, FnKw, CapKw, PropertyKw, LetKw, PubKw,
+    ModuleKw, ImportKw, TypeKw, FnKw, CapKw, EffectKw, PropertyKw, LetKw, PubKw,
 ]);
 
 pub(super) fn item(p: &mut Parser<'_>) -> Option<CompletedMarker> {
-    // `pub` can precede fn, type, or cap.
+    // `pub` can precede fn, type, or effect.
     let is_pub = p.at(PubKw);
     let start = if is_pub {
         p.current_after_pub()
@@ -25,7 +25,12 @@ pub(super) fn item(p: &mut Parser<'_>) -> Option<CompletedMarker> {
     let cm = match start {
         TypeKw => type_def(p, is_pub),
         FnKw => fn_def(p, is_pub, false),
-        CapKw => cap_def(p, is_pub),
+        CapKw => {
+            p.error("`cap` is no longer supported; use `effect`");
+            p.bump();
+            return None;
+        }
+        EffectKw => cap_def(p, is_pub),
         PropertyKw => {
             if is_pub {
                 p.error_recover("expected item", ITEM_RECOVERY);
@@ -337,15 +342,15 @@ fn invariant_clause(p: &mut Parser<'_>) {
     m.complete(p, InvariantClause);
 }
 
-// ── Capability Definition ───────────────────────────────────────────
+// ── Effect Definition ───────────────────────────────────────────────
 
-/// `pub? cap Ident TypeParamList? '{' FnDef* '}'`
+/// `pub? effect Ident TypeParamList? '{' FnDef* '}'`
 fn cap_def(p: &mut Parser<'_>, is_pub: bool) -> CompletedMarker {
     let m = p.open();
     if is_pub {
         p.bump(); // pub
     }
-    p.bump(); // cap
+    p.bump(); // effect
     p.expect(Ident);
     if p.at(Lt) {
         type_param_list(p);

--- a/crates/parser/src/syntax_kind.rs
+++ b/crates/parser/src/syntax_kind.rs
@@ -58,6 +58,8 @@ pub enum SyntaxKind {
     MatchKw,
     /// `cap`
     CapKw,
+    /// `effect`
+    EffectKw,
     /// `with`
     WithKw,
     /// `requires`
@@ -188,7 +190,7 @@ pub enum SyntaxKind {
     TypeDef,
     /// `fn foo(…) -> … { … }`
     FnDef,
-    /// `cap Foo { … }`
+    /// `effect Foo { … }`
     CapDef,
     /// `property foo(…) { … }`
     PropertyDef,
@@ -351,6 +353,7 @@ impl SyntaxKind {
                 | Self::LetKw
                 | Self::MatchKw
                 | Self::CapKw
+                | Self::EffectKw
                 | Self::WithKw
                 | Self::RequiresKw
                 | Self::EnsuresKw
@@ -443,6 +446,7 @@ impl SyntaxKind {
             "let" => Some(Self::LetKw),
             "match" => Some(Self::MatchKw),
             "cap" => Some(Self::CapKw),
+            "effect" => Some(Self::EffectKw),
             "with" => Some(Self::WithKw),
             "requires" => Some(Self::RequiresKw),
             "ensures" => Some(Self::EnsuresKw),

--- a/crates/parser/tests/parser_tests.rs
+++ b/crates/parser/tests/parser_tests.rs
@@ -573,10 +573,24 @@ fn refined_type() {
 // ── Cap definition ──────────────────────────────────────────────────
 
 #[test]
-fn cap_def() {
+fn cap_keyword_is_rejected_with_effect_rewrite_hint() {
     // cap IO { fn read() { 0 } }
-    let (events, errors) = parse_tokens(&[
+    let (_events, errors) = parse_tokens(&[
         CapKw, Ident, LBrace, FnKw, Ident, LParen, RParen, LBrace, IntLiteral, RBrace, RBrace,
+    ]);
+    assert!(
+        errors.iter().any(|e| e
+            .message
+            .contains("`cap` is no longer supported; use `effect`")),
+        "expected cap->effect rewrite hint, got: {errors:?}"
+    );
+}
+
+#[test]
+fn effect_def() {
+    // effect IO { fn read() { 0 } }
+    let (events, errors) = parse_tokens(&[
+        EffectKw, Ident, LBrace, FnKw, Ident, LParen, RParen, LBrace, IntLiteral, RBrace, RBrace,
     ]);
     assert!(has_no_errors(&errors));
     assert!(has_node(&events, CapDef));

--- a/crates/syntax/src/lexer.rs
+++ b/crates/syntax/src/lexer.rs
@@ -285,6 +285,7 @@ mod tests {
             ("let", LetKw),
             ("match", MatchKw),
             ("cap", CapKw),
+            ("effect", EffectKw),
             ("with", WithKw),
             ("requires", RequiresKw),
             ("ensures", EnsuresKw),

--- a/crates/syntax/tests/integration_tests.rs
+++ b/crates/syntax/tests/integration_tests.rs
@@ -75,9 +75,23 @@ fn parse_top_level_fn_without_body_reports_error() {
 
 #[test]
 fn parse_cap_member_fn_without_body_is_allowed() {
-    let src = "cap IO {\n  fn read() -> String\n}";
+    let src = "effect IO {\n  fn read() -> String\n}";
     let green = parse_ok(src);
     assert_eq!(green_text(&green), src);
+}
+
+#[test]
+fn parse_cap_keyword_is_rejected_with_effect_rewrite_hint() {
+    let src = "cap IO {\n  fn read() -> String\n}";
+    let result = parse(src);
+    assert!(
+        result.errors.iter().any(|e| e
+            .message
+            .contains("`cap` is no longer supported; use `effect`")),
+        "expected cap->effect rewrite hint, got: {:?}",
+        result.errors
+    );
+    assert_eq!(green_text(&result.green), src);
 }
 
 #[test]
@@ -211,7 +225,7 @@ fn roundtrip_fn_type() {
 
 #[test]
 fn roundtrip_cap_def() {
-    let src = "cap IO {\n  fn read() { 0 }\n}";
+    let src = "effect IO {\n  fn read() { 0 }\n}";
     let green = parse_ok(src);
     assert_eq!(green_text(&green), src);
 }

--- a/docs/design-v0.md
+++ b/docs/design-v0.md
@@ -142,15 +142,15 @@ fn add_fee(x: Money, fee_bps: Int) -> Money =
   { amount = x.amount + fee.amount, currency = x.currency }
 ```
 
-### 2.5 Capabilities / effects
+### 2.5 Effects
 
-Declare capabilities:
+Declare effects:
 
 ```kyokara
-cap Net
-cap Clock
-cap Db
-cap Secrets
+effect Net
+effect Clock
+effect Db
+effect Secrets
 ```
 
 Annotate effect requirements:
@@ -162,7 +162,7 @@ fn fetch_rate(base: Currency, quote: Currency) -> Result[Float, HttpError] with 
 
 Rules:
 * a function without `with ...` is pure and cannot invoke effectful operations.
-* callers must "inherit" required caps unless the cap is introduced explicitly via scoped blocks (optional v0 feature).
+* callers must "inherit" required effects unless the effect is introduced explicitly via scoped blocks (optional v0 feature).
 
 Open design questions (to resolve before hir-ty):
 * **Effect polymorphism**: higher-order functions need effect-polymorphic signatures, e.g. `fn map(f: fn(A) -> B with e, xs: List[A]) -> List[B] with e`. Without this, the stdlib will be painful.


### PR DESCRIPTION
## Summary
Phase 1 of cap->effect migration: canonicalize user-facing effect declaration keyword.

Closes #276

## What changed
- Added `effect` keyword token (`EffectKw`) in parser keyword table.
- Parser now accepts `effect` declarations where `cap` was previously accepted.
- Parser now rejects `cap` declarations with actionable message:
  - `` `cap` is no longer supported; use `effect` ``
- Formatter now emits `effect` for effect declaration nodes.
- Updated parser/syntax/fmt tests to cover:
  - `effect` parse success
  - `cap` rejection hint
  - formatter canonical output using `effect`
- Updated design doc syntax examples to `effect` declarations.

## TDD evidence
RED first:
- `kyokara-parser` test compile failed for missing `EffectKw`.
- `kyokara-syntax` integration tests failed for `effect` parse and missing cap rewrite hint.
- `kyokara-fmt` test failed due fallback formatting.

GREEN after implementation:
- `cargo test -p kyokara-parser -p kyokara-syntax -p kyokara-fmt`
- `cargo check --workspace`

## Notes
- Internal names (`CapDef`, `CapItem`, `with_caps`) are intentionally unchanged in this phase.
- Public API/LSP contract renames are deferred to #278/#280.
