### PR TITLE
refactor: fail fast for unknown quickfix target_file

### DIFF
--- a/crates/refactor/src/quickfix.rs
+++ b/crates/refactor/src/quickfix.rs
@@ -40,26 +40,43 @@ pub fn add_missing_match_cases_project(
     offset: u32,
     target_file: Option<&str>,
 ) -> Result<RefactorResult, RefactorError> {
+    if let Some(target) = target_file {
+        let target_exists = result
+            .module_graph
+            .iter()
+            .any(|(_, info)| info.path.display().to_string() == target);
+        if !target_exists {
+            return Err(RefactorError::IoError {
+                message: format!("target_file `{target}` not found in project module graph"),
+            });
+        }
+    }
+
     for (mod_path, tc) in &result.type_checks {
-        let info = result.module_graph.get(mod_path);
+        let Some(info) = result.module_graph.get(mod_path) else {
+            return Err(RefactorError::InternalError {
+                message: format!(
+                    "module graph missing entry for module in quickfix lookup: {:?}",
+                    mod_path
+                ),
+            });
+        };
 
         // Filter by target_file if provided.
-        if let Some(target) = target_file {
-            let matches = info.is_some_and(|i| i.path.display().to_string() == target);
-            if !matches {
-                continue;
-            }
+        if let Some(target) = target_file
+            && info.path.display().to_string() != target
+        {
+            continue;
         }
 
-        let file_id = info.map(|i| i.file_id).unwrap_or(FileId(0));
+        let file_id = info.file_id;
 
         for (data, span) in &tc.raw_diagnostics {
             if let TyDiagnosticData::MissingMatchArms { missing } = data {
                 let start: u32 = span.range.start().into();
                 let end: u32 = span.range.end().into();
                 if offset >= start && offset <= end {
-                    let source = info.map(|i| i.source.as_str()).unwrap_or("");
-                    let parse = kyokara_syntax::parse(source);
+                    let parse = kyokara_syntax::parse(info.source.as_str());
                     let root = SyntaxNode::new_root(parse.green);
                     return build_match_cases_edit(file_id, &root, span.range, missing);
                 }
@@ -181,26 +198,43 @@ pub fn add_missing_capability_project(
     offset: u32,
     target_file: Option<&str>,
 ) -> Result<RefactorResult, RefactorError> {
+    if let Some(target) = target_file {
+        let target_exists = result
+            .module_graph
+            .iter()
+            .any(|(_, info)| info.path.display().to_string() == target);
+        if !target_exists {
+            return Err(RefactorError::IoError {
+                message: format!("target_file `{target}` not found in project module graph"),
+            });
+        }
+    }
+
     for (mod_path, tc) in &result.type_checks {
-        let info = result.module_graph.get(mod_path);
+        let Some(info) = result.module_graph.get(mod_path) else {
+            return Err(RefactorError::InternalError {
+                message: format!(
+                    "module graph missing entry for module in quickfix lookup: {:?}",
+                    mod_path
+                ),
+            });
+        };
 
         // Filter by target_file if provided.
-        if let Some(target) = target_file {
-            let matches = info.is_some_and(|i| i.path.display().to_string() == target);
-            if !matches {
-                continue;
-            }
+        if let Some(target) = target_file
+            && info.path.display().to_string() != target
+        {
+            continue;
         }
 
-        let file_id = info.map(|i| i.file_id).unwrap_or(FileId(0));
+        let file_id = info.file_id;
 
         for (data, span) in &tc.raw_diagnostics {
             if let TyDiagnosticData::EffectViolation { missing } = data {
                 let start: u32 = span.range.start().into();
                 let end: u32 = span.range.end().into();
                 if offset >= start && offset <= end {
-                    let source = info.map(|i| i.source.as_str()).unwrap_or("");
-                    let parse = kyokara_syntax::parse(source);
+                    let parse = kyokara_syntax::parse(info.source.as_str());
                     let root = SyntaxNode::new_root(parse.green);
                     return build_capability_edit(file_id, &root, span.range, missing);
                 }

--- a/crates/refactor/tests/refactor_tests.rs
+++ b/crates/refactor/tests/refactor_tests.rs
@@ -1215,6 +1215,98 @@ fn project_quickfix_wrong_target_file_returns_error() {
 }
 
 #[test]
+fn project_quickfix_missing_target_file_returns_io_error() {
+    // If target_file does not exist in the project graph, quickfix should fail
+    // with a file-not-found style error (not NoDiagnosticAtOffset).
+    let dir = tempfile::tempdir().unwrap();
+
+    let main_path = dir.path().join("main.ky");
+    std::fs::write(
+        &main_path,
+        "type A = X | Y\nfn check_a(a: A) -> Int {\n    match (a) {\n        X => 1\n    }\n}\n",
+    )
+    .unwrap();
+
+    let result = kyokara_hir::check_project(&main_path);
+    let (_root_path, root_tc) = result
+        .type_checks
+        .iter()
+        .find(|(mp, _)| mp.is_root())
+        .expect("should have root module");
+
+    let (_, span) = root_tc
+        .raw_diagnostics
+        .iter()
+        .find(|(d, _)| matches!(d, kyokara_hir::TyDiagnosticData::MissingMatchArms { .. }))
+        .expect("main.ky should have MissingMatchArms diagnostic");
+    let offset: u32 = span.range.start().into();
+
+    let missing_target = dir.path().join("missing.ky");
+    let action = RefactorAction::AddMissingMatchCases {
+        offset,
+        target_file: Some(missing_target.display().to_string()),
+    };
+    let err = kyokara_refactor::refactor_project(&result, action).unwrap_err();
+    match err {
+        RefactorError::IoError { message } => {
+            assert!(
+                message.contains("target_file")
+                    && message.contains("not found")
+                    && message.contains(&missing_target.display().to_string()),
+                "unexpected IoError message: {message}"
+            );
+        }
+        other => panic!("expected IoError for unknown target_file, got: {other:?}"),
+    }
+}
+
+#[test]
+fn project_quickfix_missing_module_info_returns_internal_error() {
+    // Guard against silent FileId(0) fallback when project data is inconsistent.
+    let dir = tempfile::tempdir().unwrap();
+
+    let main_path = dir.path().join("main.ky");
+    std::fs::write(
+        &main_path,
+        "type A = X | Y\nfn check_a(a: A) -> Int {\n    match (a) {\n        X => 1\n    }\n}\n",
+    )
+    .unwrap();
+
+    let result = kyokara_hir::check_project(&main_path);
+    let (_root_path, root_tc) = result
+        .type_checks
+        .iter()
+        .find(|(mp, _)| mp.is_root())
+        .expect("should have root module");
+
+    let (_, span) = root_tc
+        .raw_diagnostics
+        .iter()
+        .find(|(d, _)| matches!(d, kyokara_hir::TyDiagnosticData::MissingMatchArms { .. }))
+        .expect("main.ky should have MissingMatchArms diagnostic");
+    let offset: u32 = span.range.start().into();
+
+    let inconsistent = kyokara_hir::ProjectCheckResult {
+        module_graph: kyokara_hir::ModuleGraph::new(),
+        type_checks: result.type_checks,
+        interner: result.interner,
+        file_map: result.file_map,
+        parse_errors: result.parse_errors,
+        lowering_diagnostics: result.lowering_diagnostics,
+    };
+
+    let action = RefactorAction::AddMissingMatchCases {
+        offset,
+        target_file: None,
+    };
+    let err = kyokara_refactor::refactor_project(&inconsistent, action).unwrap_err();
+    assert!(
+        matches!(err, RefactorError::InternalError { .. }),
+        "expected InternalError when module graph has no entry, got: {err:?}"
+    );
+}
+
+#[test]
 fn io_error_display_includes_io_prefix() {
     let err = RefactorError::IoError {
         message: "disk full".into(),


### PR DESCRIPTION
## Summary
- remove silent `FileId(0)` / empty-source fallback in project quickfix paths
- fail fast with `IoError` when `target_file` is provided but not present in the project module graph
- fail fast with `InternalError` when `type_checks` references a module missing from `module_graph`

Fixes #342

## Tests
- added `project_quickfix_missing_target_file_returns_io_error`
- added `project_quickfix_missing_module_info_returns_internal_error`
- existing target-file disambiguation tests still pass

## Verification
- `cargo test -p kyokara-refactor`
- `cargo clippy -p kyokara-refactor --all-targets --no-deps -- -D warnings`
