### PR TITLE
fix: align equality typing, KIR synthetic import gating, and LSP builtins

### DIFF
--- a/crates/eval/tests/eval_tests.rs
+++ b/crates/eval/tests/eval_tests.rs
@@ -273,6 +273,12 @@ fn eval_comparison_neq() {
 }
 
 #[test]
+fn eval_equality_on_list_is_compile_error() {
+    let err = run_err("fn main() -> Bool { List.new() == List.new() }");
+    assert!(err.contains("equality operator requires"), "got: {err}");
+}
+
+#[test]
 fn eval_comparison_lt() {
     let val = run_ok("fn main() -> Bool { 1 < 2 }");
     assert!(matches!(val, Value::Bool(true)));

--- a/crates/hir-ty/src/diagnostics.rs
+++ b/crates/hir-ty/src/diagnostics.rs
@@ -16,6 +16,8 @@ pub enum TyDiagnosticData {
     InvalidArithmeticOperand { ty: Ty },
     /// Comparison operator applied to non-comparable type.
     InvalidComparisonOperand { ty: Ty },
+    /// Equality operator applied to non-equality-comparable type.
+    InvalidEqualityOperand { ty: Ty },
     /// Negation applied to non-numeric type.
     InvalidNegationOperand { ty: Ty },
     /// Logical not applied to non-Bool type.
@@ -73,6 +75,7 @@ impl TyDiagnosticData {
             TyDiagnosticData::TypeMismatch { .. } => "E0001",
             TyDiagnosticData::InvalidArithmeticOperand { .. } => "E0002",
             TyDiagnosticData::InvalidComparisonOperand { .. } => "E0003",
+            TyDiagnosticData::InvalidEqualityOperand { .. } => "E0027",
             TyDiagnosticData::InvalidNegationOperand { .. } => "E0004",
             TyDiagnosticData::InvalidNotOperand { .. } => "E0005",
             TyDiagnosticData::NotAFunction { .. } => "E0006",
@@ -141,6 +144,12 @@ impl TyDiagnosticData {
             TyDiagnosticData::InvalidComparisonOperand { ty } => {
                 format!(
                     "comparison operator requires `Int` or `Float`, found `{}`",
+                    dt(ty),
+                )
+            }
+            TyDiagnosticData::InvalidEqualityOperand { ty } => {
+                format!(
+                    "equality operator requires `Int`, `Float`, `String`, `Char`, or `Bool`, found `{}`",
                     dt(ty),
                 )
             }

--- a/crates/hir-ty/src/infer/expr.rs
+++ b/crates/hir-ty/src/infer/expr.rs
@@ -319,6 +319,13 @@ impl<'a> InferenceCtx<'a> {
                 lhs_ty
             }
             _ if op.is_equality() => {
+                let resolved = self.table.resolve_deep(&lhs_ty);
+                if !resolved.is_poison() && !resolved.is_equality_comparable() {
+                    self.push_diag(TyDiagnosticData::InvalidEqualityOperand {
+                        ty: resolved.clone(),
+                    });
+                    return Ty::Error;
+                }
                 self.unify_or_err(&lhs_ty, &rhs_ty);
                 Ty::Bool
             }

--- a/crates/hir-ty/src/ty.rs
+++ b/crates/hir-ty/src/ty.rs
@@ -83,6 +83,17 @@ impl Ty {
         )
     }
 
+    /// Returns `true` if this type supports `==` / `!=`.
+    ///
+    /// Equality is defined for the same primitive subset currently implemented
+    /// by the interpreter: Int, Float, String, Char, and Bool.
+    pub fn is_equality_comparable(&self) -> bool {
+        matches!(
+            self,
+            Ty::Int | Ty::Float | Ty::String | Ty::Char | Ty::Bool | Ty::Error | Ty::Var(_)
+        )
+    }
+
     /// Returns `true` if this type contains no inference variables.
     pub fn is_fully_resolved(&self) -> bool {
         match self {

--- a/crates/hir-ty/tests/infer_tests.rs
+++ b/crates/hir-ty/tests/infer_tests.rs
@@ -153,6 +153,14 @@ fn infer_binary_equality() {
 }
 
 #[test]
+fn infer_binary_equality_rejects_non_comparable_types() {
+    check_err(
+        "fn foo() -> Bool { List.new() == List.new() }",
+        "equality operator requires",
+    );
+}
+
+#[test]
 fn infer_unary_neg() {
     check_ok("fn foo() -> Int { -42 }");
 }

--- a/crates/kir/src/lower/expr.rs
+++ b/crates/kir/src/lower/expr.rs
@@ -338,7 +338,8 @@ impl<'a> LoweringCtx<'a> {
             let seg = path.segments[0];
 
             // Module-qualified call: io.println(s), math.min(a, b)
-            if let Some(mod_fns) = self.module_scope.synthetic_modules.get(&seg)
+            if self.module_scope.imported_modules.contains(&seg)
+                && let Some(mod_fns) = self.module_scope.synthetic_modules.get(&seg)
                 && let Some(&fn_idx) = mod_fns.get(&field)
             {
                 let param_names = self.param_names_for_fn_idx(fn_idx);

--- a/crates/kir/tests/lower_tests.rs
+++ b/crates/kir/tests/lower_tests.rs
@@ -268,6 +268,24 @@ fn test_named_args_reordered_module_call() {
 }
 
 #[test]
+fn test_unimported_module_call_is_not_lowered_as_intrinsic() {
+    let result = check_file("fn main() -> Int { math.min(1, 2) }");
+    let mut interner = result.interner;
+    let module = lower_module(
+        &result.item_tree,
+        &result.module_scope,
+        &result.type_check,
+        &mut interner,
+    );
+    let ctx = DisplayCtx::new(&interner, &result.item_tree);
+    let out = display_module(&module, &ctx);
+    assert!(
+        !out.contains("call intrinsic:min"),
+        "unimported module call must not lower as intrinsic. output:\n{out}"
+    );
+}
+
+#[test]
 fn test_named_args_reordered_method_call() {
     let out = lower_and_display("fn main() -> String { \"abcd\".substring(end: 3, start: 1) }");
     assert!(

--- a/crates/lsp/src/completion.rs
+++ b/crates/lsp/src/completion.rs
@@ -70,6 +70,10 @@ fn dedup_completion_items(items: Vec<CompletionItem>) -> Vec<CompletionItem> {
 }
 
 fn should_replace_completion(existing: &CompletionItem, new_item: &CompletionItem) -> bool {
+    // Prefer richer metadata for duplicate labels (e.g., builtin type detail).
+    if existing.detail.is_none() && new_item.detail.is_some() {
+        return true;
+    }
     if existing.sort_text.is_none() && new_item.sort_text.is_some() {
         return true;
     }
@@ -258,7 +262,19 @@ fn add_module_scope_completions(analysis: &FileAnalysis, items: &mut Vec<Complet
 
 fn add_builtin_completions(items: &mut Vec<CompletionItem>) {
     for name in &[
-        "Int", "Float", "String", "Bool", "Char", "Unit", "Option", "Result", "List", "Seq", "Map",
+        "Int",
+        "Float",
+        "String",
+        "Bool",
+        "Char",
+        "Unit",
+        "Option",
+        "Result",
+        "List",
+        "Seq",
+        "Map",
+        "Set",
+        "ParseError",
     ] {
         items.push(CompletionItem {
             label: name.to_string(),
@@ -461,6 +477,16 @@ mod tests {
         let items = completion_items(&analysis, source, TextSize::from(0));
         assert!(items.iter().any(|i| i.label == "Int"));
         assert!(items.iter().any(|i| i.label == "Option"));
+        assert!(
+            items
+                .iter()
+                .any(|i| i.label == "Set" && i.detail.as_deref() == Some("builtin"))
+        );
+        assert!(
+            items
+                .iter()
+                .any(|i| i.label == "ParseError" && i.detail.as_deref() == Some("builtin"))
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- reject equality operators for non-comparable types at type-check time (align with interpreter behavior)
- gate KIR lowering of synthetic module calls (io/math/fs) on explicit imports
- include missing builtin completion items (Set, ParseError) and prefer richer completion metadata when deduplicating

## Tests
- cargo test -p kyokara-hir-ty --test infer_tests
- cargo test -p kyokara-kir --test lower_tests
- cargo test -p kyokara-lsp completion_includes_builtins
- cargo test -p kyokara-eval --test eval_tests eval_equality_on_list_is_compile_error -- --exact
- cargo clippy --workspace --tests -- -D warnings
- cargo test --workspace
