### PR TITLE
fix: reject Set generator mismatches and make effect fmt non-lossy

### DIFF
--- a/crates/fmt/src/format.rs
+++ b/crates/fmt/src/format.rs
@@ -596,6 +596,12 @@ fn format_invariant_clause(node: &SyntaxNode) -> Doc {
 // ── Cap / Property ──────────────────────────────────────────────────
 
 fn format_cap_def(node: &SyntaxNode) -> Doc {
+    // Keep invalid/extra syntax verbatim to avoid destructive formatting on
+    // parse-damaged effect declarations (e.g. effect bodies/type params).
+    if node.children().next().is_some() {
+        return verbatim(node);
+    }
+
     let mut parts = vec![Doc::text("effect"), Doc::text(" ")];
 
     if let Some(name) = find_ident(node) {

--- a/crates/fmt/tests/fmt_tests.rs
+++ b/crates/fmt/tests/fmt_tests.rs
@@ -380,6 +380,19 @@ fn fmt_effect_def() {
     assert_fmt("effect  IO", "effect IO\n");
 }
 
+#[test]
+fn fmt_effect_with_body_is_non_lossy() {
+    assert_fmt(
+        "effect IO { fn read() -> String }",
+        "effect IO { fn read() -> String }\n",
+    );
+}
+
+#[test]
+fn fmt_effect_with_type_params_is_non_lossy() {
+    assert_fmt("effect IO<T>", "effect IO<T>\n");
+}
+
 // ── Let binding with compound expressions ───────────────────────────
 
 #[test]

--- a/crates/hir-def/src/item_tree/lower.rs
+++ b/crates/hir-def/src/item_tree/lower.rs
@@ -636,6 +636,7 @@ impl ItemTreeCtx<'_> {
                 | "Unit"
                 | "List"
                 | "Map"
+                | "Set"
                 | "Option"
                 | "Result"
         )

--- a/crates/pbt/tests/integration.rs
+++ b/crates/pbt/tests/integration.rs
@@ -526,10 +526,35 @@ fn property_gen_type_mismatch_produces_diagnostic() {
 }
 
 #[test]
+fn property_gen_set_type_mismatch_produces_diagnostic() {
+    let result = kyokara_hir::check_file("property p(s: Set<Int> <- Gen.int()) { true }");
+    let has_mismatch = result
+        .lowering_diagnostics
+        .iter()
+        .any(|d| d.message.contains("generator") && d.message.contains("incompatible"));
+    assert!(
+        has_mismatch,
+        "Gen.int() for Set<Int> parameter should produce mismatch diagnostic: {:?}",
+        result.lowering_diagnostics
+    );
+}
+
+#[test]
 fn run_tests_rejects_gen_spec_type_mismatch_before_execution() {
     let config = test_config();
     let source = "property p(x: Int <- Gen.bool()) { x > 0 }";
     let err = run_tests(source, &config).expect_err("gen/type mismatch must be rejected");
+    assert!(
+        err.contains("generator") && err.contains("incompatible"),
+        "error should include generator/type mismatch, got: {err}"
+    );
+}
+
+#[test]
+fn run_tests_rejects_set_gen_spec_type_mismatch_before_execution() {
+    let config = test_config();
+    let source = "property p(s: Set<Int> <- Gen.int()) { true }";
+    let err = run_tests(source, &config).expect_err("set gen/type mismatch must be rejected");
     assert!(
         err.contains("generator") && err.contains("incompatible"),
         "error should include generator/type mismatch, got: {err}"
@@ -543,6 +568,19 @@ fn run_project_tests_rejects_gen_spec_type_mismatch_before_execution() {
         write_project(&[("main.ky", "property p(x: Int <- Gen.bool()) { x > 0 }\n")]);
     let err =
         run_project_tests(&main_path, &config).expect_err("project mismatch must be rejected");
+    assert!(
+        err.contains("generator") && err.contains("incompatible"),
+        "error should include generator/type mismatch, got: {err}"
+    );
+}
+
+#[test]
+fn run_project_tests_rejects_set_gen_spec_type_mismatch_before_execution() {
+    let config = test_config();
+    let (_dir, main_path) =
+        write_project(&[("main.ky", "property p(s: Set<Int> <- Gen.int()) { true }\n")]);
+    let err =
+        run_project_tests(&main_path, &config).expect_err("project set mismatch must be rejected");
     assert!(
         err.contains("generator") && err.contains("incompatible"),
         "error should include generator/type mismatch, got: {err}"


### PR DESCRIPTION
## Summary
- fix #288 by treating `Set` as a known builtin in property generator/type compatibility checks
- add regression coverage so `check` and `test` reject `Set<Int> <- Gen.int()` before execution
- fix #287 by making formatter preserve parse-damaged `effect` declarations verbatim (non-lossy)
- add formatter regression tests for effect body/type-parameter cases

## Tests
- cargo test -p kyokara-pbt --test integration
- cargo test -p kyokara-fmt --test fmt_tests
- cargo test -p kyokara-hir-def --test lower_tests
