### PR TITLE
fix(codegen): type-aware f64.store/f64.load for float fields

### DIFF
--- a/crates/codegen/src/wasm/func.rs
+++ b/crates/codegen/src/wasm/func.rs
@@ -1069,12 +1069,7 @@ impl<'a> FuncCodegen<'a> {
             let offset = AdtLayout::field_offset(i as u32);
             derive_ptr(func, layout.size);
             let field_ty = self.value_ty(field_vid);
-            self.emit_get_as_i64(func, field_vid, field_ty);
-            func.instruction(&Instruction::I64Store(MemArg {
-                offset: u64::from(offset),
-                align: 3,
-                memory_index: 0,
-            }));
+            self.emit_typed_store(func, field_vid, field_ty, u64::from(offset));
         }
 
         // Leave ptr on stack for the caller's local.set.
@@ -1095,16 +1090,7 @@ impl<'a> FuncCodegen<'a> {
         let offset = AdtLayout::field_offset(field_index);
 
         self.emit_get(func, base);
-        func.instruction(&Instruction::I64Load(MemArg {
-            offset: u64::from(offset),
-            align: 3,
-            memory_index: 0,
-        }));
-
-        // If the result type is i32 (Bool/Unit/Ptr), wrap down from i64.
-        if is_i32_type(result_ty) {
-            func.instruction(&Instruction::I32WrapI64);
-        }
+        self.emit_typed_load(func, result_ty, u64::from(offset));
 
         Ok(())
     }
@@ -1143,12 +1129,7 @@ impl<'a> FuncCodegen<'a> {
             let offset = layout::record_field_offset(i as u32);
             derive_ptr(func, size);
             let field_ty = self.value_ty(*vid);
-            self.emit_get_as_i64(func, *vid, field_ty);
-            func.instruction(&Instruction::I64Store(MemArg {
-                offset: u64::from(offset),
-                align: 3,
-                memory_index: 0,
-            }));
+            self.emit_typed_store(func, *vid, field_ty, u64::from(offset));
         }
 
         // Leave ptr on stack.
@@ -1172,15 +1153,7 @@ impl<'a> FuncCodegen<'a> {
         let offset = layout::record_field_offset(field_index);
 
         self.emit_get(func, base);
-        func.instruction(&Instruction::I64Load(MemArg {
-            offset: u64::from(offset),
-            align: 3,
-            memory_index: 0,
-        }));
-
-        if is_i32_type(result_ty) {
-            func.instruction(&Instruction::I32WrapI64);
-        }
+        self.emit_typed_load(func, result_ty, u64::from(offset));
 
         Ok(())
     }
@@ -1248,20 +1221,75 @@ impl<'a> FuncCodegen<'a> {
         func.instruction(&Instruction::LocalGet(self.local_for(vid)));
     }
 
-    /// Emit a value as i64 for storing in linear memory.
-    /// If the value is i32 (Bool/Unit/Ptr), extend to i64.
-    fn emit_get_as_i64(&self, func: &mut Function, vid: ValueId, ty: &Ty) {
+    /// Type-aware store: emit the value and the appropriate store instruction.
+    ///
+    /// - Float → `f64.store` (8 bytes, align 3)
+    /// - Int   → `i64.store` (8 bytes, align 3)
+    /// - i32 types (Bool/Unit/Ptr) → extend to i64, then `i64.store`
+    ///
+    /// All field slots are 8 bytes, so even i32 values are stored as i64
+    /// to keep the layout uniform.
+    fn emit_typed_store(&self, func: &mut Function, vid: ValueId, ty: &Ty, offset: u64) {
         self.emit_get(func, vid);
         match ty {
-            Ty::Int => {} // already i64
             Ty::Float => {
-                // reinterpret f64 bits as i64 for uniform storage
-                func.instruction(&Instruction::I64ReinterpretF64);
+                func.instruction(&Instruction::F64Store(MemArg {
+                    offset,
+                    align: 3,
+                    memory_index: 0,
+                }));
+            }
+            Ty::Int => {
+                func.instruction(&Instruction::I64Store(MemArg {
+                    offset,
+                    align: 3,
+                    memory_index: 0,
+                }));
+            }
+            _ => {
+                // i32 types (Bool/Unit/pointers): extend to i64 for uniform slot size.
+                if is_i32_type(ty) {
+                    func.instruction(&Instruction::I64ExtendI32U);
+                }
+                func.instruction(&Instruction::I64Store(MemArg {
+                    offset,
+                    align: 3,
+                    memory_index: 0,
+                }));
+            }
+        }
+    }
+
+    /// Type-aware load: emit the appropriate load instruction for the field type.
+    ///
+    /// - Float → `f64.load` (8 bytes)
+    /// - Int   → `i64.load` (8 bytes)
+    /// - i32 types → `i64.load` + `i32.wrap_i64`
+    fn emit_typed_load(&self, func: &mut Function, ty: &Ty, offset: u64) {
+        match ty {
+            Ty::Float => {
+                func.instruction(&Instruction::F64Load(MemArg {
+                    offset,
+                    align: 3,
+                    memory_index: 0,
+                }));
             }
             _ if is_i32_type(ty) => {
-                func.instruction(&Instruction::I64ExtendI32U);
+                func.instruction(&Instruction::I64Load(MemArg {
+                    offset,
+                    align: 3,
+                    memory_index: 0,
+                }));
+                func.instruction(&Instruction::I32WrapI64);
             }
-            _ => {} // best effort
+            _ => {
+                // Int and anything else: i64.load
+                func.instruction(&Instruction::I64Load(MemArg {
+                    offset,
+                    align: 3,
+                    memory_index: 0,
+                }));
+            }
         }
     }
 }

--- a/crates/codegen/tests/codegen_tests.rs
+++ b/crates/codegen/tests/codegen_tests.rs
@@ -1719,3 +1719,118 @@ fn test_requires_complex_and_ensures_complex() {
         30
     );
 }
+
+// ── Float field extraction (#335) ───────────────────────────────
+
+#[test]
+fn test_adt_float_field_roundtrip() {
+    // Float stored in ADT field, then extracted via match — must use
+    // type-aware f64.store/f64.load (not i64 reinterpret hack).
+    let val = run_main_f64(
+        "type Wrap = Wrap(Float)\n\
+         fn main() -> Float {\n\
+           match (Wrap(3.14)) {\n\
+             Wrap(x) => x\n\
+           }\n\
+         }",
+    );
+    assert!((val - 3.14).abs() < 1e-10, "expected 3.14, got {val}");
+}
+
+#[test]
+fn test_adt_float_field_arithmetic() {
+    // Extract float from ADT and use it in arithmetic.
+    let val = run_main_f64(
+        "type Wrap = Wrap(Float)\n\
+         fn main() -> Float {\n\
+           match (Wrap(2.5)) {\n\
+             Wrap(x) => x * 2.0\n\
+           }\n\
+         }",
+    );
+    assert!((val - 5.0).abs() < 1e-10, "expected 5.0, got {val}");
+}
+
+#[test]
+fn test_adt_mixed_int_float_fields() {
+    // ADT with both Int and Float fields — Int extraction must still work.
+    assert_eq!(
+        run_main_i64(
+            "type Pair = Pair(Int, Float)\n\
+             fn main() -> Int {\n\
+               match (Pair(42, 3.14)) {\n\
+                 Pair(n, _) => n\n\
+               }\n\
+             }"
+        ),
+        42
+    );
+}
+
+#[test]
+fn test_adt_mixed_int_float_fields_get_float() {
+    // Same mixed ADT but extract the Float field.
+    let val = run_main_f64(
+        "type Pair = Pair(Int, Float)\n\
+         fn main() -> Float {\n\
+           match (Pair(42, 3.14)) {\n\
+             Pair(_, f) => f\n\
+           }\n\
+         }",
+    );
+    assert!((val - 3.14).abs() < 1e-10, "expected 3.14, got {val}");
+}
+
+#[test]
+fn test_record_float_field_roundtrip() {
+    // Float stored in record field, then extracted via field access.
+    let val = run_main_f64(
+        "type Pt = { x: Float, y: Float }\n\
+         fn main() -> Float {\n\
+           let p = Pt { x: 1.5, y: 2.5 }\n\
+           p.x\n\
+         }",
+    );
+    assert!((val - 1.5).abs() < 1e-10, "expected 1.5, got {val}");
+}
+
+#[test]
+fn test_record_float_field_addition() {
+    // Extract two float fields from a record and add them.
+    let val = run_main_f64(
+        "type Pt = { x: Float, y: Float }\n\
+         fn main() -> Float {\n\
+           let p = Pt { x: 1.5, y: 2.5 }\n\
+           p.x + p.y\n\
+         }",
+    );
+    assert!((val - 4.0).abs() < 1e-10, "expected 4.0, got {val}");
+}
+
+#[test]
+fn test_record_mixed_int_float_fields() {
+    // Record with Int and Float fields — guard that Int extraction is unaffected.
+    assert_eq!(
+        run_main_i64(
+            "type Rec = { count: Int, value: Float }\n\
+             fn main() -> Int {\n\
+               let r = Rec { count: 7, value: 3.14 }\n\
+               r.count\n\
+             }"
+        ),
+        7
+    );
+}
+
+#[test]
+fn test_record_mixed_int_float_get_float() {
+    // Same mixed record but extract the Float field.
+    let val = run_main_f64(
+        "type Rec = { count: Int, value: Float }\n\
+         fn main() -> Float {\n\
+           let r = Rec { count: 7, value: 3.14 }\n\
+           r.value\n\
+         }",
+    );
+    assert!((val - 3.14).abs() < 1e-10, "expected 3.14, got {val}");
+}


### PR DESCRIPTION
## Summary

- Replaces the uniform i64 store/load strategy with type-aware memory operations for ADT and record fields
- `f64.store`/`f64.load` for Float fields, `i64.store`/`i64.load` for Int, i64 with i32 wrap/extend for pointers
- Removes the `emit_get_as_i64` reinterpret hack that was missing the reverse reinterpret on load, silently corrupting all float values extracted from ADTs and records

Closes #335

## Test plan

- [x] 8 new end-to-end tests (7 were RED before fix, all GREEN after)
- [x] ADT float roundtrip, arithmetic, mixed int/float extraction
- [x] Record float roundtrip, addition, mixed int/float extraction
- [x] Guard tests: Int extraction from mixed-type ADTs/records still works
- [x] Full suite: 137 tests pass, 0 regressions