### PR TITLE
Add iteration ergonomics APIs (range/enumerate/zip/chunks/windows)

### DIFF
--- a/crates/api/tests/api_tests.rs
+++ b/crates/api/tests/api_tests.rs
@@ -3965,6 +3965,57 @@ fn check_list_binary_search_sortable_elements_have_no_e0025() {
     );
 }
 
+// ── Iteration ergonomics API checks (#259) ─────────────────────────
+
+#[test]
+fn check_iteration_ergonomics_canonical_surface_has_no_diagnostics() {
+    assert_check_no_diagnostics(
+        r#"fn main() -> Bool {
+            let xs = List.range(0, 5)
+            let e = xs.enumerate()
+            let z = xs.zip(List.new().push(10).push(20))
+            let c = xs.chunks(2)
+            let w = xs.windows(3)
+            e[0].index == 0 && e[0].value == 0 && z.len() == 2 && c.len() == 3 && w.len() == 3
+        }"#,
+        "iteration canonical surface",
+    );
+}
+
+#[test]
+fn check_iteration_ergonomics_chains_from_map_set_string_have_no_diagnostics() {
+    assert_check_no_diagnostics(
+        r#"fn main() -> Bool {
+            let m = Map.new().insert("x", 1).insert("y", 2)
+            let km = m.keys().enumerate()
+            let map_ok = km.len() == 2 && km[0].index == 0
+
+            let s = Set.new().insert("a").insert("b").insert("c")
+            let sc = s.values().chunks(2)
+            let set_ok = sc.len() == 2 && sc[1].len() == 1
+
+            let p = "abc".chars().zip(List.new().push(1).push(2))
+            let str_ok = p.len() == 2 && p[0].left == 'a' && p[1].right == 2
+
+            map_ok && set_ok && str_ok
+        }"#,
+        "iteration chaining from map/set/string",
+    );
+}
+
+#[test]
+fn check_non_canonical_free_range_function_reports_unresolved_name() {
+    let output = check("fn main() -> Int { range(0, 3).len() }", "test.ky");
+    assert!(
+        output
+            .diagnostics
+            .iter()
+            .any(|d| d.message.contains("unresolved name")),
+        "expected unresolved-name diagnostic for free `range`, got: {:?}",
+        output.diagnostics
+    );
+}
+
 // ── math.gcd/math.lcm type diagnostics (E0001) ──────────────────────
 
 #[test]

--- a/crates/eval/src/interpreter.rs
+++ b/crates/eval/src/interpreter.rs
@@ -1519,6 +1519,46 @@ impl Interpreter {
                 }
                 Ok(acc)
             }
+            IntrinsicFn::ListEnumerate => {
+                let Value::List(xs) = &args[0] else {
+                    return Err(RuntimeError::TypeError(
+                        "list_enumerate expects a List".into(),
+                    ));
+                };
+                let index_name = Name::new(&mut self.interner, "index");
+                let value_name = Name::new(&mut self.interner, "value");
+                let mut result = Vec::with_capacity(xs.len());
+                for (idx, value) in xs.iter().cloned().enumerate() {
+                    let idx = i64::try_from(idx).map_err(|_| RuntimeError::IntegerOverflow)?;
+                    result.push(Value::Record {
+                        fields: vec![(index_name, Value::Int(idx)), (value_name, value)],
+                        type_idx: None,
+                    });
+                }
+                Ok(Value::list(result))
+            }
+            IntrinsicFn::ListZip => {
+                let Value::List(xs) = &args[0] else {
+                    return Err(RuntimeError::TypeError(
+                        "list_zip expects List arguments".into(),
+                    ));
+                };
+                let Value::List(ys) = &args[1] else {
+                    return Err(RuntimeError::TypeError(
+                        "list_zip expects List arguments".into(),
+                    ));
+                };
+                let left_name = Name::new(&mut self.interner, "left");
+                let right_name = Name::new(&mut self.interner, "right");
+                let mut result = Vec::with_capacity(usize::min(xs.len(), ys.len()));
+                for (left, right) in xs.iter().cloned().zip(ys.iter().cloned()) {
+                    result.push(Value::Record {
+                        fields: vec![(left_name, left), (right_name, right)],
+                        type_idx: None,
+                    });
+                }
+                Ok(Value::list(result))
+            }
             IntrinsicFn::ListSortBy => {
                 let Value::List(xs) = &args[0] else {
                     return Err(RuntimeError::TypeError(

--- a/crates/eval/src/intrinsics.rs
+++ b/crates/eval/src/intrinsics.rs
@@ -35,6 +35,11 @@ pub enum IntrinsicFn {
     ListMap,
     ListFilter,
     ListFold,
+    ListRange,
+    ListEnumerate,
+    ListZip,
+    ListChunks,
+    ListWindows,
 
     // Map<K,V>
     MapNew,
@@ -124,6 +129,8 @@ impl IntrinsicFn {
                 | IntrinsicFn::ListMap
                 | IntrinsicFn::ListFilter
                 | IntrinsicFn::ListFold
+                | IntrinsicFn::ListEnumerate
+                | IntrinsicFn::ListZip
                 | IntrinsicFn::MapGet
                 | IntrinsicFn::ListSortBy
                 | IntrinsicFn::ParseInt
@@ -242,6 +249,73 @@ impl IntrinsicFn {
                 let mut result = a.as_ref().clone();
                 result.extend(b.iter().cloned());
                 Ok(Value::list(result))
+            }
+            IntrinsicFn::ListRange => {
+                let Value::Int(start) = &args[0] else {
+                    return Err(RuntimeError::TypeError(
+                        "list_range expects Int arguments".into(),
+                    ));
+                };
+                let Value::Int(end) = &args[1] else {
+                    return Err(RuntimeError::TypeError(
+                        "list_range expects Int arguments".into(),
+                    ));
+                };
+                if start >= end {
+                    return Ok(Value::list(Vec::new()));
+                }
+                let values: Vec<Value> = (*start..*end).map(Value::Int).collect();
+                Ok(Value::list(values))
+            }
+            IntrinsicFn::ListChunks => {
+                let Value::List(xs) = &args[0] else {
+                    return Err(RuntimeError::TypeError("list_chunks expects a List".into()));
+                };
+                let Value::Int(n) = &args[1] else {
+                    return Err(RuntimeError::TypeError(
+                        "list_chunks expects an Int chunk size".into(),
+                    ));
+                };
+                if *n <= 0 {
+                    return Err(RuntimeError::TypeError(
+                        "list_chunks: chunk size must be > 0".into(),
+                    ));
+                }
+                let chunk_size = *n as usize;
+                let mut chunks = Vec::new();
+                let mut i = 0usize;
+                while i < xs.len() {
+                    let end = usize::min(i + chunk_size, xs.len());
+                    chunks.push(Value::list(xs[i..end].to_vec()));
+                    i += chunk_size;
+                }
+                Ok(Value::list(chunks))
+            }
+            IntrinsicFn::ListWindows => {
+                let Value::List(xs) = &args[0] else {
+                    return Err(RuntimeError::TypeError(
+                        "list_windows expects a List".into(),
+                    ));
+                };
+                let Value::Int(n) = &args[1] else {
+                    return Err(RuntimeError::TypeError(
+                        "list_windows expects an Int window size".into(),
+                    ));
+                };
+                if *n <= 0 {
+                    return Err(RuntimeError::TypeError(
+                        "list_windows: window size must be > 0".into(),
+                    ));
+                }
+                let window_size = *n as usize;
+                if window_size > xs.len() {
+                    return Ok(Value::list(Vec::new()));
+                }
+                let mut windows = Vec::with_capacity(xs.len() - window_size + 1);
+                for i in 0..=(xs.len() - window_size) {
+                    windows.push(Value::list(xs[i..(i + window_size)].to_vec()));
+                }
+                Ok(Value::list(windows))
             }
 
             // ── Map (simple) ─────────────────────────────────────
@@ -862,6 +936,8 @@ impl IntrinsicFn {
             | IntrinsicFn::ListMap
             | IntrinsicFn::ListFilter
             | IntrinsicFn::ListFold
+            | IntrinsicFn::ListEnumerate
+            | IntrinsicFn::ListZip
             | IntrinsicFn::MapGet
             | IntrinsicFn::ListSortBy => Err(RuntimeError::TypeError(
                 "complex intrinsic called without interpreter context".into(),
@@ -904,6 +980,17 @@ pub fn all_intrinsics(interner: &mut Interner) -> Vec<(Name, IntrinsicFn)> {
         (Name::new(interner, "list_map"), IntrinsicFn::ListMap),
         (Name::new(interner, "list_filter"), IntrinsicFn::ListFilter),
         (Name::new(interner, "list_fold"), IntrinsicFn::ListFold),
+        (Name::new(interner, "list_range"), IntrinsicFn::ListRange),
+        (
+            Name::new(interner, "list_enumerate"),
+            IntrinsicFn::ListEnumerate,
+        ),
+        (Name::new(interner, "list_zip"), IntrinsicFn::ListZip),
+        (Name::new(interner, "list_chunks"), IntrinsicFn::ListChunks),
+        (
+            Name::new(interner, "list_windows"),
+            IntrinsicFn::ListWindows,
+        ),
         // Map
         (Name::new(interner, "map_new"), IntrinsicFn::MapNew),
         (Name::new(interner, "map_insert"), IntrinsicFn::MapInsert),

--- a/crates/eval/tests/eval_tests.rs
+++ b/crates/eval/tests/eval_tests.rs
@@ -4967,6 +4967,144 @@ fn eval_list_sort_by_runtime_error() {
     assert!(err.contains("division by zero"), "got: {err}");
 }
 
+// ── Iteration ergonomics tests (#259) ──────────────────────────────
+
+#[test]
+fn eval_list_iteration_ergonomics_matrix() {
+    struct Case<'a> {
+        name: &'a str,
+        src: &'a str,
+        expected: Value,
+    }
+
+    let cases = [
+        Case {
+            name: "range half-open",
+            src: "fn main() -> Int {
+                let xs = List.range(0, 5)
+                xs.len() * 100 + xs[0] * 10 + xs[4]
+            }",
+            expected: Value::Int(504),
+        },
+        Case {
+            name: "range equal bounds empty",
+            src: "fn main() -> Int { List.range(3, 3).len() }",
+            expected: Value::Int(0),
+        },
+        Case {
+            name: "range descending empty",
+            src: "fn main() -> Int { List.range(5, 2).len() }",
+            expected: Value::Int(0),
+        },
+        Case {
+            name: "enumerate fields",
+            src: "fn main() -> Int {
+                let pairs = List.new().push(10).push(20).enumerate()
+                pairs[0].index + pairs[0].value + pairs[1].index + pairs[1].value
+            }",
+            expected: Value::Int(31),
+        },
+        Case {
+            name: "zip truncates",
+            src: "fn main() -> Int {
+                let pairs = List.new().push(1).push(2).push(3)
+                    .zip(List.new().push(10).push(20))
+                pairs.len() * 100 + pairs[0].left * 10 + pairs[1].right
+            }",
+            expected: Value::Int(230),
+        },
+        Case {
+            name: "chunks keeps tail",
+            src: "fn main() -> Int {
+                let cs = List.new().push(1).push(2).push(3).push(4).push(5).chunks(2)
+                cs.len() * 100 + cs[0].len() * 10 + cs[2].len()
+            }",
+            expected: Value::Int(321),
+        },
+        Case {
+            name: "windows overlap",
+            src: "fn main() -> Int {
+                let ws = List.new().push(1).push(2).push(3).push(4).push(5).windows(3)
+                ws.len() * 100 + ws[0][0] * 10 + ws[2][2]
+            }",
+            expected: Value::Int(315),
+        },
+        Case {
+            name: "windows larger than len empty",
+            src: "fn main() -> Int {
+                List.new().push(1).push(2).windows(6).len()
+            }",
+            expected: Value::Int(0),
+        },
+        Case {
+            name: "chaining from map set string",
+            src: "fn main() -> Bool {
+                let m = Map.new().insert(\"x\", 1).insert(\"y\", 2)
+                let km = m.keys().enumerate()
+                let map_ok = km.len() == 2 && km[0].index == 0 && km[0].value == \"x\"
+
+                let s = Set.new().insert(\"a\").insert(\"b\").insert(\"c\")
+                let sc = s.values().chunks(2)
+                let set_ok = sc.len() == 2 && sc[0].len() == 2 && sc[1].len() == 1
+
+                let p = \"abc\".chars().zip(List.new().push(10).push(20))
+                let string_ok = p.len() == 2 && p[0].left == 'a' && p[1].right == 20
+
+                map_ok && set_ok && string_ok
+            }",
+            expected: Value::Bool(true),
+        },
+    ];
+
+    for case in cases {
+        let got = run_ok(case.src);
+        assert_eq!(got, case.expected, "case `{}` failed", case.name);
+    }
+}
+
+#[test]
+fn eval_list_chunks_windows_invalid_sizes_report_direct_errors() {
+    struct Case<'a> {
+        name: &'a str,
+        src: &'a str,
+        expected_fragment: &'a str,
+    }
+
+    let cases = [
+        Case {
+            name: "chunks zero",
+            src: "fn main() -> Int { List.new().push(1).chunks(0).len() }",
+            expected_fragment: "list_chunks: chunk size must be > 0",
+        },
+        Case {
+            name: "chunks negative",
+            src: "fn main() -> Int { List.new().push(1).chunks(-1).len() }",
+            expected_fragment: "list_chunks: chunk size must be > 0",
+        },
+        Case {
+            name: "windows zero",
+            src: "fn main() -> Int { List.new().push(1).windows(0).len() }",
+            expected_fragment: "list_windows: window size must be > 0",
+        },
+        Case {
+            name: "windows negative",
+            src: "fn main() -> Int { List.new().push(1).windows(-3).len() }",
+            expected_fragment: "list_windows: window size must be > 0",
+        },
+    ];
+
+    for case in cases {
+        let err = run_err(case.src);
+        assert!(
+            err.contains(case.expected_fragment),
+            "case `{}` expected error containing `{}`, got: {}",
+            case.name,
+            case.expected_fragment,
+            err
+        );
+    }
+}
+
 // ── Index syntax tests ──────────────────────────────────────────────
 
 #[test]

--- a/crates/hir-def/src/builtins.rs
+++ b/crates/hir-def/src/builtins.rs
@@ -298,6 +298,10 @@ pub fn register_builtin_methods(scope: &mut ModuleScope, interner: &mut Interner
         ("list_map", "List", "map"),
         ("list_filter", "List", "filter"),
         ("list_fold", "List", "fold"),
+        ("list_enumerate", "List", "enumerate"),
+        ("list_zip", "List", "zip"),
+        ("list_chunks", "List", "chunks"),
+        ("list_windows", "List", "windows"),
         ("list_sort", "List", "sort"),
         ("list_sort_by", "List", "sort_by"),
         ("list_binary_search", "List", "binary_search"),
@@ -520,6 +524,7 @@ pub fn register_static_methods(scope: &mut ModuleScope, interner: &mut Interner)
     // (intrinsic_fn_name, type_name, static_method_name)
     let mappings: &[(&str, &str, &str)] = &[
         ("list_new", "List", "new"),
+        ("list_range", "List", "range"),
         ("map_new", "Map", "new"),
         ("set_new", "Set", "new"),
     ];
@@ -629,6 +634,10 @@ fn intrinsic_signatures(interner: &mut Interner) -> Vec<(Name, FnItem)> {
         path: Path::single(Name::new(interner, "List")),
         args: vec![u_ref.clone()],
     };
+    let list_list_t = TypeRef::Path {
+        path: Path::single(Name::new(interner, "List")),
+        args: vec![list_t.clone()],
+    };
     let list_k = TypeRef::Path {
         path: Path::single(Name::new(interner, "List")),
         args: vec![k_ref.clone()],
@@ -644,6 +653,30 @@ fn intrinsic_signatures(interner: &mut Interner) -> Vec<(Name, FnItem)> {
     let list_char = TypeRef::Path {
         path: Path::single(Name::new(interner, "List")),
         args: vec![char_ty.clone()],
+    };
+    let list_int = TypeRef::Path {
+        path: Path::single(Name::new(interner, "List")),
+        args: vec![int_ty.clone()],
+    };
+    let indexed_t = TypeRef::Record {
+        fields: vec![
+            (Name::new(interner, "index"), int_ty.clone()),
+            (Name::new(interner, "value"), t_ref.clone()),
+        ],
+    };
+    let list_indexed_t = TypeRef::Path {
+        path: Path::single(Name::new(interner, "List")),
+        args: vec![indexed_t],
+    };
+    let pair_tu = TypeRef::Record {
+        fields: vec![
+            (Name::new(interner, "left"), t_ref.clone()),
+            (Name::new(interner, "right"), u_ref.clone()),
+        ],
+    };
+    let list_pair_tu = TypeRef::Path {
+        path: Path::single(Name::new(interner, "List")),
+        args: vec![pair_tu],
     };
     let map_kv = TypeRef::Path {
         path: Path::single(Name::new(interner, "Map")),
@@ -804,6 +837,46 @@ fn intrinsic_signatures(interner: &mut Interner) -> Vec<(Name, FnItem)> {
                 ("f", fn_ut_to_u.clone()),
             ],
             u_ref.clone(),
+        ),
+        // list_range(start: Int, end: Int) -> List<Int>
+        mk_intrinsic(
+            interner,
+            "list_range",
+            vec![],
+            vec![("start", int_ty.clone()), ("end", int_ty.clone())],
+            list_int,
+        ),
+        // list_enumerate<T>(xs: List<T>) -> List<{ index: Int, value: T }>
+        mk_intrinsic(
+            interner,
+            "list_enumerate",
+            vec![t_name],
+            vec![("xs", list_t.clone())],
+            list_indexed_t,
+        ),
+        // list_zip<T, U>(xs: List<T>, ys: List<U>) -> List<{ left: T, right: U }>
+        mk_intrinsic(
+            interner,
+            "list_zip",
+            vec![t_name, u_name],
+            vec![("xs", list_t.clone()), ("ys", list_u.clone())],
+            list_pair_tu,
+        ),
+        // list_chunks<T>(xs: List<T>, n: Int) -> List<List<T>>
+        mk_intrinsic(
+            interner,
+            "list_chunks",
+            vec![t_name],
+            vec![("xs", list_t.clone()), ("n", int_ty.clone())],
+            list_list_t.clone(),
+        ),
+        // list_windows<T>(xs: List<T>, n: Int) -> List<List<T>>
+        mk_intrinsic(
+            interner,
+            "list_windows",
+            vec![t_name],
+            vec![("xs", list_t.clone()), ("n", int_ty.clone())],
+            list_list_t,
         ),
         // ── Map<K, V> ───────────────────────────────────────────
         // map_new<K, V>() -> Map<K, V>

--- a/crates/hir-ty/tests/infer_tests.rs
+++ b/crates/hir-ty/tests/infer_tests.rs
@@ -1,6 +1,10 @@
 //! End-to-end type inference tests: parse → collect item tree → lower → type check → assert.
 #![allow(clippy::unwrap_used)]
 
+use kyokara_hir_def::builtins::{
+    activate_synthetic_imports, register_builtin_intrinsics, register_builtin_methods,
+    register_builtin_types, register_static_methods, register_synthetic_modules,
+};
 use kyokara_hir_def::item_tree::lower::collect_item_tree;
 use kyokara_hir_ty::ty::Ty;
 use kyokara_hir_ty::{TypeCheckResult, check_module};
@@ -24,7 +28,29 @@ fn check(src: &str) -> (TypeCheckResult, Interner) {
     let root = parse_source(src);
     let sf = SourceFile::cast(root.clone()).unwrap();
     let mut interner = Interner::new();
-    let item_result = collect_item_tree(&sf, file_id(), &mut interner);
+    let mut item_result = collect_item_tree(&sf, file_id(), &mut interner);
+    register_builtin_types(
+        &mut item_result.tree,
+        &mut item_result.module_scope,
+        &mut interner,
+    );
+    register_builtin_intrinsics(
+        &mut item_result.tree,
+        &mut item_result.module_scope,
+        &mut interner,
+    );
+    register_builtin_methods(&mut item_result.module_scope, &mut interner);
+    register_synthetic_modules(
+        &mut item_result.tree,
+        &mut item_result.module_scope,
+        &mut interner,
+    );
+    activate_synthetic_imports(
+        &item_result.tree,
+        &mut item_result.module_scope,
+        &mut interner,
+    );
+    register_static_methods(&mut item_result.module_scope, &mut interner);
     let result = check_module(
         &root,
         &item_result.tree,
@@ -617,6 +643,87 @@ fn comparison_returns_bool() {
     check_ok("fn foo() -> Bool { 1 >= 2 }");
 }
 
+// ── Iteration ergonomics inference tests (#259) ────────────────────
+
+#[test]
+fn infer_iteration_ergonomics_happy_paths() {
+    let cases = ["fn main() -> Bool {
+            let xs = List.range(0, 5)
+            let e = xs.enumerate()
+            let z = xs.zip(List.new().push(10).push(20))
+            let c = xs.chunks(2)
+            let w = xs.windows(3)
+            e.len() > 0 && z.len() == 2 && c.len() == 3 && w.len() == 3
+        }"];
+
+    for src in cases {
+        let (result, _) = check(src);
+        assert!(
+            result.diagnostics.is_empty(),
+            "expected no diagnostics, got: {:?}\nsource:\n{src}",
+            result.diagnostics
+        );
+    }
+}
+
+#[test]
+fn err_iteration_ergonomics_wrong_arity_or_type() {
+    struct Case<'a> {
+        src: &'a str,
+        expected_fragment: &'a str,
+    }
+
+    let cases = [
+        Case {
+            src: "fn main() -> Int { List.range(0) }",
+            expected_fragment: "expected 2 argument(s)",
+        },
+        Case {
+            src: "fn main() -> Int { List.range(0, 3, 5).len() }",
+            expected_fragment: "expected 2 argument(s)",
+        },
+        Case {
+            src: "fn main() -> Int { List.range(true, 3).len() }",
+            expected_fragment: "type mismatch",
+        },
+        Case {
+            src: "fn main() -> Int { List.new().push(1).zip(1).len() }",
+            expected_fragment: "type mismatch",
+        },
+        Case {
+            src: "fn main() -> Int { List.new().push(1).chunks(true).len() }",
+            expected_fragment: "type mismatch",
+        },
+        Case {
+            src: "fn main() -> Int { List.new().push(1).windows(false).len() }",
+            expected_fragment: "type mismatch",
+        },
+    ];
+
+    for case in cases {
+        let (result, _) = check(case.src);
+        assert!(
+            result
+                .diagnostics
+                .iter()
+                .any(|d| d.message.contains(case.expected_fragment)),
+            "expected diagnostic containing `{}`; got: {:?}\nsource:\n{}",
+            case.expected_fragment,
+            result.diagnostics,
+            case.src
+        );
+        assert!(
+            result
+                .diagnostics
+                .iter()
+                .all(|d| !d.message.contains("unresolved name")),
+            "expected canonical surface to resolve names; got unresolved-name diagnostics: {:?}\nsource:\n{}",
+            result.diagnostics,
+            case.src
+        );
+    }
+}
+
 // ── Unresolved name tests ───────────────────────────────────────────
 
 #[test]
@@ -627,6 +734,11 @@ fn err_unresolved_name() {
 #[test]
 fn err_unresolved_name_in_expr() {
     check_err("fn main() -> Int { foo + 1 }", "unresolved name");
+}
+
+#[test]
+fn err_non_canonical_free_range_function_is_unresolved() {
+    check_err("fn main() -> Int { range(0, 3).len() }", "unresolved name");
 }
 
 // ── Unresolved-name diagnostics ─────────────────────────────────────

--- a/docs/design-v0.md
+++ b/docs/design-v0.md
@@ -544,8 +544,10 @@ while `io`/`fs` are module namespaces for no-owner/effectful operations.
 * `ParseError` — builtin ADT (`InvalidInt(String) | InvalidFloat(String)`), used as error type for `parse_int`/`parse_float` ✓
 * `List<T>` — opaque builtin type with COW-backed persistent runtime storage (`Rc<Vec<Value>>`) ✓
   * Constructor: `List.new()`
+  * Static helpers: `List.range(start, end)` returns half-open ascending range `[start, end)` (empty when `start >= end`)
   * Methods: `xs.push(v)`, `xs.len()`, `xs.get(i)` → `Option<T>`, `xs.head()` → `Option<T>`, `xs.tail()`, `xs.is_empty()`, `xs.reverse()`, `xs.concat(ys)`
   * Higher-order: `xs.map(f)`, `xs.filter(f)`, `xs.fold(init, f)`, `xs.sort()`, `xs.sort_by(f)`
+  * Iteration ergonomics: `xs.enumerate()` → `List<{ index: Int, value: T }>`, `xs.zip(ys)` → `List<{ left: T, right: U }>`, `xs.chunks(n)` → `List<List<T>>`, `xs.windows(n)` → `List<List<T>>` (`chunks/windows` require `n > 0`)
   * Search helper: `xs.binary_search(x)` → `Int` with Rust/Java-style insertion contract:
     found index returns `>= 0`; missing element returns `-(insertion_point + 1)`.
     `insertion_point` is where `x` would be inserted to keep sorted order.


### PR DESCRIPTION
## Summary
Add canonical List iteration ergonomics APIs for AoC readiness:
- `List.range(start, end)`
- `xs.enumerate()`
- `xs.zip(ys)`
- `xs.chunks(n)`
- `xs.windows(n)`

## Details
- Wired builtin signatures and canonical method/static mappings.
- Implemented runtime behavior and edge-case semantics.
- Added table-driven eval/type/api tests for happy paths and misuse.
- Updated stdlib docs in `design-v0.md`.
- Added runtime guards for `chunks/windows` when `n <= 0`.

## Follow-up
- Ergonomic type-level size constraints tracked in #290.

Closes #259
