### PR TITLE
fix(parser): prevent record-literal cascade on missing head parens

### DIFF
--- a/crates/api/tests/api_tests.rs
+++ b/crates/api/tests/api_tests.rs
@@ -170,13 +170,125 @@ fn check_parse_damaged_function_reports_parse_only_diagnostics() {
         output
             .diagnostics
             .iter()
-            .any(|d| d.code == "E0100" && d.message.contains("match scrutinee must be parenthesized")),
+            .any(|d| d.code == "E0100"
+                && d.message.contains("match scrutinee must be parenthesized")),
         "expected targeted match parse diagnostic, got: {:?}",
         output.diagnostics
     );
     assert!(
         output.diagnostics.iter().all(|d| d.code == "E0100"),
         "parse-damaged function should report parse-only diagnostics, got: {:?}",
+        output.diagnostics
+    );
+}
+
+#[test]
+fn check_if_record_like_head_near_miss_reports_targeted_parse_without_cascade_noise() {
+    let src = "fn main() -> Int { let x = if Point { x: 1 } == Point { x: 1 } { 1 } else { 0 } x }";
+    let output = check(src, "test.ky");
+    assert!(
+        output
+            .diagnostics
+            .iter()
+            .any(|d| d.code == "E0100" && d.message.contains("if condition must be parenthesized")),
+        "expected targeted if parse diagnostic, got: {:?}",
+        output.diagnostics
+    );
+    assert!(
+        output.diagnostics.iter().all(|d| d.code == "E0100"),
+        "expected parse-only diagnostics for damaged function, got: {:?}",
+        output.diagnostics
+    );
+    assert!(
+        output.diagnostics.iter().all(|d| {
+            !d.message.contains("expected item")
+                && !d.message.contains("expected RBrace")
+                && !d.message.contains("expected FatArrow")
+        }),
+        "did not expect cascade-style parser noise, got: {:?}",
+        output.diagnostics
+    );
+}
+
+#[test]
+fn check_match_record_like_head_near_miss_reports_targeted_parse_without_cascade_noise() {
+    let src = "fn main() -> Int { let x = match Point { x: 1 } { _ => 0 } x }";
+    let output = check(src, "test.ky");
+    assert!(
+        output
+            .diagnostics
+            .iter()
+            .any(|d| d.code == "E0100"
+                && d.message.contains("match scrutinee must be parenthesized")),
+        "expected targeted match parse diagnostic, got: {:?}",
+        output.diagnostics
+    );
+    assert!(
+        output.diagnostics.iter().all(|d| d.code == "E0100"),
+        "expected parse-only diagnostics for damaged function, got: {:?}",
+        output.diagnostics
+    );
+    assert!(
+        output.diagnostics.iter().all(|d| {
+            !d.message.contains("expected item")
+                && !d.message.contains("expected RBrace")
+                && !d.message.contains("expected FatArrow")
+        }),
+        "did not expect cascade-style parser noise, got: {:?}",
+        output.diagnostics
+    );
+}
+
+#[test]
+fn check_requires_record_like_head_near_miss_reports_targeted_parse_without_cascade_noise() {
+    let src = "fn main() -> Int requires Point { x: 1 } { 1 }";
+    let output = check(src, "test.ky");
+    assert!(
+        output.diagnostics.iter().any(|d| d.code == "E0100"
+            && d.message
+                .contains("requires clause expression must be parenthesized")),
+        "expected targeted requires parse diagnostic, got: {:?}",
+        output.diagnostics
+    );
+    assert!(
+        output.diagnostics.iter().all(|d| d.code == "E0100"),
+        "expected parse-only diagnostics for damaged function, got: {:?}",
+        output.diagnostics
+    );
+    assert!(
+        output.diagnostics.iter().all(|d| {
+            !d.message.contains("expected item")
+                && !d.message.contains("expected RBrace")
+                && !d.message.contains("expected FatArrow")
+        }),
+        "did not expect cascade-style parser noise, got: {:?}",
+        output.diagnostics
+    );
+}
+
+#[test]
+fn check_where_record_like_head_near_miss_reports_targeted_parse_without_cascade_noise() {
+    let src = "property p(x: Int <- Gen.auto()) where Point { x: 1 } { true }";
+    let output = check(src, "test.ky");
+    assert!(
+        output.diagnostics.iter().any(|d| d.code == "E0100"
+            && d.message
+                .contains("where clause expression must be parenthesized")),
+        "expected targeted where parse diagnostic, got: {:?}",
+        output.diagnostics
+    );
+    assert!(
+        output.diagnostics.iter().all(|d| d.code == "E0100"),
+        "expected parse-only diagnostics for damaged property, got: {:?}",
+        output.diagnostics
+    );
+    assert!(
+        output.diagnostics.iter().all(|d| {
+            !d.message.contains("expected item")
+                && !d.message.contains("expected RBrace")
+                && !d.message.contains("expected FatArrow")
+        }),
+        "did not expect cascade-style parser noise, got: {:?}",
         output.diagnostics
     );
 }
@@ -199,7 +311,8 @@ fn typed_bad() -> Int {
         output
             .diagnostics
             .iter()
-            .any(|d| d.code == "E0100" && d.message.contains("match scrutinee must be parenthesized")),
+            .any(|d| d.code == "E0100"
+                && d.message.contains("match scrutinee must be parenthesized")),
         "expected parse diagnostic for broken fn, got: {:?}",
         output.diagnostics
     );

--- a/crates/parser/src/grammar/expressions.rs
+++ b/crates/parser/src/grammar/expressions.rs
@@ -182,7 +182,7 @@ fn if_expr(p: &mut Parser<'_>) -> CompletedMarker {
         expr(p);
         p.expect(RParen);
     } else {
-        p.error_recover_until("if condition must be parenthesized", IF_HEAD_RECOVERY);
+        p.error_recover_parenthesized_head("if condition must be parenthesized", IF_HEAD_RECOVERY);
     }
     if p.at(LBrace) {
         block_expr(p);
@@ -209,7 +209,10 @@ fn match_expr(p: &mut Parser<'_>) -> CompletedMarker {
         expr(p);
         p.expect(RParen);
     } else {
-        p.error_recover_until("match scrutinee must be parenthesized", MATCH_HEAD_RECOVERY);
+        p.error_recover_parenthesized_head(
+            "match scrutinee must be parenthesized",
+            MATCH_HEAD_RECOVERY,
+        );
     }
     match_arm_list(p);
     m.complete(p, MatchExpr)

--- a/crates/parser/src/grammar/items.rs
+++ b/crates/parser/src/grammar/items.rs
@@ -13,7 +13,16 @@ pub(super) const ITEM_RECOVERY: TokenSet = TokenSet::new(&[
     ModuleKw, ImportKw, TypeKw, FnKw, CapKw, EffectKw, PropertyKw, LetKw, PubKw,
 ]);
 const CLAUSE_EXPR_RECOVERY: TokenSet = TokenSet::new(&[
-    LBrace, RBrace, Semicolon, Comma, WithKw, PipeKw, RequiresKw, EnsuresKw, InvariantKw, WhereKw,
+    LBrace,
+    RBrace,
+    Semicolon,
+    Comma,
+    WithKw,
+    PipeKw,
+    RequiresKw,
+    EnsuresKw,
+    InvariantKw,
+    WhereKw,
 ]);
 
 pub(super) fn item(p: &mut Parser<'_>) -> Option<CompletedMarker> {
@@ -329,7 +338,7 @@ fn parse_parenthesized_clause_expr(p: &mut Parser<'_>, message: &str) {
         super::expressions::expr(p);
         p.expect(RParen);
     } else {
-        p.error_recover_until(message, CLAUSE_EXPR_RECOVERY);
+        p.error_recover_parenthesized_head(message, CLAUSE_EXPR_RECOVERY);
     }
 }
 

--- a/crates/parser/src/parser.rs
+++ b/crates/parser/src/parser.rs
@@ -169,19 +169,86 @@ impl<'i> Parser<'i> {
         m.complete(self, SyntaxKind::ErrorNode);
     }
 
-    /// Skip tokens wrapping them in an ErrorNode until we hit something
-    /// in `recovery` or EOF.
-    pub fn error_recover_until(&mut self, message: &str, recovery: TokenSet) {
-        if self.at_eof() || recovery.contains(self.current()) {
-            self.error(message);
+    /// Recovery for missing-parenthesis head-expression sites (`if`, `match`,
+    /// and contract/where clauses).
+    ///
+    /// This behaves like `error_recover_until`, but treats `{ ... }` immediately
+    /// following an identifier as record-literal-shaped head content when it
+    /// starts with `Ident ':'`, so we skip that brace group instead of stopping
+    /// at the first `{`.
+    pub fn error_recover_parenthesized_head(&mut self, message: &str, recovery: TokenSet) {
+        self.error(message);
+        if self.at_eof() {
             return;
         }
+
         let m = self.open();
-        self.error(message);
-        while !self.at_eof() && !recovery.contains(self.current()) {
+        let mut consumed_any = false;
+        let mut prev_kind: Option<SyntaxKind> = None;
+
+        while !self.at_eof() {
+            let current = self.current();
+            if recovery.contains(current) {
+                if current == SyntaxKind::LBrace
+                    && prev_kind == Some(SyntaxKind::Ident)
+                    && self.looks_like_record_literal_brace()
+                {
+                    self.skip_balanced_braces();
+                    consumed_any = true;
+                    prev_kind = Some(SyntaxKind::RBrace);
+                    continue;
+                }
+                break;
+            }
+
+            let before = self.pos;
+            prev_kind = Some(current);
             self.bump();
+            consumed_any = true;
+            if self.pos == before {
+                break;
+            }
         }
-        m.complete(self, SyntaxKind::ErrorNode);
+
+        if consumed_any {
+            m.complete(self, SyntaxKind::ErrorNode);
+        } else {
+            m.abandon(self);
+        }
+    }
+
+    fn looks_like_record_literal_brace(&self) -> bool {
+        self.at(SyntaxKind::LBrace)
+            && self.nth(1) == SyntaxKind::Ident
+            && self.nth(2) == SyntaxKind::Colon
+    }
+
+    fn skip_balanced_braces(&mut self) {
+        if !self.at(SyntaxKind::LBrace) {
+            return;
+        }
+
+        let mut depth = 0usize;
+        while !self.at_eof() {
+            let before = self.pos;
+            match self.current() {
+                SyntaxKind::LBrace => {
+                    depth += 1;
+                    self.bump();
+                }
+                SyntaxKind::RBrace => {
+                    depth = depth.saturating_sub(1);
+                    self.bump();
+                    if depth == 0 {
+                        break;
+                    }
+                }
+                _ => self.bump(),
+            }
+            if self.pos == before {
+                break;
+            }
+        }
     }
 }
 

--- a/crates/parser/tests/parser_tests.rs
+++ b/crates/parser/tests/parser_tests.rs
@@ -290,6 +290,80 @@ fn fn_def_contract_unparenthesized_requires_reports_targeted_error() {
 }
 
 #[test]
+fn fn_def_contract_requires_unparenthesized_record_like_expr_reports_single_targeted_error() {
+    // fn f() -> Int requires Point { x: 1 } { 1 }
+    let (_events, errors) = parse_tokens(&[
+        FnKw, Ident, LParen, RParen, Arrow, Ident, RequiresKw, Ident, LBrace, Ident, Colon,
+        IntLiteral, RBrace, LBrace, IntLiteral, RBrace,
+    ]);
+    assert_eq!(
+        errors.len(),
+        1,
+        "expected one targeted requires error, got: {errors:?}"
+    );
+    assert!(
+        errors[0]
+            .message
+            .contains("requires clause expression must be parenthesized"),
+        "expected parenthesized-requires diagnostic, got: {errors:?}"
+    );
+}
+
+#[test]
+fn fn_def_contract_ensures_unparenthesized_record_like_expr_reports_single_targeted_error() {
+    // fn f() -> Int ensures Point { x: 1 } { 1 }
+    let (_events, errors) = parse_tokens(&[
+        FnKw, Ident, LParen, RParen, Arrow, Ident, EnsuresKw, Ident, LBrace, Ident, Colon,
+        IntLiteral, RBrace, LBrace, IntLiteral, RBrace,
+    ]);
+    assert_eq!(
+        errors.len(),
+        1,
+        "expected one targeted ensures error, got: {errors:?}"
+    );
+    assert!(
+        errors[0]
+            .message
+            .contains("ensures clause expression must be parenthesized"),
+        "expected parenthesized-ensures diagnostic, got: {errors:?}"
+    );
+}
+
+#[test]
+fn fn_def_contract_invariant_unparenthesized_record_like_expr_reports_single_targeted_error() {
+    // fn f() -> Int invariant Point { x: 1 } { 1 }
+    let (_events, errors) = parse_tokens(&[
+        FnKw,
+        Ident,
+        LParen,
+        RParen,
+        Arrow,
+        Ident,
+        InvariantKw,
+        Ident,
+        LBrace,
+        Ident,
+        Colon,
+        IntLiteral,
+        RBrace,
+        LBrace,
+        IntLiteral,
+        RBrace,
+    ]);
+    assert_eq!(
+        errors.len(),
+        1,
+        "expected one targeted invariant error, got: {errors:?}"
+    );
+    assert!(
+        errors[0]
+            .message
+            .contains("invariant clause expression must be parenthesized"),
+        "expected parenthesized-invariant diagnostic, got: {errors:?}"
+    );
+}
+
+#[test]
 fn top_level_fn_def_without_body_reports_error() {
     // fn foo() -> Int
     let (events, errors) = parse_tokens(&[FnKw, Ident, LParen, RParen, Arrow, Ident]);
@@ -437,6 +511,27 @@ fn if_expr_unparenthesized_condition_reports_targeted_error() {
 }
 
 #[test]
+fn if_expr_unparenthesized_record_like_condition_reports_single_targeted_error() {
+    // let x = if Point { x: 1 } == Point { x: 1 } { 1 } else { 0 }
+    let (_events, errors) = parse_tokens(&[
+        LetKw, Ident, Eq, IfKw, Ident, LBrace, Ident, Colon, IntLiteral, RBrace, EqEq, Ident,
+        LBrace, Ident, Colon, IntLiteral, RBrace, LBrace, IntLiteral, RBrace, ElseKw, LBrace,
+        IntLiteral, RBrace,
+    ]);
+    assert_eq!(
+        errors.len(),
+        1,
+        "expected one targeted if error, got: {errors:?}"
+    );
+    assert!(
+        errors[0]
+            .message
+            .contains("if condition must be parenthesized"),
+        "expected parenthesized-if diagnostic, got: {errors:?}"
+    );
+}
+
+#[test]
 fn match_expr() {
     // let x = match (y) { 1 => 2, _ => 3 }
     let (events, errors) = parse_tokens(&[
@@ -454,6 +549,26 @@ fn match_expr_unparenthesized_scrutinee_reports_targeted_error() {
     // let x = match y { 1 => 2, _ => 3 }
     let (_events, errors) = parse_tokens(&[
         LetKw, Ident, Eq, MatchKw, Ident, LBrace, IntLiteral, FatArrow, IntLiteral, Comma,
+        Underscore, FatArrow, IntLiteral, RBrace,
+    ]);
+    assert_eq!(
+        errors.len(),
+        1,
+        "expected one targeted match error, got: {errors:?}"
+    );
+    assert!(
+        errors[0]
+            .message
+            .contains("match scrutinee must be parenthesized"),
+        "expected parenthesized-match diagnostic, got: {errors:?}"
+    );
+}
+
+#[test]
+fn match_expr_unparenthesized_record_like_scrutinee_reports_single_targeted_error() {
+    // let x = match Point { x: 1 } { _ => 0 }
+    let (_events, errors) = parse_tokens(&[
+        LetKw, Ident, Eq, MatchKw, Ident, LBrace, Ident, Colon, IntLiteral, RBrace, LBrace,
         Underscore, FatArrow, IntLiteral, RBrace,
     ]);
     assert_eq!(
@@ -977,6 +1092,27 @@ fn property_where_unparenthesized_reports_targeted_error() {
     let (_events, errors) = parse_tokens(&[
         PropertyKw, Ident, LParen, Ident, Colon, Ident, LeftArrow, Ident, Dot, Ident, LParen,
         RParen, RParen, WhereKw, Ident, Gt, IntLiteral,
+    ]);
+    assert_eq!(
+        errors.len(),
+        1,
+        "expected one targeted where error, got: {errors:?}"
+    );
+    assert!(
+        errors[0]
+            .message
+            .contains("where clause expression must be parenthesized"),
+        "expected parenthesized-where diagnostic, got: {errors:?}"
+    );
+}
+
+#[test]
+fn property_where_unparenthesized_record_like_expr_reports_single_targeted_error() {
+    // property p(x: Int <- Gen.auto()) where Point { x: 1 } { true }
+    let (_events, errors) = parse_tokens(&[
+        PropertyKw, Ident, LParen, Ident, Colon, Ident, LeftArrow, Ident, Dot, Ident, LParen,
+        RParen, RParen, WhereKw, Ident, LBrace, Ident, Colon, IntLiteral, RBrace, LBrace, TrueKw,
+        RBrace,
     ]);
     assert_eq!(
         errors.len(),

--- a/crates/syntax/tests/integration_tests.rs
+++ b/crates/syntax/tests/integration_tests.rs
@@ -401,8 +401,48 @@ fn parse_if_without_parenthesized_condition_reports_targeted_error() {
 }
 
 #[test]
+fn parse_if_without_parenthesized_record_like_condition_reports_single_targeted_error() {
+    let src = "let x = if Point { x: 1 } == Point { x: 1 } { 1 } else { 0 }";
+    let result = parse(src);
+    assert_eq!(
+        result.errors.len(),
+        1,
+        "expected one targeted if parse error, got: {:?}",
+        result.errors
+    );
+    assert!(
+        result.errors[0]
+            .message
+            .contains("if condition must be parenthesized"),
+        "expected parenthesized-if diagnostic, got: {:?}",
+        result.errors
+    );
+    assert_eq!(green_text(&result.green), src);
+}
+
+#[test]
 fn parse_match_without_parenthesized_scrutinee_reports_targeted_error() {
     let src = "let x = match y { 1 => 2, _ => 3 }";
+    let result = parse(src);
+    assert_eq!(
+        result.errors.len(),
+        1,
+        "expected one targeted match parse error, got: {:?}",
+        result.errors
+    );
+    assert!(
+        result.errors[0]
+            .message
+            .contains("match scrutinee must be parenthesized"),
+        "expected parenthesized-match diagnostic, got: {:?}",
+        result.errors
+    );
+    assert_eq!(green_text(&result.green), src);
+}
+
+#[test]
+fn parse_match_without_parenthesized_record_like_scrutinee_reports_single_targeted_error() {
+    let src = "let x = match Point { x: 1 } { _ => 0 }";
     let result = parse(src);
     assert_eq!(
         result.errors.len(),
@@ -441,8 +481,88 @@ fn parse_requires_without_parenthesized_expr_reports_targeted_error() {
 }
 
 #[test]
+fn parse_requires_without_parenthesized_record_like_expr_reports_single_targeted_error() {
+    let src = "fn f() -> Int requires Point { x: 1 } { 1 }";
+    let result = parse(src);
+    assert_eq!(
+        result.errors.len(),
+        1,
+        "expected one targeted requires parse error, got: {:?}",
+        result.errors
+    );
+    assert!(
+        result.errors[0]
+            .message
+            .contains("requires clause expression must be parenthesized"),
+        "expected parenthesized-requires diagnostic, got: {:?}",
+        result.errors
+    );
+    assert_eq!(green_text(&result.green), src);
+}
+
+#[test]
+fn parse_ensures_without_parenthesized_record_like_expr_reports_single_targeted_error() {
+    let src = "fn f() -> Int ensures Point { x: 1 } { 1 }";
+    let result = parse(src);
+    assert_eq!(
+        result.errors.len(),
+        1,
+        "expected one targeted ensures parse error, got: {:?}",
+        result.errors
+    );
+    assert!(
+        result.errors[0]
+            .message
+            .contains("ensures clause expression must be parenthesized"),
+        "expected parenthesized-ensures diagnostic, got: {:?}",
+        result.errors
+    );
+    assert_eq!(green_text(&result.green), src);
+}
+
+#[test]
+fn parse_invariant_without_parenthesized_record_like_expr_reports_single_targeted_error() {
+    let src = "fn f() -> Int invariant Point { x: 1 } { 1 }";
+    let result = parse(src);
+    assert_eq!(
+        result.errors.len(),
+        1,
+        "expected one targeted invariant parse error, got: {:?}",
+        result.errors
+    );
+    assert!(
+        result.errors[0]
+            .message
+            .contains("invariant clause expression must be parenthesized"),
+        "expected parenthesized-invariant diagnostic, got: {:?}",
+        result.errors
+    );
+    assert_eq!(green_text(&result.green), src);
+}
+
+#[test]
 fn parse_where_without_parenthesized_expr_reports_targeted_error() {
     let src = "property p(x: Int <- Gen.auto()) where x > 0 { x > 0 }";
+    let result = parse(src);
+    assert_eq!(
+        result.errors.len(),
+        1,
+        "expected one targeted where parse error, got: {:?}",
+        result.errors
+    );
+    assert!(
+        result.errors[0]
+            .message
+            .contains("where clause expression must be parenthesized"),
+        "expected parenthesized-where diagnostic, got: {:?}",
+        result.errors
+    );
+    assert_eq!(green_text(&result.green), src);
+}
+
+#[test]
+fn parse_where_without_parenthesized_record_like_expr_reports_single_targeted_error() {
+    let src = "property p(x: Int <- Gen.auto()) where Point { x: 1 } { true }";
     let result = parse(src);
     assert_eq!(
         result.errors.len(),


### PR DESCRIPTION
## Summary
- add brace-aware recovery for missing-parenthesis head-expression sites
- prevent cascades when unparenthesized head expressions contain record-literal-shaped braces
- apply recovery across `if`, `match`, `requires`, `ensures`, `invariant`, and `where`

## Testing
- cargo test -p kyokara-parser
- cargo test -p kyokara-syntax
- cargo test -p kyokara-api
- cargo test

Fixes #274
