### PR TITLE
perf(eval): remove O(n) clone in deque_pop_front

### DIFF
--- a/crates/eval/src/interpreter.rs
+++ b/crates/eval/src/interpreter.rs
@@ -115,15 +115,42 @@ enum SeqIterState {
 }
 
 enum SeqSourceIter {
-    Range { current: i64, end: i64 },
-    FromList { items: Rc<Vec<Value>>, idx: usize },
-    FromDeque { items: Rc<VecDeque<Value>>, idx: usize },
-    StringSplit { parts: Vec<String>, idx: usize },
-    StringLines { lines: Vec<String>, idx: usize },
-    StringChars { chars: Vec<char>, idx: usize },
-    MapKeys { keys: Vec<MapKey>, idx: usize },
-    MapValues { values: Vec<Value>, idx: usize },
-    SetValues { values: Vec<MapKey>, idx: usize },
+    Range {
+        current: i64,
+        end: i64,
+    },
+    FromList {
+        items: Rc<Vec<Value>>,
+        idx: usize,
+    },
+    FromDeque {
+        items: Rc<VecDeque<Value>>,
+        idx: usize,
+    },
+    StringSplit {
+        parts: Vec<String>,
+        idx: usize,
+    },
+    StringLines {
+        lines: Vec<String>,
+        idx: usize,
+    },
+    StringChars {
+        chars: Vec<char>,
+        idx: usize,
+    },
+    MapKeys {
+        keys: Vec<MapKey>,
+        idx: usize,
+    },
+    MapValues {
+        values: Vec<Value>,
+        idx: usize,
+    },
+    SetValues {
+        values: Vec<MapKey>,
+        idx: usize,
+    },
 }
 
 fn stable_merge_sort_by<T: Clone, E, F>(items: &[T], cmp: &mut F) -> Result<Vec<T>, E>
@@ -2668,22 +2695,25 @@ impl Interpreter {
                 Ok(Value::list(self.eval_seq_to_vec(&plan)?))
             }
             IntrinsicFn::DequePopFront => {
-                let Value::Deque(q) = &args[0] else {
+                let mut args = args.into_iter();
+                let Value::Deque(mut q) = args.next().ok_or(RuntimeError::TypeError(
+                    "deque_pop_front: missing deque argument".into(),
+                ))?
+                else {
                     return Err(RuntimeError::TypeError(
                         "deque_pop_front expects a Deque".into(),
                     ));
                 };
-                let mut rest = q.as_ref().clone();
-                let Some(value) = rest.pop_front() else {
+                if q.is_empty() {
                     return self.make_none();
-                };
+                }
+                let value = Rc::make_mut(&mut q)
+                    .pop_front()
+                    .expect("checked deque is non-empty before pop_front");
                 let value_name = Name::new(&mut self.interner, "value");
                 let rest_name = Name::new(&mut self.interner, "rest");
                 let payload = Value::Record {
-                    fields: vec![
-                        (value_name, value),
-                        (rest_name, Value::Deque(Rc::new(rest))),
-                    ],
+                    fields: vec![(value_name, value), (rest_name, Value::Deque(q))],
                     type_idx: None,
                 };
                 self.make_some(payload)
@@ -3633,6 +3663,103 @@ mod tests {
             .expect_err("ensures expression should fail at runtime");
         assert!(matches!(err, RuntimeError::DivisionByZero));
         assert_no_leaked_call_state(&mut interp);
+    }
+
+    #[test]
+    fn deque_pop_front_reuses_storage_when_unique() {
+        let mut interp = make_checked_interpreter("fn main() -> Unit {}");
+        let original = Value::deque(VecDeque::from([Value::Int(1), Value::Int(2)]));
+        let before_ptr = match &original {
+            Value::Deque(q) => Rc::as_ptr(q),
+            _ => panic!("expected deque"),
+        };
+
+        let out = interp
+            .call_complex_intrinsic(IntrinsicFn::DequePopFront, smallvec![original])
+            .expect("deque_pop_front should succeed");
+
+        let payload = interp
+            .decode_option_some_payload(&out, "deque_pop_front")
+            .expect("decode should succeed")
+            .expect("expected Some payload");
+        let Value::Record { fields, .. } = payload else {
+            panic!("expected record payload");
+        };
+        assert_eq!(fields.len(), 2, "payload should contain value/rest");
+        assert_eq!(fields[0].1, Value::Int(1), "front value should be returned");
+        let Value::Deque(rest) = &fields[1].1 else {
+            panic!("rest should be a deque");
+        };
+        assert_eq!(rest.len(), 1, "rest should contain one element");
+        assert!(
+            std::ptr::eq(before_ptr, Rc::as_ptr(rest)),
+            "deque_pop_front should not allocate a fresh deque when uniquely owned"
+        );
+    }
+
+    #[test]
+    fn deque_pop_front_detaches_when_storage_is_shared() {
+        let mut interp = make_checked_interpreter("fn main() -> Unit {}");
+        let original = Value::deque(VecDeque::from([Value::Int(1), Value::Int(2)]));
+        let alias = original.clone();
+        let alias_ptr = match &alias {
+            Value::Deque(q) => Rc::as_ptr(q),
+            _ => panic!("expected alias deque"),
+        };
+
+        let out = interp
+            .call_complex_intrinsic(IntrinsicFn::DequePopFront, smallvec![original])
+            .expect("deque_pop_front should succeed");
+
+        let payload = interp
+            .decode_option_some_payload(&out, "deque_pop_front")
+            .expect("decode should succeed")
+            .expect("expected Some payload");
+        let Value::Record { fields, .. } = payload else {
+            panic!("expected record payload");
+        };
+        let Value::Deque(rest) = &fields[1].1 else {
+            panic!("rest should be a deque");
+        };
+        let Value::Deque(alias_q) = &alias else {
+            panic!("expected alias deque");
+        };
+
+        assert_eq!(alias_q.len(), 2, "alias must remain unchanged");
+        assert_eq!(rest.len(), 1, "rest should have one element after pop");
+        assert!(
+            !std::ptr::eq(alias_ptr, Rc::as_ptr(rest)),
+            "deque_pop_front must detach when input storage is shared"
+        );
+    }
+
+    #[test]
+    fn deque_pop_front_empty_shared_does_not_mutate_alias() {
+        let mut interp = make_checked_interpreter("fn main() -> Unit {}");
+        let original = Value::deque(VecDeque::new());
+        let alias = original.clone();
+        let alias_ptr_before = match &alias {
+            Value::Deque(q) => Rc::as_ptr(q),
+            _ => panic!("expected alias deque"),
+        };
+
+        let out = interp
+            .call_complex_intrinsic(IntrinsicFn::DequePopFront, smallvec![original])
+            .expect("deque_pop_front should succeed");
+
+        let none_payload = interp
+            .decode_option_some_payload(&out, "deque_pop_front")
+            .expect("decode should succeed");
+        assert!(none_payload.is_none(), "empty deque should return None");
+
+        let Value::Deque(alias_q) = &alias else {
+            panic!("expected alias deque");
+        };
+        assert_eq!(alias_q.len(), 0, "alias must remain empty");
+        assert!(
+            std::ptr::eq(alias_ptr_before, Rc::as_ptr(alias_q)),
+            "empty pop should not mutate alias storage"
+        );
     }
 
     #[test]

--- a/crates/eval/tests/eval_tests.rs
+++ b/crates/eval/tests/eval_tests.rs
@@ -1545,6 +1545,28 @@ fn eval_deque_push_front_back_and_pop_front_fifo() {
 }
 
 #[test]
+fn eval_deque_pop_front_non_empty_returns_value_and_rest() {
+    let val = run_ok(
+        "fn main() -> Int {
+           let q0 = Deque.new().push_back(10).push_back(20)
+           match (q0.pop_front()) {
+             Some(p) =>
+               if (p.value == 10 && p.rest.len() == 1) {
+                 match (p.rest.pop_front()) {
+                   Some(p2) => p2.value
+                   None => -1
+                 }
+               } else {
+                 -1
+               }
+             None => -1
+           }
+         }",
+    );
+    assert!(matches!(val, Value::Int(20)));
+}
+
+#[test]
 fn eval_deque_pop_front_empty_returns_none() {
     let val = run_ok(
         "fn main() -> Int {


### PR DESCRIPTION
## Summary
- remove unconditional deep clone in `Deque.pop_front()` intrinsic
- switch to owned `Rc::make_mut` COW path with empty fast-path
- add black-box and white-box regression tests for unique/shared/empty aliasing behavior

## TDD
- RED: added failing COW guard tests in interpreter unit tests and non-empty behavior test in eval integration tests
- GREEN: updated runtime implementation to mutate through COW only when needed

## Verification
- `cargo test -p kyokara-eval -- deque_pop_front`
- `cargo test -p kyokara-eval -- eval_deque_`
- `cargo test -p kyokara-eval`
- `cargo clippy -p kyokara-eval --all-targets --no-deps -- -D warnings`
- note: full clippy with deps still hits pre-existing `kyokara-hir-ty` `if_same_then_else` lint
