### PR TITLE
fix(syntax): make else-if equivalent to nested else-if

### DIFF
--- a/crates/api/tests/api_tests.rs
+++ b/crates/api/tests/api_tests.rs
@@ -35,6 +35,48 @@ fn check_type_mismatch_has_code() {
 }
 
 #[test]
+fn check_else_if_expression_form_typechecks_like_nested_form() {
+    let src = "fn main() -> Int { let x = if (true) { 1 } else if (false) { 2 } else { 3 }\n x }";
+    let output = check(src, "test.ky");
+    assert!(
+        output.diagnostics.is_empty(),
+        "expected no diagnostics for else-if expression form, got: {:?}",
+        output.diagnostics
+    );
+}
+
+#[test]
+fn check_else_if_missing_final_else_matches_nested_form_diagnostics() {
+    let else_if = "fn main() -> Int { if (true) { 1 } else if (false) { 2 } }";
+    let nested = "fn main() -> Int { if (true) { 1 } else { if (false) { 2 } } }";
+
+    let else_if_output = check(else_if, "test.ky");
+    let nested_output = check(nested, "test.ky");
+
+    let else_if_codes: BTreeSet<String> = else_if_output
+        .diagnostics
+        .iter()
+        .map(|d| d.code.clone())
+        .collect();
+    let nested_codes: BTreeSet<String> = nested_output
+        .diagnostics
+        .iter()
+        .map(|d| d.code.clone())
+        .collect();
+
+    assert_eq!(
+        else_if_codes, nested_codes,
+        "expected else-if and nested forms to produce same diagnostic code set, got else-if={:?}, nested={:?}",
+        else_if_output.diagnostics, nested_output.diagnostics
+    );
+    assert!(
+        else_if_codes.contains("E0001"),
+        "expected type mismatch E0001 for missing final else, got: {:?}",
+        else_if_output.diagnostics
+    );
+}
+
+#[test]
 fn check_hole_produces_spec() {
     let output = check("fn foo() -> Int { _ }", "test.ky");
     assert_eq!(output.holes.len(), 1);

--- a/crates/eval/tests/eval_tests.rs
+++ b/crates/eval/tests/eval_tests.rs
@@ -238,6 +238,26 @@ fn eval_if_with_comparison() {
     assert!(matches!(val, Value::Int(100)));
 }
 
+#[test]
+fn eval_else_if_true_path() {
+    let val = run_ok("fn main() -> Int { if (true) { 1 } else if (true) { 2 } else { 3 } }");
+    assert!(matches!(val, Value::Int(1)));
+}
+
+#[test]
+fn eval_else_if_middle_path() {
+    let val = run_ok("fn main() -> Int { if (false) { 1 } else if (true) { 2 } else { 3 } }");
+    assert!(matches!(val, Value::Int(2)));
+}
+
+#[test]
+fn eval_else_if_matches_nested_form() {
+    let else_if = run_ok("fn main() -> Int { if (false) { 1 } else if (true) { 2 } else { 3 } }");
+    let nested =
+        run_ok("fn main() -> Int { if (false) { 1 } else { if (true) { 2 } else { 3 } } }");
+    assert_eq!(else_if, nested);
+}
+
 // ── Comparison operator tests ────────────────────────────────────────
 
 #[test]

--- a/crates/hir-def/tests/lower_tests.rs
+++ b/crates/hir-def/tests/lower_tests.rs
@@ -229,6 +229,37 @@ fn lower_if_expr() {
 }
 
 #[test]
+fn lower_else_if_expr_preserves_nested_else_branch() {
+    let src = "fn foo() -> Int { if (true) { 1 } else if (false) { 2 } else { 3 } }";
+    let (body, diags, _) = lower_fn_body(src);
+    assert!(
+        diags.is_empty(),
+        "unexpected lowering diagnostics: {diags:?}"
+    );
+
+    let inner_if_idx = match &body.exprs[body.root] {
+        Expr::Block {
+            tail: Some(tail), ..
+        } => match &body.exprs[*tail] {
+            Expr::If {
+                else_branch: Some(inner_if),
+                ..
+            } => *inner_if,
+            other => panic!("expected outer If with else branch, got {other:?}"),
+        },
+        other => panic!("expected Block, got {other:?}"),
+    };
+
+    match &body.exprs[inner_if_idx] {
+        Expr::If {
+            else_branch: Some(_),
+            ..
+        } => {}
+        other => panic!("expected nested else-if node with else branch, got {other:?}"),
+    }
+}
+
+#[test]
 fn lower_match_expr() {
     let src = r#"
 type Bool = True | False

--- a/crates/hir-ty/tests/infer_tests.rs
+++ b/crates/hir-ty/tests/infer_tests.rs
@@ -142,6 +142,25 @@ fn infer_if_else() {
 }
 
 #[test]
+fn infer_else_if_chain() {
+    check_ok("fn foo() -> Int { if (true) { 1 } else if (false) { 2 } else { 3 } }");
+}
+
+#[test]
+fn infer_else_if_equivalent_to_nested_else_if_form() {
+    check_ok("fn foo() -> Int { if (true) { 1 } else if (false) { 2 } else { 3 } }");
+    check_ok("fn foo() -> Int { if (true) { 1 } else { if (false) { 2 } else { 3 } } }");
+}
+
+#[test]
+fn infer_else_if_without_final_else_matches_nested_error() {
+    let else_if = "fn foo() -> Int { if (true) { 1 } else if (false) { 2 } }";
+    let nested = "fn foo() -> Int { if (true) { 1 } else { if (false) { 2 } } }";
+    check_err(else_if, "type mismatch");
+    check_err(nested, "type mismatch");
+}
+
+#[test]
 fn infer_if_no_else_is_unit() {
     check_ok("fn foo() { if (true) { 1 } }");
 }

--- a/crates/syntax/src/ast/nodes.rs
+++ b/crates/syntax/src/ast/nodes.rs
@@ -736,21 +736,26 @@ impl IfExpr {
     }
 
     pub fn else_branch(&self) -> Option<ElseBranch> {
-        let has_else = self
-            .syntax
-            .children_with_tokens()
-            .filter_map(|it| it.into_token())
-            .any(|tok| tok.kind() == SyntaxKind::ElseKw);
-        if !has_else {
-            return None;
+        let mut seen_else = false;
+        for child in self.syntax.children_with_tokens() {
+            match child {
+                rowan::NodeOrToken::Token(tok) => {
+                    if tok.kind() == SyntaxKind::ElseKw {
+                        seen_else = true;
+                    }
+                }
+                rowan::NodeOrToken::Node(node) if seen_else => {
+                    if let Some(if_expr) = IfExpr::cast(node.clone()) {
+                        return Some(ElseBranch::IfExpr(if_expr));
+                    }
+                    if let Some(block) = BlockExpr::cast(node) {
+                        return Some(ElseBranch::Block(block));
+                    }
+                }
+                rowan::NodeOrToken::Node(_) => {}
+            }
         }
-        // else branch is either an IfExpr or the second BlockExpr
-        if let Some(if_expr) = support::children::<IfExpr>(&self.syntax).nth(1) {
-            return Some(ElseBranch::IfExpr(if_expr));
-        }
-        support::children::<BlockExpr>(&self.syntax)
-            .nth(1)
-            .map(ElseBranch::Block)
+        None
     }
 }
 

--- a/crates/syntax/tests/integration_tests.rs
+++ b/crates/syntax/tests/integration_tests.rs
@@ -1,6 +1,8 @@
 //! Integration tests — parse source text, verify CST structure + lossless roundtrip.
 #![allow(clippy::unwrap_used)]
 
+use kyokara_syntax::ast::AstNode;
+use kyokara_syntax::ast::nodes::{ElseBranch, IfExpr, SourceFile};
 use kyokara_syntax::{SyntaxKind, parse};
 
 /// Helper: parse source, check no errors, return CST debug string.
@@ -155,6 +157,34 @@ fn roundtrip_if_else() {
     let src = "let x = if (true) { 1 } else { 2 }";
     let green = parse_ok(src);
     assert_eq!(green_text(&green), src);
+}
+
+#[test]
+fn parse_else_if_ast_else_branch_chain_is_explicit() {
+    let src = "let x = if (true) { 1 } else if (false) { 2 } else { 3 }";
+    let result = parse(src);
+    assert!(
+        result.errors.is_empty(),
+        "unexpected parse errors for else-if chain: {:?}",
+        result.errors
+    );
+
+    let root = kyokara_syntax::SyntaxNode::new_root(result.green);
+    let sf = SourceFile::cast(root).expect("parsed root should cast to SourceFile");
+    let outer_if = sf
+        .syntax()
+        .descendants()
+        .find_map(IfExpr::cast)
+        .expect("expected outer if expression");
+
+    let inner_if = match outer_if.else_branch() {
+        Some(ElseBranch::IfExpr(elif)) => elif,
+        other => panic!("expected outer else branch to be else-if, got: {other:?}"),
+    };
+    assert!(
+        matches!(inner_if.else_branch(), Some(ElseBranch::Block(_))),
+        "expected inner else-if to end with block else branch"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- fix `IfExpr::else_branch()` extraction to follow token order after `else`
- make `else if` chains semantically equivalent to nested `else { if ... }`
- add red-first regressions across syntax, hir-def lowering, hir-ty, api, and eval

## Testing
- cargo test -p kyokara-syntax
- cargo test -p kyokara-hir-def
- cargo test -p kyokara-hir-ty
- cargo test -p kyokara-api
- cargo test -p kyokara-eval
- cargo test

Refs #271
