### PR TITLE
tests: expand nested generic type argument coverage

### DIFF
--- a/crates/fmt/tests/fmt_tests.rs
+++ b/crates/fmt/tests/fmt_tests.rs
@@ -3,6 +3,7 @@
 #![allow(clippy::unwrap_used)]
 
 use kyokara_fmt::format_source;
+use kyokara_syntax::parse;
 
 /// Assert formatting produces expected output, AND is idempotent.
 fn assert_fmt(input: &str, expected: &str) {
@@ -19,6 +20,18 @@ fn assert_fmt(input: &str, expected: &str) {
 /// Assert that formatting doesn't change the input (already canonical).
 fn assert_unchanged(input: &str) {
     assert_fmt(input, input);
+}
+
+/// Assert formatting output parses without syntax errors.
+fn assert_fmt_parse_ok(input: &str, expected: &str) {
+    assert_fmt(input, expected);
+    let parsed = parse(expected);
+    assert!(
+        parsed.errors.is_empty(),
+        "expected formatted output to parse cleanly, got: {:?}\nsource:\n{}",
+        parsed.errors,
+        expected
+    );
 }
 
 // ── Simple constructs ───────────────────────────────────────────────
@@ -395,6 +408,30 @@ fn main() -> Int {
 #[test]
 fn fmt_type_with_generics() {
     assert_fmt("type  Box< T >  =  T", "type Box<T> = T\n");
+}
+
+#[test]
+fn fmt_nested_type_args_canonicalize_and_parse() {
+    assert_fmt_parse_ok(
+        "fn f(xs: List< List< Int > >) -> List< List< Int > > { xs }",
+        "fn f(xs: List<List<Int>>) -> List<List<Int>> {\n  xs\n}\n",
+    );
+}
+
+#[test]
+fn fmt_deep_nested_type_args_canonicalize_and_parse() {
+    assert_fmt_parse_ok(
+        "fn f(xs: Map< String, Option< List< List< Int > > > >) -> Int { xs.len() }",
+        "fn f(xs: Map<String, Option<List<List<Int>>>>) -> Int {\n  xs.len()\n}\n",
+    );
+}
+
+#[test]
+fn fmt_nested_type_args_in_alias_canonicalize_and_parse() {
+    assert_fmt_parse_ok(
+        "type T = Map< String, List< List< Int > > >",
+        "type T = Map<String, List<List<Int>>>\n",
+    );
 }
 
 #[test]

--- a/crates/parser/tests/parser_tests.rs
+++ b/crates/parser/tests/parser_tests.rs
@@ -153,6 +153,50 @@ fn nested_type_args_accept_gtgt_token() {
 }
 
 #[test]
+fn deep_nested_type_args_accept_gtgt_plus_gt_tokens() {
+    // fn f(xs: List<List<List<Int>>>) -> Int { 0 }
+    let (events, errors) = parse_tokens(&[
+        FnKw, Ident, LParen, Ident, Colon, Ident, Lt, Ident, Lt, Ident, Lt, Ident, GtGt, Gt, RParen,
+        Arrow, Ident, LBrace, IntLiteral, RBrace,
+    ]);
+    assert!(
+        has_no_errors(&errors),
+        "deep nested type args should parse: {errors:?}"
+    );
+    assert!(has_node(&events, NameType));
+    assert_eq!(count_start_nodes(&events, TypeArgList), 3);
+}
+
+#[test]
+fn nested_type_args_in_variant_payload_parse() {
+    // type T = Wrap(List<List<Int>>) | None
+    let (events, errors) = parse_tokens(&[
+        TypeKw, Ident, Eq, Ident, LParen, Ident, Lt, Ident, Lt, Ident, GtGt, RParen, Pipe, Ident,
+    ]);
+    assert!(
+        has_no_errors(&errors),
+        "nested type args in variant payload should parse: {errors:?}"
+    );
+    assert!(has_node(&events, VariantList));
+    assert_eq!(count_start_nodes(&events, TypeArgList), 2);
+}
+
+#[test]
+fn nested_type_args_with_map_and_list_parse() {
+    // fn f(xs: Map<String, List<List<Int>>>) -> Int { 0 }
+    let (events, errors) = parse_tokens(&[
+        FnKw, Ident, LParen, Ident, Colon, Ident, Lt, Ident, Comma, Ident, Lt, Ident, Lt, Ident,
+        GtGt, Gt, RParen, Arrow, Ident, LBrace, IntLiteral, RBrace,
+    ]);
+    assert!(
+        has_no_errors(&errors),
+        "nested map/list type args should parse: {errors:?}"
+    );
+    assert!(has_node(&events, NameType));
+    assert_eq!(count_start_nodes(&events, TypeArgList), 3);
+}
+
+#[test]
 fn type_with_single_payload_variant() {
     // type Boxed = Boxed(Int)
     let (events, errors) = parse_tokens(&[TypeKw, Ident, Eq, Ident, LParen, Ident, RParen]);

--- a/crates/syntax/tests/integration_tests.rs
+++ b/crates/syntax/tests/integration_tests.rs
@@ -710,6 +710,27 @@ fn roundtrip_nested_type_args_with_gtgt() {
 }
 
 #[test]
+fn roundtrip_deep_nested_type_args_with_gtgt_plus_gt() {
+    let src = "fn main(xs: List<List<List<Int>>>) -> Int { xs.len() }";
+    let green = parse_ok(src);
+    assert_eq!(green_text(&green), src);
+}
+
+#[test]
+fn roundtrip_nested_type_args_mixed_map_option_list() {
+    let src = "fn main(xs: Map<String, Option<List<List<Int>>>>) -> Int { xs.len() }";
+    let green = parse_ok(src);
+    assert_eq!(green_text(&green), src);
+}
+
+#[test]
+fn roundtrip_nested_type_args_in_variant_payload() {
+    let src = "type T = Wrap(Map<String, List<List<Int>>>) | None";
+    let green = parse_ok(src);
+    assert_eq!(green_text(&green), src);
+}
+
+#[test]
 fn roundtrip_property_trailing_comma() {
     let src = "property p(x: Int <- Gen.auto(),) { true }";
     let green = parse_ok(src);


### PR DESCRIPTION
## Summary
- expand parser coverage for nested generic type arguments (`>>` and deeper `>>>` closures in type positions)
- add syntax roundtrip tests for deep/mixed nested type shapes
- add formatter tests that canonicalize nested generic types and assert formatted output remains parse-valid

## Scope
Test-only changes. No parser/runtime behavior changes.

## Validation
- cargo test -p kyokara-parser
- cargo test -p kyokara-syntax
- cargo test -p kyokara-fmt
