### PR TITLE
fmt: stabilize complex lambda layout in pipelines

### DIFF
--- a/crates/fmt/src/format.rs
+++ b/crates/fmt/src/format.rs
@@ -154,6 +154,14 @@ fn non_trivia_tokens(node: &SyntaxNode) -> Vec<SyntaxToken> {
         .collect()
 }
 
+/// Complex lambda bodies are clearer in forced multiline layout.
+fn lambda_body_prefers_multiline(kind: SyntaxKind) -> bool {
+    matches!(
+        kind,
+        SyntaxKind::IfExpr | SyntaxKind::MatchExpr | SyntaxKind::BlockExpr
+    )
+}
+
 // ── Source file ─────────────────────────────────────────────────────
 
 fn format_source_file(node: &SyntaxNode) -> Doc {
@@ -1274,10 +1282,17 @@ fn format_lambda_expr(node: &SyntaxNode) -> Doc {
 
     let body = node.children().find(|c| is_expr(c.kind()));
     if let Some(b) = body {
-        parts.push(Doc::group(Doc::indent(
-            INDENT,
-            Doc::concat(vec![Doc::SoftLine, format_node(&b)]),
-        )));
+        if lambda_body_prefers_multiline(b.kind()) {
+            parts.push(Doc::indent(
+                INDENT,
+                Doc::concat(vec![Doc::HardLine, format_node(&b)]),
+            ));
+        } else {
+            parts.push(Doc::group(Doc::indent(
+                INDENT,
+                Doc::concat(vec![Doc::SoftLine, format_node(&b)]),
+            )));
+        }
     }
 
     Doc::concat(parts)

--- a/crates/fmt/tests/fmt_tests.rs
+++ b/crates/fmt/tests/fmt_tests.rs
@@ -437,6 +437,22 @@ fn fmt_lambda_expr() {
     );
 }
 
+#[test]
+fn fmt_lambda_with_if_body_uses_stable_multiline_layout() {
+    assert_fmt(
+        "fn main() -> Int { fn(acc: Int, n: Int) => if (n > 1) { acc + n } else { acc } }",
+        "fn main() -> Int {\n  fn(acc: Int, n: Int) =>\n    if (n > 1) {\n      acc + n\n    } else {\n      acc\n    }\n}\n",
+    );
+}
+
+#[test]
+fn fmt_fold_lambda_in_call_uses_stable_multiline_layout() {
+    assert_fmt(
+        "fn main() -> Int { Seq.range(0, 3).fold(0, fn(acc: Int, n: Int) => if (n > 1) { acc + n } else { acc }) }",
+        "fn main() -> Int {\n  Seq.range(0, 3).fold(0, fn(acc: Int, n: Int) =>\n      if (n > 1) {\n        acc + n\n      } else {\n        acc\n      })\n}\n",
+    );
+}
+
 // ── Empty match arm list ────────────────────────────────────────────
 
 #[test]


### PR DESCRIPTION
## Summary
- force multiline layout for lambda bodies when body is complex (`if`, `match`, `block`)
- keep compact single-line layout for simple lambda bodies
- add formatter regression tests for nested higher-order pipeline readability

## Testing
- cargo test -p kyokara-fmt
