### PR TITLE
api: fix call-edge rewrite misattribution under import conflicts

### DIFF
--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -347,6 +347,13 @@ pub fn check_project(entry_file: &std::path::Path) -> CheckOutput {
     for func in &mut all_functions {
         let mut rewritten_calls = Vec::with_capacity(func.calls.len());
         for call in &func.calls {
+            // Preserve exact resolved targets already present in the emitted graph.
+            // This avoids rebinding local edges via name-only heuristics.
+            if emitted_fn_ids.contains(call) {
+                rewritten_calls.push(call.clone());
+                continue;
+            }
+
             // Extract bare callee name from IDs like `fn::foo` or `fn::m::foo`.
             let callee_name = call.strip_prefix("fn::").unwrap_or(call);
             let bare_name = callee_name.rsplit("::").next().unwrap_or(callee_name);
@@ -372,10 +379,7 @@ pub fn check_project(entry_file: &std::path::Path) -> CheckOutput {
                 continue;
             }
 
-            // Keep already-emitted IDs when no canonical rewrite is available.
-            if emitted_fn_ids.contains(call) {
-                rewritten_calls.push(call.clone());
-            }
+            // No safe rewrite available: drop unresolved/ambiguous edge.
         }
         func.calls = rewritten_calls;
         dedupe_call_ids(&mut func.calls);

--- a/crates/api/tests/api_tests.rs
+++ b/crates/api/tests/api_tests.rs
@@ -3406,6 +3406,41 @@ fn project_symbol_graph_pre_post_shadow_with_imported_function() {
     );
 }
 
+#[test]
+fn project_symbol_graph_conflicting_import_keeps_local_call_edge() {
+    // When an import conflicts with a local function of the same name,
+    // call-edge rewriting must not rebind local bare calls to imported IDs.
+    let output = check_project_from_files(&[
+        (
+            "main.ky",
+            "import math\nfn add(x: Int, y: Int) -> Int { x - y }\nfn caller() -> Int { add(5, 3) }\n",
+        ),
+        ("math.ky", "pub fn add(x: Int, y: Int) -> Int { x + y }\n"),
+    ]);
+
+    assert!(
+        output
+            .diagnostics
+            .iter()
+            .any(|d| d.code == "E0101" && d.message.contains("conflicting import")),
+        "expected conflicting import diagnostic, got: {:?}",
+        output.diagnostics
+    );
+
+    let caller = output
+        .symbol_graph
+        .functions
+        .iter()
+        .find(|f| f.name == "caller")
+        .expect("should have caller function");
+
+    assert_eq!(
+        sorted_calls(caller),
+        vec!["fn::add".to_string()],
+        "local call edge should stay bound to local add under import conflict"
+    );
+}
+
 // ── Symbol graph call-edge invariants harness (#171) ───────────────
 
 #[test]


### PR DESCRIPTION
## Summary
Fix symbol-graph call-edge post-processing to preserve exact emitted call IDs before name-based rewrite heuristics.

This prevents local bare edges (e.g. `fn::add`) from being incorrectly rebound to imported qualified IDs (e.g. `fn::math::add`) in import-conflict scenarios.

## Tests
Added regression:
- `project_symbol_graph_conflicting_import_keeps_local_call_edge`

Validated:
- `cargo test -q -p kyokara-api project_symbol_graph_conflicting_import_keeps_local_call_edge`
- `cargo test -q -p kyokara-api project_call_edges_use_qualified_ids`
- `cargo test -q -p kyokara-api project_symbol_graph_pre_post_shadow_with_imported_function`
- `cargo test -q -p kyokara-api symbol_graph_call_edge_invariants_project_import_shadow_matrix`
- `cargo test -q -p kyokara-api`
