### PR TITLE
Reduce parser cascades and suppress semantics on parse-damaged functions

### DIFF
--- a/crates/api/tests/api_tests.rs
+++ b/crates/api/tests/api_tests.rs
@@ -77,7 +77,7 @@ fn check_hole_inputs_no_duplicate_names() {
 fn check_hole_inputs_exclude_out_of_scope_inner_binding_issue_132() {
     let src = r#"
 fn main(x: Int) -> Int {
-  if true {
+  if (true) {
     let z = 1
     0
   } else {
@@ -105,7 +105,7 @@ fn main(x: Int) -> Int {
 fn check_hole_inputs_include_in_scope_branch_binding_issue_132_guard() {
     let src = r#"
 fn main() -> Int {
-  if true {
+  if (true) {
     let z = 1
     _
   } else {
@@ -159,6 +159,62 @@ fn check_parse_error_code() {
             .iter()
             .map(|d| &d.code)
             .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn check_parse_damaged_function_reports_parse_only_diagnostics() {
+    let src = "fn main() -> Int { match value { _ => 0 } }";
+    let output = check(src, "test.ky");
+    assert!(
+        output
+            .diagnostics
+            .iter()
+            .any(|d| d.code == "E0100" && d.message.contains("match scrutinee must be parenthesized")),
+        "expected targeted match parse diagnostic, got: {:?}",
+        output.diagnostics
+    );
+    assert!(
+        output.diagnostics.iter().all(|d| d.code == "E0100"),
+        "parse-damaged function should report parse-only diagnostics, got: {:?}",
+        output.diagnostics
+    );
+}
+
+#[test]
+fn check_mixed_file_keeps_unaffected_function_semantic_diagnostics() {
+    let src = r#"
+fn broken() -> Int {
+  match value {
+    _ => 0
+  }
+}
+
+fn typed_bad() -> Int {
+  "oops"
+}
+"#;
+    let output = check(src, "test.ky");
+    assert!(
+        output
+            .diagnostics
+            .iter()
+            .any(|d| d.code == "E0100" && d.message.contains("match scrutinee must be parenthesized")),
+        "expected parse diagnostic for broken fn, got: {:?}",
+        output.diagnostics
+    );
+    assert!(
+        output.diagnostics.iter().any(|d| d.code == "E0001"),
+        "expected unaffected function type mismatch diagnostic, got: {:?}",
+        output.diagnostics
+    );
+    assert!(
+        output
+            .diagnostics
+            .iter()
+            .all(|d| d.code != "E0009" && d.code != "E0101"),
+        "did not expect cascade diagnostics from parse-damaged function, got: {:?}",
+        output.diagnostics
     );
 }
 
@@ -2882,7 +2938,7 @@ fn rename_function_param_shadows_entire_body() {
 #[test]
 fn if_condition_rejects_non_bool() {
     // `if 1 {}` — the condition should require Bool, not accept Int silently.
-    let output = check("fn f() -> Unit { if 1 { } }", "test.ky");
+    let output = check("fn f() -> Unit { if (1) { } }", "test.ky");
     assert!(
         !output.diagnostics.is_empty(),
         "expected a type mismatch diagnostic for `if 1`, got none"
@@ -2913,7 +2969,7 @@ fn fallback_unification_catches_literal_type_mismatch() {
 #[test]
 fn symbol_graph_local_lambda_not_in_function_calls() {
     // A local lambda `f` should not produce a dangling fn::f call edge.
-    let src = "fn main() -> Int {\n  let f = fn(x: Int, y: Int) -> Int => x\n  f(1, 2)\n}";
+    let src = "fn main() -> Int {\n  let f = fn(x: Int, y: Int) => x\n  f(1, 2)\n}";
     let output = check(src, "test.ky");
     let main_fn = output
         .symbol_graph
@@ -2978,7 +3034,7 @@ fn symbol_graph_pre_shadow_call_edge_preserved() {
 fn foo() -> Int { 1 }
 fn main() -> Int {
   foo()
-  let foo = fn() -> Int => 2
+  let foo = fn() => 2
   foo()
 }
 "#;
@@ -3003,7 +3059,7 @@ fn symbol_graph_post_shadow_call_not_in_edges() {
     let src = r#"
 fn foo() -> Int { 1 }
 fn main() -> Int {
-  let foo = fn() -> Int => 2
+  let foo = fn() => 2
   foo()
 }
 "#;
@@ -3052,7 +3108,7 @@ fn symbol_graph_lambda_param_shadow_no_call_edge() {
 fn foo() -> Int { 1 }
 fn main() -> Int {
   let g = fn(foo) => foo()
-  g(fn() -> Int => 2)
+  g(fn() => 2)
 }
 "#;
     let output = check(src, "test.ky");
@@ -3102,7 +3158,7 @@ fn foo() -> Int { 1 }
 fn main() -> Int {
   foo()
   let g = fn(foo) => foo()
-  g(fn() -> Int => 2)
+  g(fn() => 2)
 }
 "#;
     let output = check(src, "test.ky");
@@ -3132,7 +3188,7 @@ fn symbol_graph_nested_block_shadow_respects_lexical_scope() {
 fn foo() -> Int { 1 }
 fn main() -> Int {
   {
-    let foo = fn() -> Int => 2
+    let foo = fn() => 2
     foo()
   }
   foo()
@@ -3164,7 +3220,7 @@ fn project_symbol_graph_pre_post_shadow_with_imported_function() {
     let output = check_project_from_files(&[
         (
             "main.ky",
-            "import math\nfn caller() -> Int {\n  add(1, 2)\n  let add = fn(x: Int, y: Int) -> Int => x\n  add(1, 2)\n}\n",
+            "import math\nfn caller() -> Int {\n  add(1, 2)\n  let add = fn(x: Int, y: Int) => x\n  add(1, 2)\n}\n",
         ),
         ("math.ky", "pub fn add(x: Int, y: Int) -> Int { x + y }\n"),
     ]);

--- a/crates/eval/src/lib.rs
+++ b/crates/eval/src/lib.rs
@@ -16,7 +16,7 @@ use kyokara_hir::{
     register_static_methods, register_synthetic_modules,
 };
 use kyokara_intern::Interner;
-use kyokara_span::FileId;
+use kyokara_span::{FileId, TextRange, TextSize};
 use kyokara_stdx::FxHashMap;
 use kyokara_syntax::SyntaxNode;
 use kyokara_syntax::ast::AstNode;
@@ -121,6 +121,11 @@ pub fn run_with_manifest(
 
     // 1. Parse.
     let parse = kyokara_syntax::parse(source);
+    let parse_error_ranges: Vec<TextRange> = parse
+        .errors
+        .iter()
+        .map(|err| normalize_parse_error_range(err.range_start, err.range_end, source.len() as u32))
+        .collect();
 
     // 2. Build CST.
     let root = SyntaxNode::new_root(parse.green);
@@ -161,6 +166,7 @@ pub fn run_with_manifest(
         &root,
         &item_result.tree,
         &item_result.module_scope,
+        &parse_error_ranges,
         file_id,
         &mut interner,
     );
@@ -451,4 +457,21 @@ fn collect_project_compile_errors(project: &kyokara_hir::ProjectCheckResult) -> 
     }
 
     errors
+}
+
+fn normalize_parse_error_range(start: u32, end: u32, source_len: u32) -> TextRange {
+    let start = start.min(source_len);
+    let end = end.min(source_len);
+    if start < end {
+        return TextRange::new(TextSize::from(start), TextSize::from(end));
+    }
+    if source_len == 0 {
+        return TextRange::new(TextSize::from(0), TextSize::from(0));
+    }
+    if start < source_len {
+        let right = (start + 1).min(source_len);
+        return TextRange::new(TextSize::from(start), TextSize::from(right));
+    }
+    let left = start.saturating_sub(1);
+    TextRange::new(TextSize::from(left), TextSize::from(start))
 }

--- a/crates/hir-ty/src/lib.rs
+++ b/crates/hir-ty/src/lib.rs
@@ -25,7 +25,7 @@ use kyokara_hir_def::item_tree::{FnItemIdx, ItemTree};
 use kyokara_hir_def::resolver::ModuleScope;
 use kyokara_hir_def::type_ref::TypeRef;
 use kyokara_intern::Interner;
-use kyokara_span::{FileId, Span};
+use kyokara_span::{FileId, Span, TextRange};
 use kyokara_stdx::FxHashMap;
 use kyokara_syntax::SyntaxNode;
 use kyokara_syntax::ast::AstNode;
@@ -62,6 +62,7 @@ pub fn check_module(
     root: &SyntaxNode,
     item_tree: &ItemTree,
     module_scope: &ModuleScope,
+    parse_error_ranges: &[TextRange],
     file_id: FileId,
     interner: &mut Interner,
 ) -> TypeCheckResult {
@@ -77,6 +78,12 @@ pub fn check_module(
 
     for (fn_idx, fn_item) in item_tree.functions.iter() {
         if !fn_item.has_body {
+            continue;
+        }
+        if fn_item
+            .source_range
+            .is_some_and(|range| overlaps_parse_error(range, parse_error_ranges))
+        {
             continue;
         }
 
@@ -134,6 +141,12 @@ pub fn check_module(
 
     // Validate type argument arities in function signatures.
     for (_, fn_item) in item_tree.functions.iter() {
+        if fn_item
+            .source_range
+            .is_some_and(|range| overlaps_parse_error(range, parse_error_ranges))
+        {
+            continue;
+        }
         let fn_span = fn_item
             .source_range
             .map(|r| Span {
@@ -174,6 +187,12 @@ pub fn check_module(
         body_lowering_diagnostics,
         fn_calls,
     }
+}
+
+fn overlaps_parse_error(range: TextRange, parse_error_ranges: &[TextRange]) -> bool {
+    parse_error_ranges
+        .iter()
+        .any(|parse_range| range.intersect(*parse_range).is_some())
 }
 
 /// Walk a TypeRef tree and emit diagnostics for type argument arity mismatches.

--- a/crates/hir-ty/tests/infer_tests.rs
+++ b/crates/hir-ty/tests/infer_tests.rs
@@ -29,6 +29,7 @@ fn check(src: &str) -> (TypeCheckResult, Interner) {
         &root,
         &item_result.tree,
         &item_result.module_scope,
+        &[],
         file_id(),
         &mut interner,
     );

--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -34,7 +34,7 @@ use std::collections::HashMap;
 use kyokara_diagnostics::{Diagnostic, DiagnosticKind};
 use kyokara_intern::Interner;
 use kyokara_parser::ParseError;
-use kyokara_span::{FileId, FileMap, TextRange};
+use kyokara_span::{FileId, FileMap, TextRange, TextSize};
 use kyokara_syntax::SyntaxNode;
 use kyokara_syntax::ast::AstNode;
 use kyokara_syntax::ast::nodes::SourceFile;
@@ -117,6 +117,7 @@ pub fn check_file(source: &str) -> CheckResult {
     let parse = kyokara_syntax::parse(source);
     let green = parse.green.clone();
     let parse_errors = parse.errors;
+    let parse_error_ranges = normalized_parse_error_ranges(&parse_errors, source.len() as u32);
 
     // 2. Build CST root and SourceFile.
     let root = SyntaxNode::new_root(parse.green);
@@ -155,6 +156,7 @@ pub fn check_file(source: &str) -> CheckResult {
         &root,
         &item_result.tree,
         &item_result.module_scope,
+        &parse_error_ranges,
         file_id,
         &mut interner,
     );
@@ -191,6 +193,7 @@ pub fn check_project(entry_file: &std::path::Path) -> ProjectCheckResult {
     let mut module_graph = ModuleGraph::new();
     let mut all_parse_errors = Vec::new();
     let mut all_lowering_diagnostics = Vec::new();
+    let mut parse_error_ranges_by_module: HashMap<ModulePath, Vec<TextRange>> = HashMap::new();
     let mut cst_roots: Vec<(ModulePath, SyntaxNode)> = Vec::new();
 
     let root = entry_file.parent().unwrap_or(std::path::Path::new("."));
@@ -215,6 +218,8 @@ pub fn check_project(entry_file: &std::path::Path) -> ProjectCheckResult {
             }
         };
         let parse = kyokara_syntax::parse(&source);
+        let parse_error_ranges = normalized_parse_error_ranges(&parse.errors, source.len() as u32);
+        parse_error_ranges_by_module.insert(mod_path.clone(), parse_error_ranges);
 
         if !parse.errors.is_empty() {
             all_parse_errors.push((mod_path.clone(), parse.errors.clone()));
@@ -271,10 +276,15 @@ pub fn check_project(entry_file: &std::path::Path) -> ProjectCheckResult {
     for (mod_path, cst_root) in &cst_roots {
         #[allow(clippy::unwrap_used)] // key comes from cst_roots, always in module_graph
         let info = module_graph.get(mod_path).unwrap();
+        let parse_error_ranges = parse_error_ranges_by_module
+            .get(mod_path)
+            .map(Vec::as_slice)
+            .unwrap_or(&[]);
         let tc = check_module(
             cst_root,
             &info.item_tree,
             &info.scope,
+            parse_error_ranges,
             info.file_id,
             &mut interner,
         );
@@ -289,6 +299,33 @@ pub fn check_project(entry_file: &std::path::Path) -> ProjectCheckResult {
         parse_errors: all_parse_errors,
         lowering_diagnostics: all_lowering_diagnostics,
     }
+}
+
+fn normalized_parse_error_ranges(parse_errors: &[ParseError], source_len: u32) -> Vec<TextRange> {
+    parse_errors
+        .iter()
+        .map(|err| normalize_parse_error_range(err, source_len))
+        .collect()
+}
+
+fn normalize_parse_error_range(err: &ParseError, source_len: u32) -> TextRange {
+    let start = err.range_start.min(source_len);
+    let end = err.range_end.min(source_len);
+    if start < end {
+        return TextRange::new(TextSize::from(start), TextSize::from(end));
+    }
+
+    if source_len == 0 {
+        return TextRange::new(TextSize::from(0), TextSize::from(0));
+    }
+
+    if start < source_len {
+        let right = (start + 1).min(source_len);
+        return TextRange::new(TextSize::from(start), TextSize::from(right));
+    }
+
+    let left = start.saturating_sub(1);
+    TextRange::new(TextSize::from(left), TextSize::from(start))
 }
 
 /// Resolve imports across all modules in the graph.

--- a/crates/kir/tests/lower_tests.rs
+++ b/crates/kir/tests/lower_tests.rs
@@ -1473,7 +1473,7 @@ fn test_fn_ref_emitted_for_function_value() {
 #[test]
 fn test_fn_ref_guard_hole_stays_hole() {
     // Guard: typed holes should still emit hole instructions, not fn_ref.
-    let out = lower_and_display("fn f(x: Int) -> Int { x + ?todo }");
+    let out = lower_and_display("fn f(x: Int) -> Int { x + _ }");
     assert!(
         out.contains("hole #"),
         "typed hole should remain a hole. output:\n{out}"

--- a/crates/lsp/src/code_action.rs
+++ b/crates/lsp/src/code_action.rs
@@ -156,7 +156,7 @@ mod tests {
     fn quickfix_for_missing_match_arms() {
         let source = "type Color = Red | Green | Blue\n\
                       fn pick(c: Color) -> Int {\n\
-                        match c {\n\
+                        match (c) {\n\
                           Red => 1\n\
                         }\n\
                       }";

--- a/crates/parser/src/grammar/expressions.rs
+++ b/crates/parser/src/grammar/expressions.rs
@@ -23,6 +23,8 @@ use crate::token_set::TokenSet;
 const EXPR_RECOVERY: TokenSet = TokenSet::new(&[
     LetKw, RBrace, Semicolon, RParen, Comma, FatArrow, TypeKw, FnKw, CapKw, PropertyKw, LeftArrow,
 ]);
+const IF_HEAD_RECOVERY: TokenSet = TokenSet::new(&[LBrace, ElseKw, Semicolon, RBrace]);
+const MATCH_HEAD_RECOVERY: TokenSet = TokenSet::new(&[LBrace, Semicolon, RBrace]);
 
 /// Entry point: parse an expression.
 pub(super) fn expr(p: &mut Parser<'_>) -> Option<CompletedMarker> {
@@ -180,9 +182,7 @@ fn if_expr(p: &mut Parser<'_>) -> CompletedMarker {
         expr(p);
         p.expect(RParen);
     } else {
-        p.error("if condition must be parenthesized");
-        // Recovery: parse condition expression so we can continue to the block.
-        expr(p);
+        p.error_recover_until("if condition must be parenthesized", IF_HEAD_RECOVERY);
     }
     if p.at(LBrace) {
         block_expr(p);
@@ -209,9 +209,7 @@ fn match_expr(p: &mut Parser<'_>) -> CompletedMarker {
         expr(p);
         p.expect(RParen);
     } else {
-        p.error("match scrutinee must be parenthesized");
-        // Recovery: parse scrutinee expression so we can continue to arm list.
-        expr(p);
+        p.error_recover_until("match scrutinee must be parenthesized", MATCH_HEAD_RECOVERY);
     }
     match_arm_list(p);
     m.complete(p, MatchExpr)

--- a/crates/parser/src/grammar/items.rs
+++ b/crates/parser/src/grammar/items.rs
@@ -12,6 +12,9 @@ use crate::token_set::TokenSet;
 pub(super) const ITEM_RECOVERY: TokenSet = TokenSet::new(&[
     ModuleKw, ImportKw, TypeKw, FnKw, CapKw, EffectKw, PropertyKw, LetKw, PubKw,
 ]);
+const CLAUSE_EXPR_RECOVERY: TokenSet = TokenSet::new(&[
+    LBrace, RBrace, Semicolon, Comma, WithKw, PipeKw, RequiresKw, EnsuresKw, InvariantKw, WhereKw,
+]);
 
 pub(super) fn item(p: &mut Parser<'_>) -> Option<CompletedMarker> {
     // `pub` can precede fn, type, or effect.
@@ -326,9 +329,7 @@ fn parse_parenthesized_clause_expr(p: &mut Parser<'_>, message: &str) {
         super::expressions::expr(p);
         p.expect(RParen);
     } else {
-        p.error(message);
-        // Recovery: parse the clause expression in old style and continue.
-        super::expressions::expr(p);
+        p.error_recover_until(message, CLAUSE_EXPR_RECOVERY);
     }
 }
 

--- a/crates/parser/src/parser.rs
+++ b/crates/parser/src/parser.rs
@@ -171,7 +171,6 @@ impl<'i> Parser<'i> {
 
     /// Skip tokens wrapping them in an ErrorNode until we hit something
     /// in `recovery` or EOF.
-    #[allow(dead_code)]
     pub fn error_recover_until(&mut self, message: &str, recovery: TokenSet) {
         if self.at_eof() || recovery.contains(self.current()) {
             self.error(message);

--- a/crates/parser/tests/parser_tests.rs
+++ b/crates/parser/tests/parser_tests.rs
@@ -276,10 +276,15 @@ fn fn_def_contract_unparenthesized_requires_reports_targeted_error() {
     let (_events, errors) = parse_tokens(&[
         FnKw, Ident, LParen, RParen, Arrow, Ident, RequiresKw, Ident, LBrace, IntLiteral, RBrace,
     ]);
+    assert_eq!(
+        errors.len(),
+        1,
+        "expected one targeted requires error, got: {errors:?}"
+    );
     assert!(
-        errors.iter().any(|e| e
+        errors[0]
             .message
-            .contains("requires clause expression must be parenthesized")),
+            .contains("requires clause expression must be parenthesized"),
         "expected parenthesized-requires diagnostic, got: {errors:?}"
     );
 }
@@ -418,10 +423,15 @@ fn if_expr_unparenthesized_condition_reports_targeted_error() {
         LetKw, Ident, Eq, IfKw, TrueKw, LBrace, IntLiteral, RBrace, ElseKw, LBrace, IntLiteral,
         RBrace,
     ]);
+    assert_eq!(
+        errors.len(),
+        1,
+        "expected one targeted if error, got: {errors:?}"
+    );
     assert!(
-        errors
-            .iter()
-            .any(|e| e.message.contains("if condition must be parenthesized")),
+        errors[0]
+            .message
+            .contains("if condition must be parenthesized"),
         "expected parenthesized-if diagnostic, got: {errors:?}"
     );
 }
@@ -446,10 +456,15 @@ fn match_expr_unparenthesized_scrutinee_reports_targeted_error() {
         LetKw, Ident, Eq, MatchKw, Ident, LBrace, IntLiteral, FatArrow, IntLiteral, Comma,
         Underscore, FatArrow, IntLiteral, RBrace,
     ]);
+    assert_eq!(
+        errors.len(),
+        1,
+        "expected one targeted match error, got: {errors:?}"
+    );
     assert!(
-        errors
-            .iter()
-            .any(|e| e.message.contains("match scrutinee must be parenthesized")),
+        errors[0]
+            .message
+            .contains("match scrutinee must be parenthesized"),
         "expected parenthesized-match diagnostic, got: {errors:?}"
     );
 }
@@ -963,10 +978,15 @@ fn property_where_unparenthesized_reports_targeted_error() {
         PropertyKw, Ident, LParen, Ident, Colon, Ident, LeftArrow, Ident, Dot, Ident, LParen,
         RParen, RParen, WhereKw, Ident, Gt, IntLiteral,
     ]);
+    assert_eq!(
+        errors.len(),
+        1,
+        "expected one targeted where error, got: {errors:?}"
+    );
     assert!(
-        errors.iter().any(|e| e
+        errors[0]
             .message
-            .contains("where clause expression must be parenthesized")),
+            .contains("where clause expression must be parenthesized"),
         "expected parenthesized-where diagnostic, got: {errors:?}"
     );
 }

--- a/crates/pbt/src/runner.rs
+++ b/crates/pbt/src/runner.rs
@@ -11,7 +11,7 @@ use kyokara_hir::{
 };
 use kyokara_hir_def::item_tree::FnItemIdx;
 use kyokara_intern::Interner;
-use kyokara_span::FileId;
+use kyokara_span::{FileId, TextRange, TextSize};
 use kyokara_stdx::FxHashMap;
 use kyokara_syntax::SyntaxNode;
 use kyokara_syntax::ast::AstNode;
@@ -78,6 +78,11 @@ pub fn run_tests(source: &str, config: &TestConfig) -> Result<TestReport, String
 
     // 1. Parse.
     let parse = kyokara_syntax::parse(source);
+    let parse_error_ranges: Vec<TextRange> = parse
+        .errors
+        .iter()
+        .map(|err| normalize_parse_error_range(err.range_start, err.range_end, source.len() as u32))
+        .collect();
 
     // 2. Build CST.
     let root = SyntaxNode::new_root(parse.green);
@@ -118,6 +123,7 @@ pub fn run_tests(source: &str, config: &TestConfig) -> Result<TestReport, String
         &root,
         &item_result.tree,
         &item_result.module_scope,
+        &parse_error_ranges,
         file_id,
         &mut interner,
     );
@@ -296,6 +302,23 @@ fn collect_compile_errors_project<T: std::fmt::Debug>(
 
 fn is_error(d: &&kyokara_diagnostics::Diagnostic) -> bool {
     d.severity == kyokara_diagnostics::Severity::Error
+}
+
+fn normalize_parse_error_range(start: u32, end: u32, source_len: u32) -> TextRange {
+    let start = start.min(source_len);
+    let end = end.min(source_len);
+    if start < end {
+        return TextRange::new(TextSize::from(start), TextSize::from(end));
+    }
+    if source_len == 0 {
+        return TextRange::new(TextSize::from(0), TextSize::from(0));
+    }
+    if start < source_len {
+        let right = (start + 1).min(source_len);
+        return TextRange::new(TextSize::from(start), TextSize::from(right));
+    }
+    let left = start.saturating_sub(1);
+    TextRange::new(TextSize::from(left), TextSize::from(start))
 }
 
 fn format_module_path(path: &ModulePath, interner: &Interner) -> String {

--- a/crates/syntax/tests/integration_tests.rs
+++ b/crates/syntax/tests/integration_tests.rs
@@ -384,11 +384,16 @@ fn roundtrip_property_with_where() {
 fn parse_if_without_parenthesized_condition_reports_targeted_error() {
     let src = "let x = if true { 1 } else { 2 }";
     let result = parse(src);
+    assert_eq!(
+        result.errors.len(),
+        1,
+        "expected one targeted if parse error, got: {:?}",
+        result.errors
+    );
     assert!(
-        result
-            .errors
-            .iter()
-            .any(|e| e.message.contains("if condition must be parenthesized")),
+        result.errors[0]
+            .message
+            .contains("if condition must be parenthesized"),
         "expected parenthesized-if diagnostic, got: {:?}",
         result.errors
     );
@@ -399,11 +404,16 @@ fn parse_if_without_parenthesized_condition_reports_targeted_error() {
 fn parse_match_without_parenthesized_scrutinee_reports_targeted_error() {
     let src = "let x = match y { 1 => 2, _ => 3 }";
     let result = parse(src);
+    assert_eq!(
+        result.errors.len(),
+        1,
+        "expected one targeted match parse error, got: {:?}",
+        result.errors
+    );
     assert!(
-        result
-            .errors
-            .iter()
-            .any(|e| e.message.contains("match scrutinee must be parenthesized")),
+        result.errors[0]
+            .message
+            .contains("match scrutinee must be parenthesized"),
         "expected parenthesized-match diagnostic, got: {:?}",
         result.errors
     );
@@ -414,10 +424,16 @@ fn parse_match_without_parenthesized_scrutinee_reports_targeted_error() {
 fn parse_requires_without_parenthesized_expr_reports_targeted_error() {
     let src = "fn f(x: Int) -> Int requires x > 0 { x }";
     let result = parse(src);
+    assert_eq!(
+        result.errors.len(),
+        1,
+        "expected one targeted requires parse error, got: {:?}",
+        result.errors
+    );
     assert!(
-        result.errors.iter().any(|e| e
+        result.errors[0]
             .message
-            .contains("requires clause expression must be parenthesized")),
+            .contains("requires clause expression must be parenthesized"),
         "expected parenthesized-requires diagnostic, got: {:?}",
         result.errors
     );
@@ -428,10 +444,16 @@ fn parse_requires_without_parenthesized_expr_reports_targeted_error() {
 fn parse_where_without_parenthesized_expr_reports_targeted_error() {
     let src = "property p(x: Int <- Gen.auto()) where x > 0 { x > 0 }";
     let result = parse(src);
+    assert_eq!(
+        result.errors.len(),
+        1,
+        "expected one targeted where parse error, got: {:?}",
+        result.errors
+    );
     assert!(
-        result.errors.iter().any(|e| e
+        result.errors[0]
             .message
-            .contains("where clause expression must be parenthesized")),
+            .contains("where clause expression must be parenthesized"),
         "expected parenthesized-where diagnostic, got: {:?}",
         result.errors
     );


### PR DESCRIPTION
## Summary
- remove fallback expression parsing for missing-parenthesis head expressions (`if`, `match`, contract/where clauses)
- switch to targeted synchronization recovery to prevent parse cascades
- pass normalized parse-error ranges into `check_module` and skip lowering/type-checking for overlapping functions/properties
- add API regressions for parse-damaged function behavior and mixed-file diagnostics
- update affected tests/fixtures to canonical parenthesized syntax where needed

## Validation
- cargo test -p kyokara-parser
- cargo test -p kyokara-syntax
- cargo test -p kyokara-hir-ty
- cargo test -p kyokara-hir
- cargo test -p kyokara-api
- cargo test -p kyokara-eval
- cargo test -p kyokara-pbt
- cargo test
