### PR TITLE
fix: batch quick fixes (#348, #349, #354, #355)

### DIFF
--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -152,17 +152,11 @@ pub fn check_project(entry_file: &std::path::Path) -> CheckOutput {
 
     // Aggregate parse errors from all modules.
     for (mod_path, errors) in &result.parse_errors {
-        let file_name = result
-            .file_map
-            .path(
-                result
-                    .module_graph
-                    .get(mod_path)
-                    .map(|i| i.file_id)
-                    .unwrap_or(kyokara_span::FileId(0)),
-            )
+        let file_id = result.module_graph.get(mod_path).map(|i| i.file_id);
+        let file_name = file_id
+            .and_then(|fid| result.file_map.path(fid))
             .map(|p| p.display().to_string())
-            .unwrap_or_else(|| "<unknown>".into());
+            .unwrap_or_else(|| format!("<unresolved:{:?}>", mod_path));
 
         for err in errors {
             diagnostics.push(DiagnosticDto {
@@ -188,7 +182,7 @@ pub fn check_project(entry_file: &std::path::Path) -> CheckOutput {
             .file_map
             .path(diag.span.file)
             .map(|p| p.display().to_string())
-            .unwrap_or_else(|| "<project>".into());
+            .unwrap_or_else(|| format!("<unresolved:FileId({})>", diag.span.file.0));
         diagnostics.push(convert_lowering_diagnostic(diag, code, &file_name));
     }
 
@@ -199,7 +193,7 @@ pub fn check_project(entry_file: &std::path::Path) -> CheckOutput {
             .get(mod_path)
             .and_then(|i| result.file_map.path(i.file_id))
             .map(|p| p.display().to_string())
-            .unwrap_or_else(|| "<unknown>".into());
+            .unwrap_or_else(|| format!("<unresolved:{:?}>", mod_path));
 
         let item_tree = result.module_graph.get(mod_path).map(|i| &i.item_tree);
 
@@ -224,16 +218,10 @@ pub fn check_project(entry_file: &std::path::Path) -> CheckOutput {
     let mut all_types = Vec::new();
     let mut all_capabilities = Vec::new();
 
-    let builtin_names: std::collections::HashSet<&str> = [
-        "Option",
-        "Result",
-        "List",
-        "Map",
-        "Set",
-        "ParseError",
-    ]
-    .into_iter()
-    .collect();
+    let builtin_names: std::collections::HashSet<&str> =
+        ["Option", "Result", "List", "Map", "Set", "ParseError"]
+            .into_iter()
+            .collect();
     let mut seen_builtins: std::collections::HashSet<String> = std::collections::HashSet::new();
 
     for (mod_path, tc) in &result.type_checks {
@@ -242,7 +230,7 @@ pub fn check_project(entry_file: &std::path::Path) -> CheckOutput {
             .get(mod_path)
             .and_then(|i| result.file_map.path(i.file_id))
             .map(|p| p.display().to_string())
-            .unwrap_or_else(|| "<unknown>".into());
+            .unwrap_or_else(|| format!("<unresolved:{:?}>", mod_path));
 
         // Build module prefix from ModulePath segments.
         let prefix = if mod_path.is_root() {
@@ -946,7 +934,7 @@ pub fn refactor(
             if fid == file_id {
                 file_name.to_string()
             } else {
-                "<unknown>".into()
+                format!("<unresolved:FileId({})>", fid.0)
             }
         }),
         Err(e) => error_dto(e),
@@ -975,7 +963,7 @@ pub fn refactor_project(
             file_map
                 .path(fid)
                 .map(|p| p.display().to_string())
-                .unwrap_or_else(|| "<unknown>".into())
+                .unwrap_or_else(|| format!("<unresolved:FileId({})>", fid.0))
         }),
         Err(e) => error_dto(e),
     }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -379,6 +379,9 @@ fn main() {
             }
 
             if apply && (output.status == "typechecked" || output.status == "skipped") {
+                if output.status == "skipped" {
+                    eprintln!("warning: verification skipped due to --force flag");
+                }
                 // Use patched sources from the transaction when available.
                 if let Some(patched) = &output.patched_sources {
                     if let Err(e) = apply_patched_sources_atomically(patched) {

--- a/crates/eval/src/interpreter.rs
+++ b/crates/eval/src/interpreter.rs
@@ -2601,10 +2601,10 @@ impl Interpreter {
                     ));
                 };
                 if *i < 0 || *i as usize >= xs.len() {
-                    return Err(RuntimeError::TypeError(format!(
-                        "list_update: index out of bounds: index {i}, length {}",
-                        xs.len()
-                    )));
+                    return Err(RuntimeError::IndexOutOfBounds {
+                        index: *i,
+                        len: xs.len() as i64,
+                    });
                 }
                 let idx = *i as usize;
                 let updater = args[2].clone();

--- a/crates/eval/src/intrinsics.rs
+++ b/crates/eval/src/intrinsics.rs
@@ -321,10 +321,10 @@ impl IntrinsicFn {
                 };
 
                 if i < 0 || i as usize >= xs.len() {
-                    return Err(RuntimeError::TypeError(format!(
-                        "list_set: index out of bounds: index {i}, length {}",
-                        xs.len()
-                    )));
+                    return Err(RuntimeError::IndexOutOfBounds {
+                        index: i,
+                        len: xs.len() as i64,
+                    });
                 }
 
                 Rc::make_mut(&mut xs)[i as usize] = val;
@@ -1704,5 +1704,4 @@ mod tests {
             other => panic!("expected range source, got {other:?}"),
         }
     }
-
 }

--- a/crates/eval/tests/eval_tests.rs
+++ b/crates/eval/tests/eval_tests.rs
@@ -1499,7 +1499,7 @@ fn eval_list_set_out_of_bounds_runtime_error() {
            List.new().push(10).set(9, 0).len()
          }",
     );
-    assert!(err.contains("list_set: index out of bounds"), "got: {err}");
+    assert!(err.contains("index out of bounds"), "got: {err}");
 }
 
 #[test]
@@ -1509,10 +1509,7 @@ fn eval_list_update_out_of_bounds_runtime_error() {
            List.new().push(10).update(3, fn(n: Int) => n + 1).len()
          }",
     );
-    assert!(
-        err.contains("list_update: index out of bounds"),
-        "got: {err}"
-    );
+    assert!(err.contains("index out of bounds"), "got: {err}");
 }
 
 #[test]
@@ -1522,7 +1519,7 @@ fn eval_list_set_negative_index_runtime_error() {
            List.new().push(10).set(0 - 1, 0).len()
          }",
     );
-    assert!(err.contains("list_set: index out of bounds"), "got: {err}");
+    assert!(err.contains("index out of bounds"), "got: {err}");
 }
 
 // ── Deque tests ─────────────────────────────────────────────────────
@@ -7445,5 +7442,80 @@ fn eval_list_sort_valid_types_no_rejection() {
             let bools = List.new().push(true).push(false).sort()
             ints.len() == 3 && floats.len() == 3 && strings.len() == 3 && chars.len() == 3 && bools.len() == 2
         }"#,
+    );
+}
+
+// ── Negative index and error consistency (#348, #349) ────────────
+
+#[test]
+fn eval_list_get_negative_index_returns_none() {
+    // Negative index should return None, not silently wrap to huge usize.
+    let val = run_ok(
+        "fn main() -> Int {
+           let xs = List.new().push(10).push(20)
+           match (xs.get(0 - 1)) {
+             Some(_) => 1
+             None => 0
+           }
+         }",
+    );
+    assert!(
+        matches!(val, Value::Int(0)),
+        "negative index should yield None, got: {val:?}"
+    );
+}
+
+#[test]
+fn eval_list_update_negative_index_error() {
+    // Negative index in list_update should report IndexOutOfBounds, not TypeError.
+    let err = run_err(
+        "fn main() -> Int {
+           List.new().push(10).update(0 - 1, fn(n: Int) => n + 1).len()
+         }",
+    );
+    assert!(
+        err.contains("index out of bounds"),
+        "expected IndexOutOfBounds error, got: {err}"
+    );
+    // Should NOT be a TypeError.
+    assert!(
+        !err.starts_with("type error"),
+        "should use IndexOutOfBounds, not TypeError: {err}"
+    );
+}
+
+#[test]
+fn eval_list_update_oob_error_type() {
+    // list_update with positive OOB should also use IndexOutOfBounds.
+    let err = run_err(
+        "fn main() -> Int {
+           List.new().push(10).update(5, fn(n: Int) => n + 1).len()
+         }",
+    );
+    assert!(
+        err.contains("index out of bounds"),
+        "expected IndexOutOfBounds error, got: {err}"
+    );
+    assert!(
+        !err.starts_with("type error"),
+        "should use IndexOutOfBounds, not TypeError: {err}"
+    );
+}
+
+#[test]
+fn eval_list_set_oob_error_type() {
+    // list_set with positive OOB should also use IndexOutOfBounds, not TypeError.
+    let err = run_err(
+        "fn main() -> Int {
+           List.new().push(10).set(5, 0).len()
+         }",
+    );
+    assert!(
+        err.contains("index out of bounds"),
+        "expected IndexOutOfBounds error, got: {err}"
+    );
+    assert!(
+        !err.starts_with("type error"),
+        "should use IndexOutOfBounds, not TypeError: {err}"
     );
 }


### PR DESCRIPTION
## Summary

Four quick fixes batched together:

### #349 — eval: use IndexOutOfBounds for list_set/list_update
`list_set` and `list_update` were using `TypeError` for index out-of-bounds errors. Changed to use the existing `IndexOutOfBounds` error variant for consistency with other index operations.

### #348 — eval: negative index in list_get
`list_get` with negative index already returns `None` (wraps to huge usize, `.get()` returns None). Added a test to pin this behavior.

### #355 — api: replace silent `<unknown>` file fallback
All `<unknown>` sentinels in diagnostic JSON output replaced with `<unresolved:...>` that includes the module path or FileId, making it possible to diagnose which file could not be resolved.

### #354 — cli: warn when --force skips verification
Added `warning: verification skipped due to --force flag` when applying refactors with `--force`.

## Test plan

- 4 new eval tests, 3 existing tests updated
- 560 eval tests pass, 0 regressions
- API and CLI compile clean

Closes #348, closes #349, closes #354, closes #355