### PR TITLE
docs: resync language docs with current parser and stdlib

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,8 +57,8 @@ contract
   requires (amt.amount > 0)
   requires (amt.currency == acct.balance.currency)
   ensures (match (result) {
-    Ok(a) => a.balance.amount == old(acct.balance.amount) - amt.amount,
-    Err(_) => true,
+    Ok(a) => a.balance.amount == old(acct.balance.amount) - amt.amount
+    Err(_) => true
   })
 {
   ...
@@ -69,7 +69,7 @@ Legacy direct-clause form (without `contract`) is invalid in v0.
 
 ```kyokara
 property sort_idempotent(xs: List<Int> <- Gen.auto()) {
-  List.sort(List.sort(xs)) == List.sort(xs)
+  xs.sort().sort() == xs.sort()
 }
 ```
 
@@ -83,7 +83,7 @@ Code doesn't have to be finished to be useful. Kyokara compiles incomplete progr
 
 ```kyokara
 fn normalize_email(s: String) -> String {
-  let trimmed = String.trim(s)
+  let trimmed = s.trim()
   let lowered = _   // hole: expects String, must be pure
   lowered
 }
@@ -153,7 +153,7 @@ pub fn currency_symbol(c: Currency) -> String {
 import math
 
 fn main() -> Int {
-  let result = math.add_fee(Money { amount: 1000, currency: USD }, 250)
+  let result = add_fee(Money { amount: 1000, currency: USD }, 250)
   result.amount
 }
 ```

--- a/docs/design-v0.md
+++ b/docs/design-v0.md
@@ -36,7 +36,7 @@ Support "almost valid" programs:
 ### 1.2 Intent is explicit and checkable
 First-class specification:
 - preconditions/postconditions (`contract` section with `requires`/`ensures`/`invariant`)
-- property-based tests (`property name(x: T <- Gen.auto()) where pred { body }`)
+- property-based tests (`property name(x: T <- Gen.auto()) where (pred) { body }`)
 - optional refinement constraints (`type PositiveInt = Int where x>0`)
 
 ### 1.3 Determinism by default
@@ -138,8 +138,8 @@ Purity default:
 
 ```kyokara
 fn add_fee(x: Money, fee_bps: Int) -> Money {
-  let fee = Money { amount: x.amount * fee_bps / 10_000, currency: x.currency }
-  Money { amount: x.amount + fee.amount, currency: x.currency }
+  let fee = x.amount * fee_bps / 10_000
+  Money { amount: x.amount + fee, currency: x.currency }
 }
 ```
 
@@ -196,8 +196,8 @@ contract
   requires (amt.amount > 0)
   requires (amt.currency == acct.balance.currency)
   ensures (match (result) {
-    Ok(a2) => a2.balance.amount == old(acct.balance.amount) - amt.amount,
-    Err(_) => true,
+    Ok(a2) => a2.balance.amount == old(acct.balance.amount) - amt.amount
+    Err(_) => true
   })
 {
   ...
@@ -220,7 +220,7 @@ fn withdraw(acct: Account, amt: Money) -> Result<Account, WithdrawError>
 
 ```kyokara
 property sort_idempotent(xs: List<Int> <- Gen.auto()) {
-  List.sort(List.sort(xs)) == List.sort(xs)
+  xs.sort().sort() == xs.sort()
 }
 
 property add_commutative(a: Int <- Gen.auto(), b: Int <- Gen.auto()) {
@@ -250,8 +250,8 @@ Holes are legal syntax:
 
 ```kyokara
 fn normalize_email(s: String) -> String {
-  let trimmed = String.trim(s)
-  let lowered = lowercase(trimmed)
+  let trimmed = s.trim()
+  let lowered = _   // expression hole
   lowered
 }
 ```
@@ -270,13 +270,13 @@ Rules:
 Surface:
 
 ```kyokara
-x |> f(a=1, b=2)
+x |> f(a: 1, b: 2)
 ```
 
 Desugars to:
 
 ```kyokara
-f(x, a=1, b=2)
+f(x, a: 1, b: 2)
 ```
 
 Rules:
@@ -286,7 +286,9 @@ Rules:
 * optionally, function declarations can mark an explicit pipe parameter:
 
   ```kyokara
-  fn split(text: String, sep: String) -> List<String> pipe text = ...
+  fn split(text: String, sep: String) -> List<String> pipe text {
+    text.split(sep)
+  }
   ```
 
   then `|>` binds to that parameter.
@@ -296,7 +298,7 @@ Rules:
 Provide `?` postfix sugar to propagate `Err`:
 
 ```kyokara
-let body = Http.get(url=... )?
+let body = Http.get(url: "...")?
 ```
 
 Desugars to a `match` returning early on `Err`.

--- a/docs/rfcs/0001-api-surface-law.md
+++ b/docs/rfcs/0001-api-surface-law.md
@@ -110,8 +110,8 @@ Principle:
 
 Canonical parsing forms for numeric text:
 
-- `s.parse_int() -> Result[Int, ParseError]`
-- `s.parse_float() -> Result[Float, ParseError]`
+- `s.parse_int() -> Result<Int, ParseError>`
+- `s.parse_float() -> Result<Float, ParseError>`
 - canonical fallback/composition on `Result`:
   - `s.parse_int().unwrap_or(0)`
   - `s.parse_int().map_or(0, fn(n: Int) => n + 1)`

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -60,7 +60,7 @@ ADTs (tagged unions):
 
 ```kyokara
 type Currency =
-  | USD
+  USD
   | IDR
   | EUR
 
@@ -80,20 +80,21 @@ No `null` in the language — use `Option<T>`.
 Functions are pure by default:
 
 ```kyokara
-fn add_fee(x: Money, fee_bps: Int) -> Money =
-  let fee = { amount = x.amount * fee_bps / 10_000, currency = x.currency }
-  { amount = x.amount + fee.amount, currency = x.currency }
+fn add_fee(x: Money, fee_bps: Int) -> Money {
+  let fee = x.amount * fee_bps / 10_000
+  Money { amount: x.amount + fee, currency: x.currency }
+}
 ```
 
 ### Capabilities and Effects
 
-Declare capabilities:
+Declare effects:
 
 ```kyokara
-cap Net
-cap Clock
-cap Db
-cap Secrets
+effect Net
+effect Clock
+effect Db
+effect Secrets
 ```
 
 Annotate effect requirements:
@@ -145,7 +146,7 @@ Legacy direct-clause form (without `contract`) is invalid in v0.
 
 ```kyokara
 property sort_idempotent(xs: List<Int> <- Gen.auto()) {
-  List.sort(List.sort(xs)) == List.sort(xs)
+  xs.sort().sort() == xs.sort()
 }
 ```
 
@@ -167,8 +168,8 @@ The `where` expression is lowered as a precondition. Candidates violating the co
 
 ```kyokara
 fn normalize_email(s: String) -> String {
-  let trimmed = String.trim(s)
-  let lowered = lowercase(trimmed)
+  let trimmed = s.trim()
+  let lowered = _   // expression hole
   lowered
 }
 ```
@@ -178,19 +179,21 @@ Holes carry an expected type from context. The compiler emits machine-readable h
 ### Pipeline Operator
 
 ```kyokara
-x |> f(a=1, b=2)
+x |> f(a: 1, b: 2)
 ```
 
-Desugars to `f(x, a=1, b=2)`. Pipeline feeds the first parameter positionally. Argument expressions are evaluated left-to-right in source order before slot binding, and positional arguments must come before named arguments. Functions can declare an explicit pipe parameter:
+Desugars to `f(x, a: 1, b: 2)`. Pipeline feeds the first parameter positionally. Argument expressions are evaluated left-to-right in source order before slot binding, and positional arguments must come before named arguments. Functions can declare an explicit pipe parameter:
 
 ```kyokara
-fn split(text: String, sep: String) -> List<String> pipe text = ...
+fn split(text: String, sep: String) -> List<String> pipe text {
+  text.split(sep)
+}
 ```
 
 ### Error Propagation
 
 ```kyokara
-let body = Http.get(url=...)?
+let body = Http.get(url: "...")?
 ```
 
 `?` postfix desugars to a `match` returning early on `Err`.
@@ -369,16 +372,17 @@ cli             (depends: api, refactor, eval, pbt, fmt, hir, lsp, syntax, diagn
 - tracing 0.1: structured logging
 - text-size 1.1: TextRange/TextSize
 
-## Standard Library (Planned)
+## Core Standard Library (Implemented Surface)
 
-- `std.option` — `Option<T>` and combinators
-- `std.result` — `Result<T, E>` and combinators
-- `std.list` — `List<T>` (immutable linked list)
-- `std.map` — `Map[K, V]` (immutable ordered map)
-- `std.string` — string operations
-- `std.int` / `std.float` — numeric operations
-- `std.io` — basic text I/O (requires `IO` cap)
-- `std.test` — property test generators and assertions
+- Prelude value types: `Option<T>`, `Result<T, E>`, `List<T>`, `Seq<T>`, `Map<K, V>`, `Set<T>`, `ParseError`
+- Constructors: `List.new()`, `Seq.range(start, end)`, `Map.new()`, `Set.new()`
+- List storage methods: `push/len/get/head/tail/is_empty/reverse/concat/sort/sort_by/binary_search/seq`
+- Seq traversal methods: `map/filter/fold/enumerate/zip/chunks/windows/count/to_list`
+- Map methods: `insert/get/contains/remove/len/keys/values/is_empty`
+- Set methods: `insert/contains/remove/len/is_empty/values`
+- String methods: `len/contains/starts_with/ends_with/trim/split/substring/to_upper/to_lower/concat/lines/chars/parse_int/parse_float`
+- Capability modules (explicit import + manifest enforcement): `io.*`, `fs.*`
+- Pure utility module (explicit import): `math.*`
 
 ## Roadmap
 

--- a/llms.txt
+++ b/llms.txt
@@ -15,9 +15,9 @@
 - Explicit capabilities: `with Net`, `with Db`, `with Clock`, `with Secrets` — deny-by-default, manifest-enforced
 - ADTs and exhaustive pattern matching: `type Result<T, E> = Ok(T) | Err(E)`
 - Contracts: `contract` sections with `requires`/`ensures`/`invariant` clauses and `old()` — checked at runtime, optionally verified by SMT (restricted fragment, best-effort)
-- Property-based tests: `property name(x: T <- Gen.auto()) where pred { expr }` as first-class syntax, `<-` generator bindings (`Gen.auto()`, `Gen.int()`, `Gen.int_range(min, max)`, etc.), optional `where` constraints (discard-based), bodies type-checked (must return Bool)
-- Typed holes: `?name(args)` compiles to structured hole specs with expected type, effects, and constraints
-- Pipeline operator: `x |> f(a=1)` desugars to `f(x, a=1)`
+- Property-based tests: `property name(x: T <- Gen.auto()) where (pred) { expr }` as first-class syntax, `<-` generator bindings (`Gen.auto()`, `Gen.int()`, `Gen.int_range(min, max)`, etc.), optional `where` constraints (discard-based), bodies type-checked (must return Bool)
+- Typed holes: `_` compiles to structured hole specs with expected type, effects, and constraints
+- Pipeline operator: `x |> f(a: 1)` desugars to `f(x, a: 1)`
 - Error propagation: `expr?` desugars to early-return match on `Result`
 - No null, no exceptions: `Option<T>` and `Result<T, E>` only (builtin types, available without imports)
 

--- a/spec/grammar.md
+++ b/spec/grammar.md
@@ -1,63 +1,67 @@
 # Kyokara Formal Grammar
 
-> PEG-style reference grammar for the Kyokara language (v0.0).
-> This document is the authoritative specification for the parser.
+> PEG-style reference grammar for Kyokara (v0 parser contract).
+> This document tracks implemented parser behavior.
 
 ## Notation
 
-| Syntax       | Meaning                              |
-|--------------|--------------------------------------|
-| `'text'`     | Literal token                        |
-| `RULE`       | Reference to another rule            |
-| `a b`        | Sequence                             |
-| `a / b`      | Ordered choice                       |
-| `a?`         | Optional (zero or one)               |
-| `a*`         | Zero or more                         |
-| `a+`         | One or more                          |
-| `(a)`        | Grouping                             |
-| `!a`         | Not predicate (does not consume)     |
-| `&a`         | And predicate (does not consume)     |
+| Syntax | Meaning |
+|---|---|
+| `'text'` | Literal token |
+| `RULE` | Reference to another rule |
+| `a b` | Sequence |
+| `a / b` | Ordered choice |
+| `a?` | Optional |
+| `a*` | Zero or more |
+| `a+` | One or more |
+| `(a)` | Grouping |
 
 ---
 
 ## Lexical Grammar
 
 ```peg
-# ── Whitespace & Comments ────────────────────────────────────────────
-
-Whitespace    <- [ \t\n\r]+
-LineComment   <- '//' [^\n]*
-BlockComment  <- '/*' BlockCommentBody '*/'
+# Whitespace & comments
+Whitespace       <- [ \t\n\r]+
+LineComment      <- '//' [^\n]*
+BlockComment     <- '/*' BlockCommentBody '*/'
 BlockCommentBody <- (BlockComment / !'*/' .)*
 
-# ── Literals ─────────────────────────────────────────────────────────
+# Literals
+IntLiteral       <- [0-9] [0-9_]*
+FloatLiteral     <- [0-9] [0-9_]* '.' [0-9] [0-9_]*
+StringLiteral    <- '"' (StringChar)* '"'
+StringChar       <- '\\' . / [^"\\]
+CharLiteral      <- "'" ('\\' . / [^'\\]) "'"
 
-IntLiteral    <- [0-9] [0-9_]*
-FloatLiteral  <- [0-9] [0-9_]* '.' [0-9] [0-9_]*
-StringLiteral <- '"' (StringChar)* '"'
-StringChar    <- '\\' . / [^"\\]
-CharLiteral   <- "'" ('\\' . / [^'\\]) "'"
+# Identifiers (that are not keywords)
+Ident            <- [a-zA-Z_] [a-zA-Z0-9_]*
 
-# ── Identifiers & Keywords ───────────────────────────────────────────
+# Keywords
+# Note: `cap` is lexed as a reserved keyword for targeted diagnostics, but
+# item parsing rejects it and requires `effect` declarations.
+Keyword          <- 'module' / 'import' / 'as' / 'type' / 'fn' / 'let' / 'pub'
+                  / 'match' / 'cap' / 'effect' / 'with' / 'pipe' / 'contract'
+                  / 'requires' / 'ensures' / 'invariant'
+                  / 'property' / 'for' / 'all' / 'where'
+                  / 'old' / 'true' / 'false' / 'if' / 'else' / 'return'
 
-Ident         <- [a-zA-Z_] [a-zA-Z0-9_]*  # not a keyword
+# Operators
+Arrow            <- '->'
+LeftArrow        <- '<-'
+FatArrow         <- '=>'
+PipeGt           <- '|>'
+EqEq             <- '=='
+BangEq           <- '!='
+GtEq             <- '>='
+LtEq             <- '<='
+AmpAmp           <- '&&'
+PipePipe         <- '||'
+LtLt             <- '<<'
+GtGt             <- '>>'
 
-Keyword       <- 'module' / 'import' / 'as' / 'type' / 'fn' / 'let' / 'pub'
-               / 'match' / 'cap' / 'effect' / 'with' / 'pipe' / 'contract'
-               / 'requires' / 'ensures' / 'invariant'
-               / 'property' / 'for' / 'all' / 'where'
-               / 'old' / 'true' / 'false' / 'if' / 'else' / 'return'
-
-# ── Operators & Delimiters ───────────────────────────────────────────
-
-Arrow         <- '->'
-FatArrow      <- '=>'
-PipeGt        <- '|>'
-EqEq          <- '=='
-BangEq        <- '!='
-GtEq          <- '>='
-LtEq          <- '<='
-# Single-char: = ! > < + - * / | & ? ( ) { } [ ] , : ; .
+# Single-char tokens
+# = ! > < + - * / % | & ^ ~ ? ( ) { } [ ] , : ; .
 ```
 
 ---
@@ -67,191 +71,212 @@ LtEq          <- '<='
 ### Source File
 
 ```peg
-SourceFile     <- ModuleDecl? ImportDecl* Item* EOF
+SourceFile       <- ModuleDecl? ImportDecl* Item* EOF
 ```
 
 ### Module & Imports
 
 ```peg
-ModuleDecl     <- 'module' Path
-ImportDecl     <- 'import' Path ImportAlias?
-ImportAlias    <- 'as' Ident
-Path           <- Ident ('.' Ident)*
+ModuleDecl       <- 'module' Path
+ImportDecl       <- 'import' Path ImportAlias?
+ImportAlias      <- 'as' Ident
+Path             <- Ident ('.' Ident)*
 ```
 
 ### Items
 
 ```peg
-Item           <- 'pub'? (TypeDef
-               /  FnDef
-               /  EffectDef
-               /  PropertyDef
-               /  LetBinding)
+Item             <- 'pub'? (TypeDef
+                   / FnDef
+                   / EffectDef
+                   / PropertyDef
+                   / LetBinding)
 ```
 
 ### Type Definitions
 
 ```peg
-TypeDef        <- 'type' Ident TypeParamList? '=' TypeBody
+TypeDef          <- 'type' Ident TypeParamList? '=' TypeBody
+TypeBody         <- VariantList / TypeExpr
 
-TypeBody       <- VariantList / TypeExpr
-
-VariantList    <- Variant ('|' Variant)*
-Variant        <- Ident VariantFieldList?
+# Canonical ADT syntax: no leading `|` before the first variant.
+VariantList      <- Variant ('|' Variant)*
+Variant          <- Ident VariantFieldList?
 VariantFieldList <- '(' TypeExpr (',' TypeExpr)* ','? ')'
 
-# Record types used inline
-RecordFieldList <- '{' (RecordField (',' RecordField)* ','?)? '}'
-RecordField    <- Ident ':' TypeExpr
+RecordFieldList  <- '{' (RecordField (',' RecordField)* ','?)? '}'
+RecordField      <- Ident ':' TypeExpr
 ```
 
 ### Function Definitions
 
 ```peg
-FnDef          <- 'fn' Ident TypeParamList? ParamList ReturnType?
-                  WithClause? PipeClause? ContractSection? BlockExpr
+# Also supports method form: fn TypeName.method(...)
+FnDef            <- 'fn' (Ident ('.' Ident)?) TypeParamList? ParamList ReturnType?
+                    FnContract? BlockExpr
 
-ParamList      <- '(' (Param (',' Param)* ','?)? ')'
-Param          <- Ident ':' TypeExpr
-ReturnType     <- '->' TypeExpr
+ParamList        <- '(' (Param (',' Param)* ','?)? ')'
+# `self` without a type annotation is accepted syntactically; semantic checks
+# enforce where omitted type annotations are valid.
+Param            <- Ident (':' TypeExpr)?
+ReturnType       <- '->' TypeExpr
 
-WithClause     <- 'with' TypeExpr (',' TypeExpr)*
-PipeClause     <- 'pipe' TypeExpr (',' TypeExpr)*
-ContractSection <- 'contract' ContractClause+
-ContractClause <- RequiresClause / EnsuresClause / InvariantClause
-RequiresClause <- 'requires' '(' Expr ')'
-EnsuresClause  <- 'ensures' '(' Expr ')'
-InvariantClause <- 'invariant' '(' Expr ')'
-
-# Contract clause order is strict: requires* ensures* invariant*
+# Parsed in canonical order: with, pipe, then optional contract section.
+# Duplicate clauses and out-of-order contract clauses are diagnosed.
+FnContract       <- WithClause? PipeClause? ContractSection?
+WithClause       <- 'with' TypeExpr (',' TypeExpr)*
+PipeClause       <- 'pipe' TypeExpr (',' TypeExpr)*
+ContractSection  <- 'contract' ContractClause+
+ContractClause   <- RequiresClause / EnsuresClause / InvariantClause
+RequiresClause   <- 'requires' '(' Expr ')'
+EnsuresClause    <- 'ensures' '(' Expr ')'
+InvariantClause  <- 'invariant' '(' Expr ')'
+# Contract-clause order is strict: requires* ensures* invariant*
+# Direct clauses outside `contract` are rejected.
 ```
 
 ### Effect Definitions
 
 ```peg
-EffectDef      <- 'effect' Ident
+# Label-only declarations.
+EffectDef        <- 'effect' Ident
 ```
 
 ### Property Definitions
 
 ```peg
-PropertyDef    <- 'property' Ident PropertyParamList WhereClause? BlockExpr?
+# Body is currently optional in parser recovery mode.
+PropertyDef       <- 'property' Ident PropertyParamList WhereClause? BlockExpr?
 PropertyParamList <- '(' (PropertyParam (',' PropertyParam)* ','?)? ')'
-PropertyParam  <- Ident ':' TypeExpr '<-' Expr
-WhereClause    <- 'where' '(' Expr ')'
-ForAllBinder   <- 'for' 'all' Ident ':' TypeExpr '.'
+PropertyParam     <- Ident ':' TypeExpr '<-' Expr
+WhereClause       <- 'where' '(' Expr ')'
+ForAllBinder      <- 'for' 'all' Ident ':' TypeExpr '.'
 ```
 
 ### Let Bindings
 
 ```peg
-LetBinding     <- 'let' Pattern (':' TypeExpr)? '=' Expr
+LetBinding       <- 'let' Pattern (':' TypeExpr)? '=' Expr
 ```
 
 ### Generics
 
 ```peg
-TypeParamList  <- '<' TypeParam (',' TypeParam)* ','? '>'
-TypeParam      <- Ident
-TypeArgList    <- '<' TypeExpr (',' TypeExpr)* ','? '>'
+TypeParamList    <- '<' TypeParam (',' TypeParam)* ','? '>'
+TypeParam        <- Ident
+TypeArgList      <- '<' TypeExpr (',' TypeExpr)* ','? '>'
 ```
 
 ### Type Expressions
 
 ```peg
-TypeExpr       <- FnType
-               /  RefinedType
-               /  RecordType
-               /  NameType
+TypeExpr         <- FnType
+                 / RefinedType
+                 / RecordType
+                 / NameType
 
-NameType       <- Path TypeArgList?
-FnType         <- 'fn' '(' (TypeExpr (',' TypeExpr)*)? ')' '->' TypeExpr
-RecordType     <- RecordFieldList
-RefinedType    <- '{' Ident ':' TypeExpr '|' Expr '}'
+NameType         <- Path TypeArgList?
+FnType           <- 'fn' '(' (TypeExpr (',' TypeExpr)*)? ')' '->' TypeExpr
+RecordType       <- RecordFieldList
+RefinedType      <- '{' Ident ':' TypeExpr '|' Expr '}'
 ```
 
 ### Expressions
 
 Operator precedence (lowest to highest):
 
-| Precedence | Operators      | Associativity |
-|------------|----------------|---------------|
-| 1          | `\|>`          | Left          |
-| 2          | `==` `!=`      | Left          |
-| 3          | `<` `>` `<=` `>=` | Left       |
-| 4          | `+` `-`        | Left          |
-| 5          | `*` `/`        | Left          |
-| 6          | Unary `!` `-`  | Prefix        |
-| 7          | `?` `.` `()`   | Postfix       |
+| Precedence | Operators | Associativity |
+|---|---|---|
+| 1 | `\|>` | Left |
+| 2 | `\|\|` | Left |
+| 3 | `&&` | Left |
+| 4 | `==` `!=` | Left |
+| 5 | `<` `>` `<=` `>=` | Left |
+| 6 | `\|` | Left |
+| 7 | `^` | Left |
+| 8 | `&` | Left |
+| 9 | `<<` `>>` | Left |
+| 10 | `+` `-` | Left |
+| 11 | `*` `/` `%` | Left |
+| 12 | Unary `!` `-` `~` | Prefix |
+| 13 | Postfix `?` `.` `()` `[]` | Postfix |
 
 ```peg
-Expr           <- PipelineExpr
+Expr               <- PipelineExpr
 
-PipelineExpr   <- EqualityExpr ('|>' EqualityExpr)*
-EqualityExpr   <- ComparisonExpr (('==' / '!=') ComparisonExpr)*
-ComparisonExpr <- AdditiveExpr (('<' / '>' / '<=' / '>=') AdditiveExpr)*
-AdditiveExpr   <- MultiplicativeExpr (('+' / '-') MultiplicativeExpr)*
-MultiplicativeExpr <- UnaryExpr (('*' / '/') UnaryExpr)*
+PipelineExpr       <- OrExpr ('|>' OrExpr)*
+OrExpr             <- AndExpr ('||' AndExpr)*
+AndExpr            <- EqualityExpr ('&&' EqualityExpr)*
+EqualityExpr       <- ComparisonExpr (('==' / '!=') ComparisonExpr)*
+ComparisonExpr     <- BitOrExpr (('<' / '>' / '<=' / '>=') BitOrExpr)*
+BitOrExpr          <- BitXorExpr ('|' BitXorExpr)*
+BitXorExpr         <- BitAndExpr ('^' BitAndExpr)*
+BitAndExpr         <- ShiftExpr ('&' ShiftExpr)*
+ShiftExpr          <- AdditiveExpr (('<<' / '>>') AdditiveExpr)*
+AdditiveExpr       <- MultiplicativeExpr (('+' / '-') MultiplicativeExpr)*
+MultiplicativeExpr <- UnaryExpr (('*' / '/' / '%') UnaryExpr)*
 
-UnaryExpr      <- ('!' / '-') UnaryExpr / PostfixExpr
+UnaryExpr          <- ('!' / '-' / '~') UnaryExpr / PostfixExpr
 
-PostfixExpr    <- PrimaryExpr (PostfixOp)*
-PostfixOp      <- '?'                       # PropagateExpr
-               /  '.' Ident                  # FieldExpr
-               /  '(' ArgList ')'            # CallExpr
+PostfixExpr        <- PrimaryExpr PostfixOp*
+PostfixOp          <- '?'                    # PropagateExpr
+                   / '.' Ident               # FieldExpr
+                   / '(' ArgList ')'         # CallExpr
+                   / '[' Expr ']'            # IndexExpr
 
-ArgList        <- (Arg (',' Arg)* ','?)?
-Arg            <- NamedArg / Expr
-NamedArg       <- Ident ':' Expr
+ArgList            <- (Arg (',' Arg)* ','?)?
+Arg                <- NamedArg / Expr
+NamedArg           <- Ident ':' Expr
 
-PrimaryExpr    <- LiteralExpr
-               /  IdentExpr
-               /  PathExpr
-               /  ParenExpr
-               /  BlockExpr
-               /  IfExpr
-               /  MatchExpr
-               /  RecordExpr
-               /  ReturnExpr
-               /  OldExpr
-               /  LambdaExpr
-               /  HoleExpr
+PrimaryExpr        <- LiteralExpr
+                   / IdentExpr
+                   / PathExpr
+                   / ParenExpr
+                   / BlockExpr
+                   / IfExpr
+                   / MatchExpr
+                   / RecordExpr
+                   / ReturnExpr
+                   / OldExpr
+                   / LambdaExpr
+                   / HoleExpr
 
-LiteralExpr    <- IntLiteral / FloatLiteral / StringLiteral
-               /  CharLiteral / 'true' / 'false'
-IdentExpr      <- Ident
-PathExpr       <- Path       # when Path has 2+ segments
-ParenExpr      <- '(' Expr ')'
-BlockExpr      <- '{' (LetBinding / Expr)* Expr? '}'
-IfExpr         <- 'if' '(' Expr ')' BlockExpr ('else' (IfExpr / BlockExpr))?
-MatchExpr      <- 'match' '(' Expr ')' MatchArmList
-MatchArmList   <- '{' (MatchArm (',' MatchArm)* ','?)? '}'
-MatchArm       <- Pattern '=>' Expr
-RecordExpr     <- Path '{' RecordExprFieldList '}'
+LiteralExpr        <- IntLiteral / FloatLiteral / StringLiteral
+                   / CharLiteral / 'true' / 'false'
+IdentExpr          <- Ident
+PathExpr           <- Path
+ParenExpr          <- '(' Expr ')'
+BlockExpr          <- '{' (LetBinding / Expr)* Expr? '}'
+IfExpr             <- 'if' '(' Expr ')' BlockExpr ('else' (IfExpr / BlockExpr))?
+MatchExpr          <- 'match' '(' Expr ')' MatchArmList
+# Match arms accept optional commas; leading `|` is rejected.
+MatchArmList       <- '{' (MatchArm (',' MatchArm)* ','?)? '}'
+MatchArm           <- Pattern '=>' Expr
+RecordExpr         <- Path '{' RecordExprFieldList '}'
 RecordExprFieldList <- (RecordExprField (',' RecordExprField)* ','?)?
-RecordExprField <- Ident ':' Expr
-ReturnExpr     <- 'return' Expr?
-OldExpr        <- 'old' '(' Expr ')'
-LambdaExpr     <- 'fn' '(' (Param (',' Param)*)? ')' '=>' Expr
-HoleExpr       <- '_'
+RecordExprField    <- Ident ':' Expr
+ReturnExpr         <- 'return' Expr?
+OldExpr            <- 'old' '(' Expr ')'
+LambdaExpr         <- 'fn' '(' (Param (',' Param)*)? ')' '=>' Expr
+HoleExpr           <- '_'
 ```
 
 ### Patterns
 
 ```peg
-Pattern        <- ConstructorPat
-               /  RecordPat
-               /  LiteralPat
-               /  WildcardPat
-               /  IdentPat
+Pattern            <- ConstructorPat
+                   / RecordPat
+                   / LiteralPat
+                   / WildcardPat
+                   / IdentPat
 
-IdentPat       <- Ident
-ConstructorPat <- Path '(' PatList ')'
-PatList        <- (Pattern (',' Pattern)* ','?)?
-WildcardPat    <- '_'
-LiteralPat     <- IntLiteral / FloatLiteral / StringLiteral
-               /  CharLiteral / 'true' / 'false'
-RecordPat      <- Path? '{' (Ident (',' Ident)* ','?)? '}'
+IdentPat           <- Path
+ConstructorPat     <- Path '(' PatList ')'
+PatList            <- (Pattern (',' Pattern)* ','?)?
+WildcardPat        <- '_'
+LiteralPat         <- IntLiteral / FloatLiteral / StringLiteral
+                   / CharLiteral / 'true' / 'false'
+RecordPat          <- Path? '{' (Ident (',' Ident)* ','?)? '}'
 ```
 
 ---


### PR DESCRIPTION
## Summary
- resync README/design/llms docs to current implemented syntax and stdlib surface
- refresh grammar spec to match current parser contracts (contract section, <- property params, named args, precedence)
- fix RFC parse result type notation (`Result<T, E>` form)

## Notes
- docs-only changes, no runtime behavior changes

## Validation
- manual docs drift audit against current parser/builtins/eval behavior
