### PR TITLE
perf(hir-ty): borrow expr/pat inference nodes

### DIFF
--- a/crates/hir-ty/src/infer/expr.rs
+++ b/crates/hir-ty/src/infer/expr.rs
@@ -45,11 +45,10 @@ impl<'a> InferenceCtx<'a> {
     }
 
     fn infer_expr_inner(&mut self, idx: ExprIdx, expected: &Expectation) -> Ty {
-        let expr = self.body.exprs[idx].clone();
-        match expr {
+        match &self.body.exprs[idx] {
             Expr::Missing => Ty::Error,
 
-            Expr::Literal(lit) => self.infer_literal(&lit),
+            Expr::Literal(lit) => self.infer_literal(lit),
 
             Expr::Path(path) => {
                 if !path.is_single() {
@@ -67,41 +66,29 @@ impl<'a> InferenceCtx<'a> {
                 self.infer_name(name, idx)
             }
 
-            Expr::Binary { op, lhs, rhs } => self.infer_binary(op, lhs, rhs),
+            Expr::Binary { op, lhs, rhs } => self.infer_binary(*op, *lhs, *rhs),
 
-            Expr::Unary { op, operand } => self.infer_unary(op, operand),
+            Expr::Unary { op, operand } => self.infer_unary(*op, *operand),
 
-            Expr::Call { callee, ref args } => {
-                let args = args.clone();
-                self.infer_call(callee, &args)
-            }
+            Expr::Call { callee, args } => self.infer_call(*callee, args),
 
-            Expr::Field { base, field } => self.infer_field(base, field),
+            Expr::Field { base, field } => self.infer_field(*base, *field),
 
-            Expr::Index { base, index } => self.infer_index(base, index),
+            Expr::Index { base, index } => self.infer_index(*base, *index),
 
             Expr::If {
                 condition,
                 then_branch,
                 else_branch,
-            } => self.infer_if(condition, then_branch, else_branch, expected),
+            } => self.infer_if(*condition, *then_branch, *else_branch, expected),
 
-            Expr::Match {
-                scrutinee,
-                ref arms,
-            } => {
-                let arms = arms.clone();
-                self.infer_match(idx, scrutinee, &arms, expected)
-            }
+            Expr::Match { scrutinee, arms } => self.infer_match(idx, *scrutinee, arms, expected),
 
-            Expr::Block { ref stmts, tail } => {
-                let stmts = stmts.clone();
-                self.infer_block(&stmts, tail, expected)
-            }
+            Expr::Block { stmts, tail } => self.infer_block(stmts, *tail, expected),
 
             Expr::Return(val) => {
                 let ret = self.ret_ty.clone();
-                if let Some(val_idx) = val {
+                if let Some(val_idx) = *val {
                     self.infer_expr(val_idx, &Expectation::Has(ret));
                 } else {
                     self.unify_or_err(&ret, &Ty::Unit);
@@ -109,24 +96,11 @@ impl<'a> InferenceCtx<'a> {
                 Ty::Never
             }
 
-            Expr::RecordLit {
-                ref path,
-                ref fields,
-            } => {
-                let path = path.clone();
-                let fields = fields.clone();
-                self.infer_record_lit(path.as_ref(), &fields)
-            }
+            Expr::RecordLit { path, fields } => self.infer_record_lit(path.as_ref(), fields),
 
-            Expr::Lambda {
-                ref params,
-                body: body_expr,
-            } => {
-                let params = params.clone();
-                self.infer_lambda(&params, body_expr, expected)
-            }
+            Expr::Lambda { params, body } => self.infer_lambda(params, *body, expected),
 
-            Expr::Old(inner) => self.infer_expr(inner, expected),
+            Expr::Old(inner) => self.infer_expr(*inner, expected),
 
             Expr::Hole => {
                 let expected_ty = expected.ty().cloned();
@@ -926,7 +900,7 @@ impl<'a> InferenceCtx<'a> {
             return true;
         }
 
-        match self.body.pats[pat_idx].clone() {
+        match &self.body.pats[pat_idx] {
             Pat::Missing | Pat::Wildcard | Pat::Bind { .. } => true,
             Pat::Literal(_) => false,
             Pat::Record { fields, .. } => match expected {

--- a/crates/hir-ty/src/infer/pat.rs
+++ b/crates/hir-ty/src/infer/pat.rs
@@ -13,8 +13,7 @@ use super::InferenceCtx;
 impl<'a> InferenceCtx<'a> {
     /// Infer the type of a pattern against an expected scrutinee type.
     pub(crate) fn infer_pat(&mut self, pat_idx: la_arena::Idx<Pat>, expected: &Ty) {
-        let pat = self.body.pats[pat_idx].clone();
-        let ty = match pat {
+        let ty = match &self.body.pats[pat_idx] {
             Pat::Missing => Ty::Error,
 
             Pat::Wildcard => expected.clone(),
@@ -26,7 +25,7 @@ impl<'a> InferenceCtx<'a> {
             }
 
             Pat::Literal(lit) => {
-                let lit_ty = match &lit {
+                let lit_ty = match lit {
                     Literal::Int(_) => Ty::Int,
                     Literal::Float(_) => Ty::Float,
                     Literal::String(_) => Ty::String,
@@ -50,7 +49,7 @@ impl<'a> InferenceCtx<'a> {
                                 .join("."),
                         },
                     );
-                    for sub in &args {
+                    for sub in args {
                         self.infer_pat(*sub, &Ty::Error);
                     }
                     self.pat_types.insert(pat_idx, Ty::Error);
@@ -86,7 +85,7 @@ impl<'a> InferenceCtx<'a> {
                                 actual: args.len(),
                             },
                         );
-                        for sub in &args {
+                        for sub in args {
                             self.infer_pat(*sub, &Ty::Error);
                         }
                     } else {
@@ -117,7 +116,7 @@ impl<'a> InferenceCtx<'a> {
                                 actual: args.len(),
                             },
                         );
-                        for sub in &args {
+                        for sub in args {
                             self.infer_pat(*sub, &Ty::Error);
                         }
                     } else {
@@ -133,7 +132,7 @@ impl<'a> InferenceCtx<'a> {
                             name: name.resolve(self.interner).to_owned(),
                         },
                     );
-                    for sub in &args {
+                    for sub in args {
                         self.infer_pat(*sub, &Ty::Error);
                     }
                     Ty::Error
@@ -159,7 +158,7 @@ impl<'a> InferenceCtx<'a> {
                     Ty::Record {
                         fields: ref rec_fields,
                     } => {
-                        for field_name in &fields {
+                        for field_name in fields {
                             let field_str = field_name.resolve(self.interner);
                             if let Some((_, field_ty)) = rec_fields
                                 .iter()
@@ -205,7 +204,7 @@ impl<'a> InferenceCtx<'a> {
                                 type_params: tp_map,
                                 resolving_aliases: vec![],
                             };
-                            for field_name in &fields {
+                            for field_name in fields {
                                 let field_str = field_name.resolve(self.interner);
                                 if let Some((_, type_ref)) = def_fields
                                     .iter()

--- a/crates/hir-ty/tests/perf_hotspot_guards.rs
+++ b/crates/hir-ty/tests/perf_hotspot_guards.rs
@@ -1,0 +1,18 @@
+#[test]
+fn infer_expr_and_pat_hot_paths_do_not_clone_whole_nodes() {
+    let infer_expr_src = include_str!("../src/infer/expr.rs");
+    let infer_pat_src = include_str!("../src/infer/pat.rs");
+
+    assert!(
+        !infer_expr_src.contains("self.body.exprs[idx].clone()"),
+        "infer_expr_inner should borrow Expr instead of cloning whole node"
+    );
+    assert!(
+        !infer_expr_src.contains("self.body.pats[pat_idx].clone()"),
+        "is_irrefutable_let_pattern should borrow Pat instead of cloning whole node"
+    );
+    assert!(
+        !infer_pat_src.contains("self.body.pats[pat_idx].clone()"),
+        "infer_pat should borrow Pat instead of cloning whole node"
+    );
+}


### PR DESCRIPTION
## Summary
- Remove whole-node clones from `hir-ty` inference hot paths:
  - `infer_expr_inner` now matches on `&Expr` instead of cloning `Expr`.
  - `infer_pat` now matches on `&Pat` instead of cloning `Pat`.
  - `is_irrefutable_let_pattern` now matches on `&Pat` instead of cloning `Pat`.
- Keep existing inference behavior unchanged while reducing clone/allocation pressure.
- Add a guard test to prevent reintroducing these exact clone hotspots.

## Strict TDD (red -> green)
- Red: added `perf_hotspot_guards` test first; it failed because clone hotspots were present.
- Green: refactored inference paths to borrowed matching and re-ran tests; guard passes.

## Verification
- `cargo test -p kyokara-hir-ty --test perf_hotspot_guards`
- `cargo test -p kyokara-hir-ty --test infer_tests`
- `cargo fmt --all`
- `cargo clippy -p kyokara-hir-ty --tests -- -D warnings`
- `cargo test -p kyokara-hir-ty`

## Related issues
- Closes #309
- Refs #195
