### PR TITLE
hir-ty: make structural record unification field-order-insensitive

### DIFF
--- a/crates/api/tests/api_tests.rs
+++ b/crates/api/tests/api_tests.rs
@@ -2227,6 +2227,20 @@ fn duplicate_record_field_in_type_alias_produces_diagnostic() {
 }
 
 #[test]
+fn structural_record_assignment_ignores_field_order() {
+    let src = r#"
+fn take(p: { x: Int, y: Int }) -> Int { p.x }
+fn main() -> Int { take({ y: 2, x: 1 }) }
+"#;
+    let output = check(src, "test.ky");
+    assert!(
+        output.diagnostics.is_empty(),
+        "expected no diagnostics for reordered structural-record fields, got: {:?}",
+        output.diagnostics
+    );
+}
+
+#[test]
 fn unknown_constructor_pattern_emits_diagnostic() {
     // `Nope` is not a constructor in scope — should produce E0013.
     let src = "fn main() -> Int { match (Some(1)) { Nope(x) => x, _ => 0 } }";

--- a/crates/hir-ty/src/unify.rs
+++ b/crates/hir-ty/src/unify.rs
@@ -114,13 +114,34 @@ impl UnificationTable {
                 }
             }
 
-            // Structural record: same fields (order-sensitive for now).
+            // Structural record: same named fields, independent of declaration order.
             (Ty::Record { fields: f1 }, Ty::Record { fields: f2 }) => {
-                f1.len() == f2.len()
-                    && f1
-                        .iter()
-                        .zip(f2.iter())
-                        .all(|((n1, t1), (n2, t2))| n1 == n2 && self.unify(t1, t2))
+                if f1.len() != f2.len() {
+                    return false;
+                }
+
+                let mut used = vec![false; f2.len()];
+                for (n1, t1) in f1 {
+                    let mut match_idx = None;
+                    for (idx, (n2, _)) in f2.iter().enumerate() {
+                        if !used[idx] && n1 == n2 {
+                            match_idx = Some(idx);
+                            break;
+                        }
+                    }
+
+                    let Some(idx) = match_idx else {
+                        return false;
+                    };
+                    used[idx] = true;
+
+                    let t2 = &f2[idx].1;
+                    if !self.unify(t1, t2) {
+                        return false;
+                    }
+                }
+
+                true
             }
 
             // Function type: params + ret.

--- a/crates/hir-ty/tests/infer_tests.rs
+++ b/crates/hir-ty/tests/infer_tests.rs
@@ -616,6 +616,14 @@ fn infer_structural_record() {
     check_ok("fn foo() -> { x: Int, y: Int } { let r = { x: 1, y: 2 }\n r }");
 }
 
+#[test]
+fn infer_structural_record_field_order_is_irrelevant() {
+    check_ok(
+        "fn take(p: { x: Int, y: Int }) -> Int { p.x }
+         fn main() -> Int { take({ y: 2, x: 1 }) }",
+    );
+}
+
 // ── Lambda tests ─────────────────────────────────────────────────────
 
 #[test]


### PR DESCRIPTION
## Summary
Structural record unification now matches fields by name, not declaration order.

This fixes false type mismatches like:
- expected `{ x: Int, y: Int }`, found `{ y: Int, x: Int }`

## Tests
Added regressions:
- `infer_structural_record_field_order_is_irrelevant` (hir-ty)
- `structural_record_assignment_ignores_field_order` (api)

## Validation
- `cargo test -q -p kyokara-hir-ty infer_structural_record_field_order_is_irrelevant`
- `cargo test -q -p kyokara-hir-ty`
- `cargo test -q -p kyokara-api structural_record_assignment_ignores_field_order`
- `cargo test -q -p kyokara-api`
