### PR TITLE
test(cli): fix stale parity code for invalid set element diagnostic

### DIFF
--- a/crates/cli/tests/fixtures/parity/single_set_invalid_element_type/expect.json
+++ b/crates/cli/tests/fixtures/parity/single_set_invalid_element_type/expect.json
@@ -3,7 +3,7 @@
   "entry": "main.ky",
   "check": {
     "ok": false,
-    "codes_all": ["E0026"],
+    "codes_all": ["E0028"],
     "messages_all": ["cannot be used as a set element"]
   },
   "run": {


### PR DESCRIPTION
## Summary
- update single_set_invalid_element_type parity fixture to expect E0028
- align fixture with current InvalidSetElement diagnostic code mapping

## Verification
- cargo test -p kyokara-cli --test parity_fixtures
