### PR TITLE
Parser: block postfix call/index continuation across line breaks

### DIFF
--- a/crates/api/tests/api_tests.rs
+++ b/crates/api/tests/api_tests.rs
@@ -205,6 +205,24 @@ fn check_parse_error_code() {
 }
 
 #[test]
+fn check_newline_parenthesized_range_after_let_has_no_call_cascade() {
+    let src = r#"
+fn main() -> Int {
+  (0..<1).fold(0, fn(acc: Int, i: Int) => {
+    let base = i
+    ((i + 1)..<4).fold(acc, fn(a: Int, j: Int) => a + j + base)
+  })
+}
+"#;
+    let output = check(src, "test.ky");
+    assert!(
+        output.diagnostics.is_empty(),
+        "expected no diagnostics for newline parenthesized range expression, got: {:?}",
+        output.diagnostics
+    );
+}
+
+#[test]
 fn check_parse_damaged_function_reports_parse_only_diagnostics() {
     let src = "fn main() -> Int { match value { _ => 0 } }";
     let output = check(src, "test.ky");
@@ -4389,7 +4407,10 @@ fn check_seq_static_constructors_are_rejected_rfc_0003() {
 
 #[test]
 fn check_seq_type_annotation_is_rejected_rfc_0003() {
-    let output = check("fn takes_seq(xs: Seq<Int>) -> Int { xs.count() }\nfn main() -> Int { 0 }", "test.ky");
+    let output = check(
+        "fn takes_seq(xs: Seq<Int>) -> Int { xs.count() }\nfn main() -> Int { 0 }",
+        "test.ky",
+    );
     assert!(
         output
             .diagnostics

--- a/crates/eval/tests/eval_tests.rs
+++ b/crates/eval/tests/eval_tests.rs
@@ -213,6 +213,19 @@ fn eval_let_multiple() {
     assert!(matches!(val, Value::Int(7)));
 }
 
+#[test]
+fn eval_newline_parenthesized_range_after_let() {
+    let val = run_ok(
+        "fn main() -> Int {
+           (0..<1).fold(0, fn(acc: Int, i: Int) => {
+             let base = i
+             ((i + 1)..<4).fold(acc, fn(a: Int, j: Int) => a + j + base)
+           })
+         }",
+    );
+    assert!(matches!(val, Value::Int(6)));
+}
+
 // ── If/else tests ────────────────────────────────────────────────────
 
 #[test]
@@ -5538,7 +5551,8 @@ fn eval_seq_surface_is_rejected_rfc_0003() {
         "expected Seq.unfold rejection, got: {err_unfold}"
     );
 
-    let err_type = run_err("fn takes_seq(xs: Seq<Int>) -> Int { xs.count() }\nfn main() -> Int { 0 }");
+    let err_type =
+        run_err("fn takes_seq(xs: Seq<Int>) -> Int { xs.count() }\nfn main() -> Int { 0 }");
     assert!(
         err_type.contains("unresolved type") || err_type.contains("type mismatch"),
         "expected Seq type rejection, got: {err_type}"

--- a/crates/hir-ty/tests/infer_tests.rs
+++ b/crates/hir-ty/tests/infer_tests.rs
@@ -234,6 +234,18 @@ fn infer_else_if_without_final_else_matches_nested_error() {
 }
 
 #[test]
+fn infer_newline_parenthesized_range_after_let_is_separate_expression() {
+    check_ok(
+        "fn main() -> Int {
+           (0..<1).fold(0, fn(acc: Int, i: Int) => {
+             let base = i
+             ((i + 1)..<4).fold(acc, fn(a: Int, j: Int) => a + j + base)
+           })
+         }",
+    );
+}
+
+#[test]
 fn infer_if_no_else_is_unit() {
     check_ok("fn foo() { if (true) { 1 } }");
 }
@@ -1345,7 +1357,8 @@ fn err_seq_static_constructors_are_rejected_rfc_0003() {
 
 #[test]
 fn err_seq_type_annotation_is_rejected_rfc_0003() {
-    let (result, _) = check("fn takes_seq(xs: Seq<Int>) -> Int { xs.count() }\nfn main() -> Int { 0 }");
+    let (result, _) =
+        check("fn takes_seq(xs: Seq<Int>) -> Int { xs.count() }\nfn main() -> Int { 0 }");
     assert!(
         result
             .diagnostics

--- a/crates/parser/src/grammar/expressions.rs
+++ b/crates/parser/src/grammar/expressions.rs
@@ -53,12 +53,12 @@ fn expr_bp(p: &mut Parser<'_>, min_bp: u8) -> Option<CompletedMarker> {
                 p.expect(Ident);
                 m.complete(p, FieldExpr)
             }
-            LParen if 25 >= min_bp => {
+            LParen if 25 >= min_bp && !p.has_line_break_before_current() => {
                 let m = lhs.precede(p);
                 arg_list(p);
                 m.complete(p, CallExpr)
             }
-            LBracket if 25 >= min_bp => {
+            LBracket if 25 >= min_bp && !p.has_line_break_before_current() => {
                 let m = lhs.precede(p);
                 p.bump(); // [
                 expr(p);

--- a/crates/parser/src/input.rs
+++ b/crates/parser/src/input.rs
@@ -14,20 +14,39 @@ pub struct Input {
     raw_kinds: Vec<SyntaxKind>,
     /// Maps non-trivia index → raw index.
     non_trivia_to_raw: Vec<u32>,
+    /// Whether there was a line break in trivia immediately before each
+    /// non-trivia token.
+    line_break_before_non_trivia: Vec<bool>,
 }
 
 impl Input {
     /// Build an `Input` from an iterator of raw token kinds.
     pub fn new(raw_kinds: Vec<SyntaxKind>) -> Input {
-        let non_trivia_to_raw = raw_kinds
+        let non_trivia_count = raw_kinds.iter().filter(|k| !k.is_trivia()).count();
+        Self::new_with_line_breaks(raw_kinds, vec![false; non_trivia_count])
+    }
+
+    /// Build an `Input` with explicit line-break-before metadata for each
+    /// non-trivia token.
+    pub fn new_with_line_breaks(
+        raw_kinds: Vec<SyntaxKind>,
+        line_break_before_non_trivia: Vec<bool>,
+    ) -> Input {
+        let non_trivia_to_raw: Vec<u32> = raw_kinds
             .iter()
             .enumerate()
             .filter(|(_, k)| !k.is_trivia())
             .map(|(i, _)| i as u32)
             .collect();
+        assert_eq!(
+            non_trivia_to_raw.len(),
+            line_break_before_non_trivia.len(),
+            "line-break metadata must match non-trivia token count"
+        );
         Input {
             raw_kinds,
             non_trivia_to_raw,
+            line_break_before_non_trivia,
         }
     }
 
@@ -48,6 +67,15 @@ impl Input {
     /// Returns `true` if there are no non-trivia tokens.
     pub fn is_empty(&self) -> bool {
         self.non_trivia_to_raw.is_empty()
+    }
+
+    /// Returns whether there is a line break in trivia before non-trivia token
+    /// `index`.
+    pub fn line_break_before(&self, index: usize) -> bool {
+        self.line_break_before_non_trivia
+            .get(index)
+            .copied()
+            .unwrap_or(false)
     }
 
     /// The raw index corresponding to non-trivia token `index`.

--- a/crates/parser/src/parser.rs
+++ b/crates/parser/src/parser.rs
@@ -100,6 +100,16 @@ impl<'i> Parser<'i> {
         }
     }
 
+    /// Returns `true` when a newline appears in trivia immediately before the
+    /// current token.
+    pub fn has_line_break_before_current(&self) -> bool {
+        if self.pending_virtual_gt > 0 {
+            false
+        } else {
+            self.input.line_break_before(self.pos)
+        }
+    }
+
     // ── Token consumption ───────────────────────────────────────────
 
     /// Advance past the current token, emitting a `Token` event.

--- a/crates/parser/tests/parser_tests.rs
+++ b/crates/parser/tests/parser_tests.rs
@@ -10,6 +10,16 @@ fn parse_tokens(kinds: &[SyntaxKind]) -> (Vec<Event>, Vec<ParseError>) {
     parse(&input)
 }
 
+/// Helper: parse from token kinds with explicit line-break-before metadata
+/// for each non-trivia token.
+fn parse_tokens_with_line_breaks(
+    kinds: &[SyntaxKind],
+    line_break_before_non_trivia: &[bool],
+) -> (Vec<Event>, Vec<ParseError>) {
+    let input = Input::new_with_line_breaks(kinds.to_vec(), line_break_before_non_trivia.to_vec());
+    parse(&input)
+}
+
 /// Helper: count events of a given variant.
 fn count_start_nodes(events: &[Event], kind: SyntaxKind) -> usize {
     events
@@ -565,7 +575,10 @@ fn binary_expr_precedence() {
 fn range_until_expr_compact_form_parses() {
     // let x = 0..<5
     let (events, errors) = parse_tokens(&[LetKw, Ident, Eq, IntLiteral, DotDotLt, IntLiteral]);
-    assert!(has_no_errors(&errors), "expected no parse errors: {errors:?}");
+    assert!(
+        has_no_errors(&errors),
+        "expected no parse errors: {errors:?}"
+    );
     assert!(has_node(&events, BinaryExpr));
 }
 
@@ -575,7 +588,10 @@ fn range_until_precedence_between_arithmetic_and_pipeline() {
     let (events, errors) = parse_tokens(&[
         LetKw, Ident, Eq, IntLiteral, Plus, IntLiteral, DotDotLt, IntLiteral, PipeGt, Ident,
     ]);
-    assert!(has_no_errors(&errors), "expected no parse errors: {errors:?}");
+    assert!(
+        has_no_errors(&errors),
+        "expected no parse errors: {errors:?}"
+    );
     assert_eq!(
         count_start_nodes(&events, BinaryExpr),
         2,
@@ -591,9 +607,7 @@ fn range_until_precedence_between_arithmetic_and_pipeline() {
 #[test]
 fn malformed_range_until_reports_single_targeted_error() {
     // let x = 0..< |> f
-    let (_events, errors) = parse_tokens(&[
-        LetKw, Ident, Eq, IntLiteral, DotDotLt, PipeGt, Ident,
-    ]);
+    let (_events, errors) = parse_tokens(&[LetKw, Ident, Eq, IntLiteral, DotDotLt, PipeGt, Ident]);
     assert_eq!(
         errors.len(),
         1,
@@ -624,6 +638,31 @@ fn call_expr() {
     assert!(has_no_errors(&errors));
     assert!(has_node(&events, CallExpr));
     assert!(has_node(&events, ArgList));
+}
+
+#[test]
+fn call_expr_not_continued_across_line_break_before_lparen() {
+    // fn main() -> Int { let x = foo
+    // (1)
+    // x }
+    //
+    // Here we represent the line break as metadata before the LParen token.
+    let kinds = &[
+        FnKw, Ident, LParen, RParen, Arrow, Ident, LBrace, LetKw, Ident, Eq, Ident, LParen,
+        IntLiteral, RParen, Ident, RBrace,
+    ];
+    let mut breaks = vec![false; kinds.len()];
+    breaks[11] = true; // line break before the call-start `(`
+    let (events, errors) = parse_tokens_with_line_breaks(kinds, &breaks);
+    assert!(
+        has_no_errors(&errors),
+        "unexpected parser errors: {errors:?}"
+    );
+    assert_eq!(
+        count_start_nodes(&events, CallExpr),
+        0,
+        "line break before `(` must prevent postfix call continuation"
+    );
 }
 
 #[test]

--- a/crates/syntax/src/lib.rs
+++ b/crates/syntax/src/lib.rs
@@ -33,9 +33,23 @@ pub fn parse(source: &str) -> Parse {
     // 1. Lex into raw tokens.
     let tokens = lexer::lex(source);
 
-    // 2. Build parser input (trivia-filtered view).
+    // 2. Build parser input (trivia-filtered view), including line-break
+    // metadata before each non-trivia token.
     let raw_kinds: Vec<SyntaxKind> = tokens.iter().map(|t| t.kind).collect();
-    let input = kyokara_parser::Input::new(raw_kinds);
+    let mut line_break_before_non_trivia: Vec<bool> = Vec::new();
+    let mut saw_line_break_since_last_non_trivia = false;
+    for tok in &tokens {
+        if tok.kind.is_trivia() {
+            if tok.text.contains('\n') || tok.text.contains('\r') {
+                saw_line_break_since_last_non_trivia = true;
+            }
+        } else {
+            line_break_before_non_trivia.push(saw_line_break_since_last_non_trivia);
+            saw_line_break_since_last_non_trivia = false;
+        }
+    }
+    let input =
+        kyokara_parser::Input::new_with_line_breaks(raw_kinds, line_break_before_non_trivia);
 
     // 3. Run the parser to get events.
     let (events, mut errors) = kyokara_parser::parse(&input);


### PR DESCRIPTION
## Summary
- prevent postfix call/index parsing when `(` or `[` appears after a line break
- wire newline-before-token metadata from syntax lexer trivia into parser input
- add regression tests for the newline parenthesized-range case that previously cascaded into E0006/E0023

## Why
This removes the `let x = i` + next-line `((i + 1)..<n).fold(...)` near-miss that was misparsed as call continuation, producing semantic cascade diagnostics.

## Validation
- cargo test -p kyokara-parser
- cargo test -p kyokara-syntax
- cargo test -p kyokara-hir-ty
- cargo test -p kyokara-api
- cargo test -p kyokara-eval
- cargo test
