### PR TITLE
feat(result): add unwrap_or and map_or methods

### DIFF
--- a/crates/api/tests/api_tests.rs
+++ b/crates/api/tests/api_tests.rs
@@ -4004,6 +4004,36 @@ fn check_iteration_ergonomics_chains_from_map_set_string_have_no_diagnostics() {
 }
 
 #[test]
+fn check_result_ergonomics_canonical_surface_has_no_diagnostics() {
+    assert_check_no_diagnostics(
+        r#"fn main() -> Int {
+            let a = "42".parse_int().unwrap_or(0)
+            let b = "oops".parse_int().map_or(7, fn(n: Int) => n + 1)
+            a + b
+        }"#,
+        "result ergonomics canonical surface",
+    );
+}
+
+#[test]
+fn check_result_map_or_wrong_mapper_type_reports_type_mismatch() {
+    let output = check(
+        r#"fn main() -> Int {
+            "42".parse_int().map_or(0, fn(n: Int) => "x")
+        }"#,
+        "test.ky",
+    );
+    assert!(
+        output
+            .diagnostics
+            .iter()
+            .any(|d| d.code == "E0001" && d.message.contains("type mismatch")),
+        "expected E0001 type mismatch for result map_or mapper result type, got: {:?}",
+        output.diagnostics
+    );
+}
+
+#[test]
 fn check_non_canonical_free_range_function_reports_unresolved_name() {
     let output = check("fn main() -> Int { range(0, 3).len() }", "test.ky");
     assert!(

--- a/crates/eval/src/interpreter.rs
+++ b/crates/eval/src/interpreter.rs
@@ -1400,6 +1400,62 @@ impl Interpreter {
         }
     }
 
+    /// Decode a `Result` value into `Some(ok_payload)` for `Ok`, `None` for `Err`.
+    ///
+    /// We resolve by type/variant names (`Result`, `Ok`, `Err`) so user shadowing
+    /// cannot silently reinterpret non-result ADTs.
+    fn decode_result_ok_payload(
+        &mut self,
+        value: &Value,
+        intrinsic_name: &str,
+    ) -> Result<Option<Value>, RuntimeError> {
+        let Value::Adt {
+            type_idx,
+            variant,
+            fields,
+        } = value
+        else {
+            return Err(RuntimeError::TypeError(format!(
+                "{intrinsic_name} expects a Result value"
+            )));
+        };
+
+        let result_name = Name::new(&mut self.interner, "Result");
+        if self.item_tree.types[*type_idx].name != result_name {
+            return Err(RuntimeError::TypeError(format!(
+                "{intrinsic_name} expects a Result value"
+            )));
+        }
+
+        let TypeDefKind::Adt { variants } = &self.item_tree.types[*type_idx].kind else {
+            return Err(RuntimeError::TypeError(format!(
+                "{intrinsic_name} expects a Result ADT"
+            )));
+        };
+        let Some(variant_def) = variants.get(*variant) else {
+            return Err(RuntimeError::TypeError(format!(
+                "{intrinsic_name} received invalid Result variant index"
+            )));
+        };
+
+        let ok_name = Name::new(&mut self.interner, "Ok");
+        let err_name = Name::new(&mut self.interner, "Err");
+        if variant_def.name == ok_name {
+            if fields.len() != 1 {
+                return Err(RuntimeError::TypeError(format!(
+                    "{intrinsic_name} expects Result::Ok to carry one value"
+                )));
+            }
+            Ok(Some(fields[0].clone()))
+        } else if variant_def.name == err_name {
+            Ok(None)
+        } else {
+            Err(RuntimeError::TypeError(format!(
+                "{intrinsic_name} expects Result::Ok/Err variants"
+            )))
+        }
+    }
+
     fn make_invalid_int(&self, msg: String) -> Result<Value, RuntimeError> {
         let Some((type_idx, variant)) = self.parse_error_invalid_int else {
             return Err(RuntimeError::TypeError(
@@ -1592,6 +1648,21 @@ impl Interpreter {
                     }
                 }
                 Ok(Value::list(items))
+            }
+            IntrinsicFn::ResultUnwrapOr => {
+                let fallback = args[1].clone();
+                match self.decode_result_ok_payload(&args[0], "result_unwrap_or")? {
+                    Some(v) => Ok(v),
+                    None => Ok(fallback),
+                }
+            }
+            IntrinsicFn::ResultMapOr => {
+                let fallback = args[1].clone();
+                let mapper = args[2].clone();
+                match self.decode_result_ok_payload(&args[0], "result_map_or")? {
+                    Some(v) => self.call_value(mapper, smallvec::smallvec![v]),
+                    None => Ok(fallback),
+                }
             }
             IntrinsicFn::ParseInt => {
                 let Value::String(s) = &args[0] else {

--- a/crates/eval/src/intrinsics.rs
+++ b/crates/eval/src/intrinsics.rs
@@ -59,6 +59,9 @@ pub enum IntrinsicFn {
     SetLen,
     SetIsEmpty,
     SetValues,
+    // Result<T, E>
+    ResultUnwrapOr,
+    ResultMapOr,
 
     // String ops
     StringLen,
@@ -133,6 +136,8 @@ impl IntrinsicFn {
                 | IntrinsicFn::ListZip
                 | IntrinsicFn::MapGet
                 | IntrinsicFn::ListSortBy
+                | IntrinsicFn::ResultUnwrapOr
+                | IntrinsicFn::ResultMapOr
                 | IntrinsicFn::ParseInt
                 | IntrinsicFn::ParseFloat
         )
@@ -689,8 +694,11 @@ impl IntrinsicFn {
             }
 
             // ── Parsing (now complex — needs interpreter for Result construction) ──
-            IntrinsicFn::ParseInt | IntrinsicFn::ParseFloat => Err(RuntimeError::TypeError(
-                "parse intrinsics need interpreter context for Result construction".into(),
+            IntrinsicFn::ResultUnwrapOr
+            | IntrinsicFn::ResultMapOr
+            | IntrinsicFn::ParseInt
+            | IntrinsicFn::ParseFloat => Err(RuntimeError::TypeError(
+                "intrinsic needs interpreter context".into(),
             )),
 
             // ── String decomposition ──────────────────────────────
@@ -1015,6 +1023,11 @@ pub fn all_intrinsics(interner: &mut Interner) -> Vec<(Name, IntrinsicFn)> {
         (Name::new(interner, "set_len"), IntrinsicFn::SetLen),
         (Name::new(interner, "set_is_empty"), IntrinsicFn::SetIsEmpty),
         (Name::new(interner, "set_values"), IntrinsicFn::SetValues),
+        (
+            Name::new(interner, "result_unwrap_or"),
+            IntrinsicFn::ResultUnwrapOr,
+        ),
+        (Name::new(interner, "result_map_or"), IntrinsicFn::ResultMapOr),
         // String
         (Name::new(interner, "string_len"), IntrinsicFn::StringLen),
         (

--- a/crates/eval/tests/eval_tests.rs
+++ b/crates/eval/tests/eval_tests.rs
@@ -4089,6 +4089,38 @@ fn eval_parse_int_overflow_fails() {
     assert_eq!(val, Value::Bool(true));
 }
 
+#[test]
+fn eval_parse_int_unwrap_or_ok_returns_inner_value() {
+    let val = run_ok(r#"fn main() -> Int { "42".parse_int().unwrap_or(0) }"#);
+    assert_eq!(val, Value::Int(42));
+}
+
+#[test]
+fn eval_parse_int_unwrap_or_err_returns_default() {
+    let val = run_ok(r#"fn main() -> Int { "oops".parse_int().unwrap_or(7) }"#);
+    assert_eq!(val, Value::Int(7));
+}
+
+#[test]
+fn eval_parse_int_map_or_ok_applies_mapper() {
+    let val = run_ok(
+        r#"fn main() -> Int {
+            "41".parse_int().map_or(0, fn(n: Int) => n + 1)
+        }"#,
+    );
+    assert_eq!(val, Value::Int(42));
+}
+
+#[test]
+fn eval_parse_int_map_or_err_returns_default() {
+    let val = run_ok(
+        r#"fn main() -> Int {
+            "oops".parse_int().map_or(9, fn(n: Int) => n + 1)
+        }"#,
+    );
+    assert_eq!(val, Value::Int(9));
+}
+
 // ── parse_float tests ───────────────────────────────────────────────
 // parse_float returns Result<Float, ParseError>.
 

--- a/crates/hir-def/src/builtins.rs
+++ b/crates/hir-def/src/builtins.rs
@@ -321,6 +321,9 @@ pub fn register_builtin_methods(scope: &mut ModuleScope, interner: &mut Interner
         ("set_len", "Set", "len"),
         ("set_is_empty", "Set", "is_empty"),
         ("set_values", "Set", "values"),
+        // Result methods
+        ("result_unwrap_or", "Result", "unwrap_or"),
+        ("result_map_or", "Result", "map_or"),
         // Int methods
         ("int_to_string", "Int", "to_string"),
         ("int_to_float", "Int", "to_float"),
@@ -604,6 +607,7 @@ fn intrinsic_signatures(interner: &mut Interner) -> Vec<(Name, FnItem)> {
     // Type parameter names.
     let t_name = Name::new(interner, "T");
     let u_name = Name::new(interner, "U");
+    let e_name = Name::new(interner, "E");
     let k_name = Name::new(interner, "K");
     let v_name = Name::new(interner, "V");
 
@@ -614,6 +618,10 @@ fn intrinsic_signatures(interner: &mut Interner) -> Vec<(Name, FnItem)> {
     };
     let u_ref = TypeRef::Path {
         path: Path::single(u_name),
+        args: Vec::new(),
+    };
+    let e_ref = TypeRef::Path {
+        path: Path::single(e_name),
         args: Vec::new(),
     };
     let k_ref = TypeRef::Path {
@@ -689,6 +697,10 @@ fn intrinsic_signatures(interner: &mut Interner) -> Vec<(Name, FnItem)> {
     let option_t = TypeRef::Path {
         path: Path::single(Name::new(interner, "Option")),
         args: vec![t_ref.clone()],
+    };
+    let result_te = TypeRef::Path {
+        path: Path::single(Name::new(interner, "Result")),
+        args: vec![t_ref.clone(), e_ref.clone()],
     };
     let option_v = TypeRef::Path {
         path: Path::single(Name::new(interner, "Option")),
@@ -1005,6 +1017,26 @@ fn intrinsic_signatures(interner: &mut Interner) -> Vec<(Name, FnItem)> {
             vec![t_name],
             vec![("s", set_t.clone())],
             list_t.clone(),
+        ),
+        // result_unwrap_or<T, E>(r: Result<T, E>, fallback: T) -> T
+        mk_intrinsic(
+            interner,
+            "result_unwrap_or",
+            vec![t_name, e_name],
+            vec![("r", result_te.clone()), ("fallback", t_ref.clone())],
+            t_ref.clone(),
+        ),
+        // result_map_or<T, E, U>(r: Result<T, E>, fallback: U, f: fn(T) -> U) -> U
+        mk_intrinsic(
+            interner,
+            "result_map_or",
+            vec![t_name, e_name, u_name],
+            vec![
+                ("r", result_te),
+                ("fallback", u_ref.clone()),
+                ("f", fn_t_to_u.clone()),
+            ],
+            u_ref.clone(),
         ),
         // ── String ops ──────────────────────────────────────────
         // string_len(s: String) -> Int

--- a/crates/hir-ty/tests/infer_tests.rs
+++ b/crates/hir-ty/tests/infer_tests.rs
@@ -667,6 +667,70 @@ fn infer_iteration_ergonomics_happy_paths() {
 }
 
 #[test]
+fn infer_result_ergonomics_happy_paths() {
+    let cases = [
+        "fn main() -> Int { \"42\".parse_int().unwrap_or(0) }",
+        "fn main() -> Int { \"42\".parse_int().map_or(0, fn(n: Int) => n + 1) }",
+        "fn main() -> Int { \"abc\".parse_int().map_or(7, fn(n: Int) => n + 1) }",
+    ];
+
+    for src in cases {
+        let (result, _) = check(src);
+        assert!(
+            result.diagnostics.is_empty(),
+            "expected no diagnostics, got: {:?}\nsource:\n{src}",
+            result.diagnostics
+        );
+    }
+}
+
+#[test]
+fn err_result_ergonomics_wrong_types_or_arity() {
+    struct Case<'a> {
+        src: &'a str,
+        expected_fragment: &'a str,
+    }
+
+    let cases = [
+        Case {
+            src: "fn main() -> Int { \"42\".parse_int().unwrap_or(\"x\") }",
+            expected_fragment: "type mismatch",
+        },
+        Case {
+            src: "fn main() -> Int { \"42\".parse_int().map_or(0) }",
+            expected_fragment: "expected 2 argument(s)",
+        },
+        Case {
+            src: "fn main() -> Int { \"42\".parse_int().map_or(0, fn(n: Int) => \"x\") }",
+            expected_fragment: "type mismatch",
+        },
+    ];
+
+    for case in cases {
+        let (result, _) = check(case.src);
+        assert!(
+            result
+                .diagnostics
+                .iter()
+                .any(|d| d.message.contains(case.expected_fragment)),
+            "expected diagnostic containing `{}`; got: {:?}\nsource:\n{}",
+            case.expected_fragment,
+            result.diagnostics,
+            case.src
+        );
+        assert!(
+            result
+                .diagnostics
+                .iter()
+                .all(|d| !d.message.contains("unresolved name")),
+            "expected canonical surface to resolve names; got unresolved-name diagnostics: {:?}\nsource:\n{}",
+            result.diagnostics,
+            case.src
+        );
+    }
+}
+
+#[test]
 fn err_iteration_ergonomics_wrong_arity_or_type() {
     struct Case<'a> {
         src: &'a str,

--- a/docs/design-v0.md
+++ b/docs/design-v0.md
@@ -541,6 +541,7 @@ while `io`/`fs` are module namespaces for no-owner/effectful operations.
 **Implemented (v0.1+):**
 * `Option<T>` — builtin ADT (`Some(T) | None`), used as return type for safe lookups ✓
 * `Result<T, E>` — builtin ADT (`Ok(T) | Err(E)`), `?` propagation works ✓
+  * Methods: `r.unwrap_or(fallback)`, `r.map_or(fallback, f)`
 * `ParseError` — builtin ADT (`InvalidInt(String) | InvalidFloat(String)`), used as error type for `parse_int`/`parse_float` ✓
 * `List<T>` — opaque builtin type with COW-backed persistent runtime storage (`Rc<Vec<Value>>`) ✓
   * Constructor: `List.new()`

--- a/docs/rfcs/0001-api-surface-law.md
+++ b/docs/rfcs/0001-api-surface-law.md
@@ -3,7 +3,7 @@
 - Status: Draft
 - Owner: Language Design
 - Tracking issue: [#243](https://github.com/kyokaralang/kyokara/issues/243)
-- Last updated: 2026-03-01
+- Last updated: 2026-03-02
 
 ## Summary
 
@@ -112,6 +112,9 @@ Canonical parsing forms for numeric text:
 
 - `s.parse_int() -> Result[Int, ParseError]`
 - `s.parse_float() -> Result[Float, ParseError]`
+- canonical fallback/composition on `Result`:
+  - `s.parse_int().unwrap_or(0)`
+  - `s.parse_int().map_or(0, fn(n: Int) => n + 1)`
 
 Non-canonical aliases must not be introduced as parallel public APIs:
 


### PR DESCRIPTION
## Summary
- add `Result.unwrap_or(fallback)` and `Result.map_or(fallback, f)` as canonical methods
- wire builtin signatures, method resolution, and eval intrinsics/interpreter behavior
- add red-first regression tests in hir-ty/eval/api
- update design and API-surface docs

## Validation
- cargo test -p kyokara-hir-def
- cargo test -p kyokara-hir-ty
- cargo test -p kyokara-eval
- cargo test -p kyokara-api
- cargo test
