### PR TITLE
Fix nested generic >> parsing and unfold alias payload typing

### DIFF
--- a/crates/api/tests/api_tests.rs
+++ b/crates/api/tests/api_tests.rs
@@ -4046,6 +4046,24 @@ fn check_seq_scan_unfold_int_pow_canonical_surface_has_no_diagnostics() {
 }
 
 #[test]
+fn check_seq_unfold_accepts_named_record_alias_payload() {
+    assert_check_no_diagnostics(
+        r#"type PickStep = { value: Int, state: Int }
+
+        fn main() -> Int {
+            Seq.unfold(0, fn(state: Int) =>
+                if (state < 3) {
+                    Some(PickStep { value: state + 1, state: state + 1 })
+                } else {
+                    None
+                }
+            ).count()
+        }"#,
+        "seq unfold accepts named record payload alias",
+    );
+}
+
+#[test]
 fn check_non_canonical_free_scan_unfold_pow_int_report_unresolved_name() {
     let output = check(
         r#"fn main() -> Int {

--- a/crates/eval/tests/eval_tests.rs
+++ b/crates/eval/tests/eval_tests.rs
@@ -5525,6 +5525,25 @@ fn eval_seq_unfold_semantics_matrix() {
 }
 
 #[test]
+fn eval_seq_unfold_accepts_named_record_alias_payload() {
+    let val = run_ok(
+        r#"type PickStep = { value: Int, state: Int }
+
+        fn main() -> Int {
+            let xs = Seq.unfold(0, fn(state: Int) =>
+                if (state < 4) {
+                    Some(PickStep { value: state * 2, state: state + 1 })
+                } else {
+                    None
+                }
+            ).to_list()
+            xs.len() * 100 + xs[0] * 10 + xs[3]
+        }"#,
+    );
+    assert_eq!(val, Value::Int(406));
+}
+
+#[test]
 fn eval_int_pow_semantics_matrix() {
     struct Case<'a> {
         name: &'a str,

--- a/crates/hir-ty/src/infer.rs
+++ b/crates/hir-ty/src/infer.rs
@@ -9,7 +9,7 @@ mod pat;
 use kyokara_diagnostics::Diagnostic;
 use kyokara_hir_def::body::{Body, LocalBindingOrigin};
 use kyokara_hir_def::expr::ExprIdx;
-use kyokara_hir_def::item_tree::{FnItem, FnItemIdx, ItemTree};
+use kyokara_hir_def::item_tree::{FnItem, FnItemIdx, ItemTree, TypeDefKind, TypeItemIdx};
 use kyokara_hir_def::name::Name;
 use kyokara_hir_def::pat::Pat;
 use kyokara_hir_def::resolver::ModuleScope;
@@ -119,11 +119,14 @@ impl<'a> InferenceCtx<'a> {
     /// Unify two types, emitting a type mismatch diagnostic on failure.
     /// Returns the unified type (or Error on failure).
     pub(crate) fn unify_or_err(&mut self, expected: &Ty, actual: &Ty) -> Ty {
-        if self.table.unify(expected, actual) {
-            self.table.resolve_deep(expected)
+        let expected_norm = self.normalize_record_aliases_for_unify(expected);
+        let actual_norm = self.normalize_record_aliases_for_unify(actual);
+
+        if self.table.unify(&expected_norm, &actual_norm) {
+            self.table.resolve_deep(&expected_norm)
         } else {
-            let expected = self.table.resolve_deep(expected);
-            let actual = self.table.resolve_deep(actual);
+            let expected = self.table.resolve_deep(&expected_norm);
+            let actual = self.table.resolve_deep(&actual_norm);
             if !expected.is_poison() && !actual.is_poison() {
                 self.push_diag(TyDiagnosticData::TypeMismatch {
                     expected: expected.clone(),
@@ -132,6 +135,87 @@ impl<'a> InferenceCtx<'a> {
             }
             Ty::Error
         }
+    }
+
+    /// Expand record aliases into structural records for unification-only paths.
+    ///
+    /// We keep alias-to-record values as `Ty::Adt` elsewhere for method
+    /// dispatch identity, but expectation unification should accept structurally
+    /// equivalent shapes (e.g., `Option<PickStep>` vs `Option<{ value, state }>`).
+    fn normalize_record_aliases_for_unify(&mut self, ty: &Ty) -> Ty {
+        let resolved = self.table.resolve_deep(ty);
+        self.normalize_record_aliases_inner(resolved)
+    }
+
+    fn normalize_record_aliases_inner(&mut self, ty: Ty) -> Ty {
+        match ty {
+            Ty::Adt { def, args } => {
+                if let Some(fields) = self.expand_record_alias(def, &args) {
+                    return Ty::Record { fields };
+                }
+                Ty::Adt {
+                    def,
+                    args: args
+                        .into_iter()
+                        .map(|arg| self.normalize_record_aliases_inner(arg))
+                        .collect(),
+                }
+            }
+            Ty::Record { fields } => Ty::Record {
+                fields: fields
+                    .into_iter()
+                    .map(|(name, field_ty)| (name, self.normalize_record_aliases_inner(field_ty)))
+                    .collect(),
+            },
+            Ty::Fn { params, ret } => Ty::Fn {
+                params: params
+                    .into_iter()
+                    .map(|param| self.normalize_record_aliases_inner(param))
+                    .collect(),
+                ret: Box::new(self.normalize_record_aliases_inner(*ret)),
+            },
+            other => other,
+        }
+    }
+
+    fn expand_record_alias(
+        &mut self,
+        type_idx: TypeItemIdx,
+        args: &[Ty],
+    ) -> Option<Vec<(Name, Ty)>> {
+        let type_item = &self.item_tree.types[type_idx];
+        let TypeDefKind::Alias(TypeRef::Record { fields }) = &type_item.kind else {
+            return None;
+        };
+
+        let mut type_params = self.type_params.clone();
+        for (i, &param_name) in type_item.type_params.iter().enumerate() {
+            let arg = args
+                .get(i)
+                .cloned()
+                .unwrap_or_else(|| self.table.fresh_var());
+            type_params.push((param_name, arg));
+        }
+
+        let env = TyResolutionEnv {
+            item_tree: self.item_tree,
+            module_scope: self.module_scope,
+            interner: self.interner,
+            type_params,
+            resolving_aliases: vec![type_idx],
+        };
+
+        let resolved_fields = fields
+            .iter()
+            .map(|(field_name, field_ty_ref)| {
+                let resolved = env.resolve_type_ref(field_ty_ref, &mut self.table);
+                (
+                    *field_name,
+                    self.normalize_record_aliases_for_unify(&resolved),
+                )
+            })
+            .collect();
+        Some(resolved_fields)
     }
 
     /// Build a `TyResolutionEnv` from non-table fields.

--- a/crates/hir-ty/tests/infer_tests.rs
+++ b/crates/hir-ty/tests/infer_tests.rs
@@ -765,6 +765,29 @@ fn infer_seq_scan_unfold_int_pow_happy_paths() {
 }
 
 #[test]
+fn infer_seq_unfold_accepts_named_record_alias_payload() {
+    let src = r#"type PickStep = { value: Int, state: Int }
+
+fn main() -> Int {
+    let unfolded = Seq.unfold(0, fn(state: Int) =>
+        if (state < 3) {
+            Some(PickStep { value: state + 1, state: state + 1 })
+        } else {
+            None
+        }
+    ).to_list()
+    unfolded.len()
+}"#;
+
+    let (result, _) = check(src);
+    assert!(
+        result.diagnostics.is_empty(),
+        "expected no diagnostics, got: {:?}\nsource:\n{src}",
+        result.diagnostics
+    );
+}
+
+#[test]
 fn infer_result_ergonomics_happy_paths() {
     let cases = [
         "fn main() -> Int { \"42\".parse_int().unwrap_or(0) }",

--- a/crates/parser/src/grammar/types.rs
+++ b/crates/parser/src/grammar/types.rs
@@ -115,11 +115,11 @@ pub(super) fn type_arg_list(p: &mut Parser<'_>) {
     p.bump(); // <
     type_expr(p);
     while p.eat(Comma) {
-        if p.at(Gt) {
+        if p.at(Gt) || p.at(GtGt) {
             break;
         }
         type_expr(p);
     }
-    p.expect(Gt);
+    p.expect_type_arg_rangle();
     m.complete(p, TypeArgList);
 }

--- a/crates/parser/src/parser.rs
+++ b/crates/parser/src/parser.rs
@@ -26,6 +26,8 @@ pub struct Parser<'i> {
     input: &'i Input,
     /// Current non-trivia token index.
     pos: usize,
+    /// Virtual `>` token pending from splitting a `>>` token while parsing type args.
+    pending_virtual_gt: u8,
     /// Accumulated events.
     events: Vec<Event>,
     /// Accumulated errors.
@@ -37,6 +39,7 @@ impl<'i> Parser<'i> {
         Parser {
             input,
             pos: 0,
+            pending_virtual_gt: 0,
             events: Vec::new(),
             errors: Vec::new(),
         }
@@ -56,7 +59,15 @@ impl<'i> Parser<'i> {
 
     /// The kind of the non-trivia token `n` positions ahead.
     pub fn nth(&self, n: usize) -> SyntaxKind {
-        self.input.kind(self.pos + n)
+        if self.pending_virtual_gt > 0 {
+            if n == 0 {
+                SyntaxKind::Gt
+            } else {
+                self.input.kind(self.pos + n - 1)
+            }
+        } else {
+            self.input.kind(self.pos + n)
+        }
     }
 
     /// Returns `true` if the current token matches `kind`.
@@ -77,18 +88,26 @@ impl<'i> Parser<'i> {
 
     /// Returns `true` if we've reached the end of input.
     pub fn at_eof(&self) -> bool {
-        self.pos >= self.input.len()
+        self.pending_virtual_gt == 0 && self.pos >= self.input.len()
     }
 
     /// Current non-trivia token position.
     pub fn token_pos(&self) -> usize {
-        self.pos
+        if self.pending_virtual_gt > 0 {
+            self.pos.saturating_sub(1)
+        } else {
+            self.pos
+        }
     }
 
     // ── Token consumption ───────────────────────────────────────────
 
     /// Advance past the current token, emitting a `Token` event.
     pub fn bump(&mut self) {
+        if self.pending_virtual_gt > 0 {
+            self.pending_virtual_gt -= 1;
+            return;
+        }
         let kind = self.current();
         assert!(!self.at_eof(), "bump at EOF");
         self.do_bump(kind);
@@ -125,6 +144,32 @@ impl<'i> Parser<'i> {
             true
         } else {
             self.error_recover(&format!("expected {kind:?}"), TokenSet::EMPTY);
+            false
+        }
+    }
+
+    /// Consume one right-angle token for type-argument parsing.
+    ///
+    /// In type contexts, `>>` should be interpreted as two consecutive `>`
+    /// delimiters for nested generic closures.
+    pub fn eat_type_arg_rangle(&mut self) -> bool {
+        if self.eat(SyntaxKind::Gt) {
+            return true;
+        }
+        if self.at(SyntaxKind::GtGt) {
+            self.bump(); // consume raw `>>`
+            self.pending_virtual_gt = self.pending_virtual_gt.saturating_add(1);
+            return true;
+        }
+        false
+    }
+
+    /// Expect one right-angle token for type-argument parsing.
+    pub fn expect_type_arg_rangle(&mut self) -> bool {
+        if self.eat_type_arg_rangle() {
+            true
+        } else {
+            self.error_recover("expected Gt", TokenSet::EMPTY);
             false
         }
     }

--- a/crates/parser/tests/parser_tests.rs
+++ b/crates/parser/tests/parser_tests.rs
@@ -128,6 +128,21 @@ fn type_with_generics() {
 }
 
 #[test]
+fn nested_type_args_accept_gtgt_token() {
+    // fn f(xs: List<List<Int>>) -> Int { 0 }
+    let (events, errors) = parse_tokens(&[
+        FnKw, Ident, LParen, Ident, Colon, Ident, Lt, Ident, Lt, Ident, GtGt, RParen, Arrow, Ident,
+        LBrace, IntLiteral, RBrace,
+    ]);
+    assert!(
+        has_no_errors(&errors),
+        "nested type args should parse: {errors:?}"
+    );
+    assert!(has_node(&events, NameType));
+    assert_eq!(count_start_nodes(&events, TypeArgList), 2);
+}
+
+#[test]
 fn type_with_single_payload_variant() {
     // type Boxed = Boxed(Int)
     let (events, errors) = parse_tokens(&[TypeKw, Ident, Eq, Ident, LParen, Ident, RParen]);

--- a/crates/syntax/tests/integration_tests.rs
+++ b/crates/syntax/tests/integration_tests.rs
@@ -669,6 +669,13 @@ fn roundtrip_property_gen_list() {
 }
 
 #[test]
+fn roundtrip_nested_type_args_with_gtgt() {
+    let src = "fn main(xs: List<List<Int>>) -> Int { xs.len() }";
+    let green = parse_ok(src);
+    assert_eq!(green_text(&green), src);
+}
+
+#[test]
 fn roundtrip_property_trailing_comma() {
     let src = "property p(x: Int <- Gen.auto(),) { true }";
     let green = parse_ok(src);


### PR DESCRIPTION
## Summary
- parser: accept nested type-arg closing with `>>` in type contexts (no parse cascade)
- hir-ty: allow record alias payloads to unify structurally in expectation paths (fixes Seq.unfold alias payload mismatch)
- add parser/syntax/hir-ty/api/eval regression tests for both issues

## Validation
- cargo test -p kyokara-parser -p kyokara-syntax -p kyokara-hir-ty -p kyokara-api -p kyokara-eval
- cargo test
