### PR TITLE
perf(hir-def): avoid pending method queue clone

### DIFF
--- a/crates/hir-def/src/item_tree/lower.rs
+++ b/crates/hir-def/src/item_tree/lower.rs
@@ -375,7 +375,8 @@ impl ItemTreeCtx<'_> {
     }
 
     fn finalize_method_bindings(&mut self) {
-        for (recv_name, method_name, fn_idx, span) in self.pending_methods.clone() {
+        let pending_methods = std::mem::take(&mut self.pending_methods);
+        for (recv_name, method_name, fn_idx, span) in pending_methods {
             let Some(receiver_key) = self.receiver_key_for_name(recv_name) else {
                 self.diagnostics.push(Diagnostic::error(
                     format!(

--- a/crates/hir-def/tests/lower_tests.rs
+++ b/crates/hir-def/tests/lower_tests.rs
@@ -115,6 +115,15 @@ fn duplicate_type_diagnostic() {
     assert!(result.diagnostics[0].message.contains("duplicate type"));
 }
 
+#[test]
+fn method_binding_finalization_does_not_clone_pending_queue() {
+    let src = include_str!("../src/item_tree/lower.rs");
+    assert!(
+        !src.contains("self.pending_methods.clone()"),
+        "finalize_method_bindings should consume pending queue without cloning"
+    );
+}
+
 // ── Body lowering tests ────────────────────────────────────────────
 
 fn lower_fn_body(


### PR DESCRIPTION
## Summary
- Remove clone of `pending_methods` in method binding finalization.
- Use `std::mem::take` to consume pending entries without allocating/copying the whole queue.
- Add a guard test to prevent reintroducing `self.pending_methods.clone()` in this hot path.

## Strict TDD (red -> green)
- Red: added `method_binding_finalization_does_not_clone_pending_queue` guard test first; it failed with the clone still present.
- Green: switched to move-based iteration via `mem::take`; guard and full `hir-def` tests now pass.

## Verification
- `cargo test -p kyokara-hir-def --test lower_tests method_binding_finalization_does_not_clone_pending_queue`
- `cargo fmt --all`
- `cargo clippy -p kyokara-hir-def --tests -- -D warnings`
- `cargo test -p kyokara-hir-def`

## Related issues
- Closes #315
- Refs #195
