### PR TITLE
RFC 0006: add while/for/break/continue loop control surface

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,21 @@ fn main() -> Int {
 }
 ```
 
-Pure by default. Private by default — use `pub` to export. No null — use `Option<T>`. No exceptions — use `Result<T, E>`. Exhaustive pattern matching enforced by the compiler. Pipeline operator (`|>`) and error propagation (`?`) for clean data flow. Convention-based modules — file path determines module path, `import` brings public names into scope. `List` includes immutable index updates (`set`/`update`) and direct traversal (`map/filter/fold/...`). `collections.Deque` provides persistent queue-style operations (`push_front`/`push_back`/`pop_front`/`pop_back`) plus the same traversal surface. `collections.MutableList` provides alias-visible in-place updates for dense-index workloads (`push`/`set`/`update`) plus the same traversal surface. Traversal constructors are surface-level expressions: `start..<end` for half-open integer ranges and `seed.unfold(step)` for stateful generation. Canonical traversal style is collection-first (`xs.map(...).filter(...).count()`). For predicate/search traversal, default to `any`/`all`/`find` (short-circuit) and reserve `fold` for true accumulation/reduction. `Int` includes `pow` as the canonical integer exponentiation method.
+Pure by default. Private by default — use `pub` to export. No null — use `Option<T>`. No exceptions — use `Result<T, E>`. Exhaustive pattern matching enforced by the compiler. Pipeline operator (`|>`) and error propagation (`?`) for clean data flow. Convention-based modules — file path determines module path, `import` brings public names into scope. `List` includes immutable index updates (`set`/`update`) and direct traversal (`map/filter/fold/...`). `collections.Deque` provides persistent queue-style operations (`push_front`/`push_back`/`pop_front`/`pop_back`) plus the same traversal surface. `collections.MutableList` provides alias-visible in-place updates for dense-index workloads (`push`/`set`/`update`) plus the same traversal surface. Traversal constructors are surface-level expressions: `start..<end` for half-open integer ranges and `seed.unfold(step)` for stateful generation. Canonical traversal style is collection-first (`xs.map(...).filter(...).count()`). For predicate/search traversal, default to `any`/`all`/`find` (short-circuit) and reserve `fold` for true accumulation/reduction. Loop control syntax is statement-only: `while (cond) { ... }`, `for (pattern in source) { ... }`, `break`, `continue`; `for` patterns support destructuring but must be irrefutable. `Int` includes `pow` as the canonical integer exponentiation method.
+
+```kyokara
+import collections
+
+fn loop_examples(xs: List<Int>, s: String) -> Int {
+  let acc = collections.MutableList.new().push(0)
+
+  for (n in 0..<10) { if ((n % 2) == 1) { acc.set(0, acc[0] + n) } }   // range
+  for (x in xs) { if (x > 0) { acc.set(0, acc[0] + 1) } }               // collection
+  for (line in s.lines()) { if (line.len() > 0) { acc.set(0, acc[0] + 1) } } // producer
+
+  acc[0]
+}
+```
 
 ## Architecture
 

--- a/crates/api/tests/api_tests.rs
+++ b/crates/api/tests/api_tests.rs
@@ -223,6 +223,65 @@ fn main() -> Int {
 }
 
 #[test]
+fn check_while_and_for_loops_typecheck() {
+    let src = r#"
+fn main(xs: List<Int>) -> Int {
+  for (x in xs) { x }
+  while (true) { break }
+  0
+}
+"#;
+    let output = check(src, "test.ky");
+    assert!(
+        output.diagnostics.is_empty(),
+        "expected no diagnostics, got: {:?}",
+        output.diagnostics
+    );
+}
+
+#[test]
+fn check_break_outside_loop_reports_targeted_type_diagnostic() {
+    let output = check("fn main() { break }", "test.ky");
+    assert!(
+        output
+            .diagnostics
+            .iter()
+            .any(|d| d.message.contains("`break` used outside loop")),
+        "expected targeted break-outside-loop diagnostic, got: {:?}",
+        output.diagnostics
+    );
+}
+
+#[test]
+fn check_for_non_traversable_source_reports_targeted_type_diagnostic() {
+    let output = check("fn main() { for (x in 1) { x } }", "test.ky");
+    assert!(
+        output
+            .diagnostics
+            .iter()
+            .any(|d| d.message.contains("for source must be traversable")),
+        "expected targeted non-traversable diagnostic, got: {:?}",
+        output.diagnostics
+    );
+}
+
+#[test]
+fn check_refutable_for_pattern_reports_targeted_type_diagnostic() {
+    let output = check(
+        "fn main(xs: List<Option<Int>>) { for (Some(x) in xs) { x } }",
+        "test.ky",
+    );
+    assert!(
+        output
+            .diagnostics
+            .iter()
+            .any(|d| d.message.contains("for loop pattern must be irrefutable")),
+        "expected targeted refutable-pattern diagnostic, got: {:?}",
+        output.diagnostics
+    );
+}
+
+#[test]
 fn check_parse_damaged_function_reports_parse_only_diagnostics() {
     let src = "fn main() -> Int { match value { _ => 0 } }";
     let output = check(src, "test.ky");
@@ -623,7 +682,11 @@ fn symbol_graph_contains_types() {
     assert_eq!(variant_names, vec!["Red", "Green", "Blue"]);
 
     assert!(
-        output.symbol_graph.types.iter().any(|t| t.name == "MutableList"),
+        output
+            .symbol_graph
+            .types
+            .iter()
+            .any(|t| t.name == "MutableList"),
         "MutableList builtin type should be in symbol graph"
     );
 }

--- a/crates/eval/src/interpreter.rs
+++ b/crates/eval/src/interpreter.rs
@@ -58,6 +58,8 @@ pub struct Interpreter {
 enum ControlFlow {
     Value(Value),
     Return(Value),
+    Break,
+    Continue,
 }
 
 enum LogicalEvalStep {
@@ -202,6 +204,7 @@ impl ControlFlow {
     fn into_value(self) -> Value {
         match self {
             ControlFlow::Value(v) | ControlFlow::Return(v) => v,
+            ControlFlow::Break | ControlFlow::Continue => Value::Unit,
         }
     }
 }
@@ -216,6 +219,7 @@ macro_rules! eval_propagate {
         let cf = $self.eval_expr($env, $body, $idx)?;
         match cf {
             cf @ ControlFlow::Return(_) => return Ok(cf),
+            cf @ ControlFlow::Break | cf @ ControlFlow::Continue => return Ok(cf),
             ControlFlow::Value(v) => v,
         }
     }};
@@ -227,6 +231,7 @@ macro_rules! eval_propagate_shared {
         let cf = $self.eval_expr_shared($body, $idx)?;
         match cf {
             cf @ ControlFlow::Return(_) => return Ok(cf),
+            cf @ ControlFlow::Break | cf @ ControlFlow::Continue => return Ok(cf),
             ControlFlow::Value(v) => v,
         }
     }};
@@ -583,6 +588,14 @@ impl Interpreter {
             if !has_requires && !has_ensures && !has_invariant {
                 let return_val = match self.eval_expr_shared(&body, body.root)? {
                     ControlFlow::Value(v) | ControlFlow::Return(v) => v,
+                    ControlFlow::Break => {
+                        return Err(RuntimeError::TypeError("`break` used outside loop".into()));
+                    }
+                    ControlFlow::Continue => {
+                        return Err(RuntimeError::TypeError(
+                            "`continue` used outside loop".into(),
+                        ));
+                    }
                 };
                 Ok(return_val)
             } else {
@@ -600,6 +613,14 @@ impl Interpreter {
 
                 let return_val = match self.eval_expr_shared(&body, body.root)? {
                     ControlFlow::Value(v) | ControlFlow::Return(v) => v,
+                    ControlFlow::Break => {
+                        return Err(RuntimeError::TypeError("`break` used outside loop".into()));
+                    }
+                    ControlFlow::Continue => {
+                        return Err(RuntimeError::TypeError(
+                            "`continue` used outside loop".into(),
+                        ));
+                    }
                 };
 
                 for inv_idx in body.invariant.iter().copied() {
@@ -1969,9 +1990,9 @@ impl Interpreter {
         match value {
             Value::Seq(plan) => Ok(plan.clone()),
             Value::List(xs) => Ok(Rc::new(SeqPlan::Source(SeqSource::FromList(xs.clone())))),
-            Value::MutableList(xs) => Ok(Rc::new(SeqPlan::Source(SeqSource::FromList(
-                Rc::new(xs.borrow().clone()),
-            )))),
+            Value::MutableList(xs) => Ok(Rc::new(SeqPlan::Source(SeqSource::FromList(Rc::new(
+                xs.borrow().clone(),
+            ))))),
             Value::Deque(xs) => Ok(Rc::new(SeqPlan::Source(SeqSource::FromDeque(xs.clone())))),
             _ => Err(RuntimeError::TypeError(format!(
                 "{intrinsic_name} expects a traversal source"
@@ -3302,7 +3323,10 @@ impl Interpreter {
                             return Err(err);
                         }
                     };
-                    if let ControlFlow::Return(_) = &result {
+                    if matches!(
+                        result,
+                        ControlFlow::Return(_) | ControlFlow::Break | ControlFlow::Continue
+                    ) {
                         env.pop_scope();
                         return Ok(result);
                     }
@@ -3310,6 +3334,47 @@ impl Interpreter {
                         env.pop_scope();
                         return Err(err);
                     }
+                }
+                Stmt::While {
+                    condition,
+                    body: loop_body,
+                } => {
+                    let result = match self.eval_while(env, body, *condition, *loop_body) {
+                        Ok(result) => result,
+                        Err(err) => {
+                            env.pop_scope();
+                            return Err(err);
+                        }
+                    };
+                    if !matches!(result, ControlFlow::Value(_)) {
+                        env.pop_scope();
+                        return Ok(result);
+                    }
+                }
+                Stmt::For {
+                    pat,
+                    source,
+                    body: loop_body,
+                } => {
+                    let result = match self.eval_for(env, body, *pat, *source, *loop_body) {
+                        Ok(result) => result,
+                        Err(err) => {
+                            env.pop_scope();
+                            return Err(err);
+                        }
+                    };
+                    if !matches!(result, ControlFlow::Value(_)) {
+                        env.pop_scope();
+                        return Ok(result);
+                    }
+                }
+                Stmt::Break => {
+                    env.pop_scope();
+                    return Ok(ControlFlow::Break);
+                }
+                Stmt::Continue => {
+                    env.pop_scope();
+                    return Ok(ControlFlow::Continue);
                 }
                 Stmt::Expr(idx) => {
                     let result = match self.eval_expr(env, body, *idx) {
@@ -3319,7 +3384,10 @@ impl Interpreter {
                             return Err(err);
                         }
                     };
-                    if let ControlFlow::Return(_) = &result {
+                    if matches!(
+                        result,
+                        ControlFlow::Return(_) | ControlFlow::Break | ControlFlow::Continue
+                    ) {
                         env.pop_scope();
                         return Ok(result);
                     }
@@ -3333,6 +3401,87 @@ impl Interpreter {
         };
         env.pop_scope();
         result
+    }
+
+    fn eval_while(
+        &mut self,
+        env: &mut Env,
+        body: &Body,
+        condition: ExprIdx,
+        loop_body: ExprIdx,
+    ) -> Result<ControlFlow, RuntimeError> {
+        loop {
+            let cond = match self.eval_expr(env, body, condition)? {
+                ControlFlow::Value(v) => v,
+                ControlFlow::Return(v) => return Ok(ControlFlow::Return(v)),
+                ControlFlow::Break => return Ok(ControlFlow::Break),
+                ControlFlow::Continue => return Ok(ControlFlow::Continue),
+            };
+            let Value::Bool(cond_bool) = cond else {
+                return Err(RuntimeError::TypeError(
+                    "while condition must be Bool".into(),
+                ));
+            };
+            if !cond_bool {
+                return Ok(ControlFlow::Value(Value::Unit));
+            }
+
+            match self.eval_expr(env, body, loop_body)? {
+                ControlFlow::Value(_) => {}
+                ControlFlow::Continue => continue,
+                ControlFlow::Break => return Ok(ControlFlow::Value(Value::Unit)),
+                ControlFlow::Return(v) => return Ok(ControlFlow::Return(v)),
+            }
+        }
+    }
+
+    fn eval_for(
+        &mut self,
+        env: &mut Env,
+        body: &Body,
+        pat: kyokara_hir_def::expr::PatIdx,
+        source: ExprIdx,
+        loop_body: ExprIdx,
+    ) -> Result<ControlFlow, RuntimeError> {
+        let source_val = match self.eval_expr(env, body, source)? {
+            ControlFlow::Value(v) => v,
+            ControlFlow::Return(v) => return Ok(ControlFlow::Return(v)),
+            ControlFlow::Break => return Ok(ControlFlow::Break),
+            ControlFlow::Continue => return Ok(ControlFlow::Continue),
+        };
+        let plan = self.require_traversal_plan(&source_val, "for loop source")?;
+        let mut early_return: Option<Value> = None;
+        self.seq_for_each_control(&plan, &mut |interp, item| {
+            env.push_scope();
+            if let Err(err) = interp.bind_pat(body, pat, &item, env) {
+                env.pop_scope();
+                return Err(err);
+            }
+
+            let body_result = match interp.eval_expr(env, body, loop_body) {
+                Ok(result) => result,
+                Err(err) => {
+                    env.pop_scope();
+                    return Err(err);
+                }
+            };
+            env.pop_scope();
+
+            match body_result {
+                ControlFlow::Value(_) | ControlFlow::Continue => Ok(SeqEmitControl::Continue),
+                ControlFlow::Break => Ok(SeqEmitControl::Break),
+                ControlFlow::Return(v) => {
+                    early_return = Some(v);
+                    Ok(SeqEmitControl::Break)
+                }
+            }
+        })?;
+
+        if let Some(v) = early_return {
+            Ok(ControlFlow::Return(v))
+        } else {
+            Ok(ControlFlow::Value(Value::Unit))
+        }
     }
 
     fn bind_pat(
@@ -3438,7 +3587,10 @@ impl Interpreter {
                             return Err(err);
                         }
                     };
-                    if let ControlFlow::Return(_) = &result {
+                    if matches!(
+                        result,
+                        ControlFlow::Return(_) | ControlFlow::Break | ControlFlow::Continue
+                    ) {
                         self.env.pop_scope();
                         return Ok(result);
                     }
@@ -3446,6 +3598,47 @@ impl Interpreter {
                         self.env.pop_scope();
                         return Err(err);
                     }
+                }
+                Stmt::While {
+                    condition,
+                    body: loop_body,
+                } => {
+                    let result = match self.eval_while_shared(body, *condition, *loop_body) {
+                        Ok(result) => result,
+                        Err(err) => {
+                            self.env.pop_scope();
+                            return Err(err);
+                        }
+                    };
+                    if !matches!(result, ControlFlow::Value(_)) {
+                        self.env.pop_scope();
+                        return Ok(result);
+                    }
+                }
+                Stmt::For {
+                    pat,
+                    source,
+                    body: loop_body,
+                } => {
+                    let result = match self.eval_for_shared(body, *pat, *source, *loop_body) {
+                        Ok(result) => result,
+                        Err(err) => {
+                            self.env.pop_scope();
+                            return Err(err);
+                        }
+                    };
+                    if !matches!(result, ControlFlow::Value(_)) {
+                        self.env.pop_scope();
+                        return Ok(result);
+                    }
+                }
+                Stmt::Break => {
+                    self.env.pop_scope();
+                    return Ok(ControlFlow::Break);
+                }
+                Stmt::Continue => {
+                    self.env.pop_scope();
+                    return Ok(ControlFlow::Continue);
                 }
                 Stmt::Expr(idx) => {
                     let result = match self.eval_expr_shared(body, *idx) {
@@ -3455,7 +3648,10 @@ impl Interpreter {
                             return Err(err);
                         }
                     };
-                    if let ControlFlow::Return(_) = &result {
+                    if matches!(
+                        result,
+                        ControlFlow::Return(_) | ControlFlow::Break | ControlFlow::Continue
+                    ) {
                         self.env.pop_scope();
                         return Ok(result);
                     }
@@ -3469,6 +3665,85 @@ impl Interpreter {
         };
         self.env.pop_scope();
         result
+    }
+
+    fn eval_while_shared(
+        &mut self,
+        body: &Body,
+        condition: ExprIdx,
+        loop_body: ExprIdx,
+    ) -> Result<ControlFlow, RuntimeError> {
+        loop {
+            let cond = match self.eval_expr_shared(body, condition)? {
+                ControlFlow::Value(v) => v,
+                ControlFlow::Return(v) => return Ok(ControlFlow::Return(v)),
+                ControlFlow::Break => return Ok(ControlFlow::Break),
+                ControlFlow::Continue => return Ok(ControlFlow::Continue),
+            };
+            let Value::Bool(cond_bool) = cond else {
+                return Err(RuntimeError::TypeError(
+                    "while condition must be Bool".into(),
+                ));
+            };
+            if !cond_bool {
+                return Ok(ControlFlow::Value(Value::Unit));
+            }
+
+            match self.eval_expr_shared(body, loop_body)? {
+                ControlFlow::Value(_) => {}
+                ControlFlow::Continue => continue,
+                ControlFlow::Break => return Ok(ControlFlow::Value(Value::Unit)),
+                ControlFlow::Return(v) => return Ok(ControlFlow::Return(v)),
+            }
+        }
+    }
+
+    fn eval_for_shared(
+        &mut self,
+        body: &Body,
+        pat: kyokara_hir_def::expr::PatIdx,
+        source: ExprIdx,
+        loop_body: ExprIdx,
+    ) -> Result<ControlFlow, RuntimeError> {
+        let source_val = match self.eval_expr_shared(body, source)? {
+            ControlFlow::Value(v) => v,
+            ControlFlow::Return(v) => return Ok(ControlFlow::Return(v)),
+            ControlFlow::Break => return Ok(ControlFlow::Break),
+            ControlFlow::Continue => return Ok(ControlFlow::Continue),
+        };
+        let plan = self.require_traversal_plan(&source_val, "for loop source")?;
+        let mut early_return: Option<Value> = None;
+        self.seq_for_each_control(&plan, &mut |interp, item| {
+            interp.env.push_scope();
+            if let Err(err) = interp.bind_pat_shared(body, pat, &item) {
+                interp.env.pop_scope();
+                return Err(err);
+            }
+
+            let body_result = match interp.eval_expr_shared(body, loop_body) {
+                Ok(result) => result,
+                Err(err) => {
+                    interp.env.pop_scope();
+                    return Err(err);
+                }
+            };
+            interp.env.pop_scope();
+
+            match body_result {
+                ControlFlow::Value(_) | ControlFlow::Continue => Ok(SeqEmitControl::Continue),
+                ControlFlow::Break => Ok(SeqEmitControl::Break),
+                ControlFlow::Return(v) => {
+                    early_return = Some(v);
+                    Ok(SeqEmitControl::Break)
+                }
+            }
+        })?;
+
+        if let Some(v) = early_return {
+            Ok(ControlFlow::Return(v))
+        } else {
+            Ok(ControlFlow::Value(Value::Unit))
+        }
     }
 
     fn bind_pat_shared(

--- a/crates/eval/src/value.rs
+++ b/crates/eval/src/value.rs
@@ -259,11 +259,7 @@ impl Value {
                 format!("[{}]", fs.join(", "))
             }
             Value::MutableList(items) => {
-                let fs: Vec<String> = items
-                    .borrow()
-                    .iter()
-                    .map(|v| v.display(interner))
-                    .collect();
+                let fs: Vec<String> = items.borrow().iter().map(|v| v.display(interner)).collect();
                 format!("MutableList([{}])", fs.join(", "))
             }
             Value::Deque(items) => {

--- a/crates/eval/tests/eval_tests.rs
+++ b/crates/eval/tests/eval_tests.rs
@@ -240,6 +240,65 @@ fn eval_if_false() {
     assert!(matches!(val, Value::Int(2)));
 }
 
+// ── Loop tests ───────────────────────────────────────────────────────
+
+#[test]
+fn eval_while_loop_breaks_correctly() {
+    let val = run_ok(
+        "import collections
+         fn main() -> Int {
+           let box = collections.MutableList.new().push(0)
+           while (box[0] < 5) {
+             box.set(0, box[0] + 1)
+           }
+           box[0]
+         }",
+    );
+    assert!(matches!(val, Value::Int(5)));
+}
+
+#[test]
+fn eval_for_loop_over_range_with_continue_and_break() {
+    let val = run_ok(
+        "import collections
+         fn main() -> Int {
+           let acc = collections.MutableList.new().push(0)
+           for (x in 0..<10) {
+             if (x == 7) { break }
+             if ((x % 2) == 0) { continue }
+             acc.set(0, acc[0] + x)
+           }
+           acc[0]
+         }",
+    );
+    assert!(matches!(val, Value::Int(9)));
+}
+
+#[test]
+fn eval_return_inside_loop_exits_function() {
+    let val = run_ok("fn main() -> Int { while (true) { return 7 }\n 0 }");
+    assert!(matches!(val, Value::Int(7)));
+}
+
+#[test]
+fn eval_for_source_is_evaluated_once() {
+    let val = run_ok(
+        "import collections
+         fn main() -> Int {
+           let counter = collections.MutableList.new().push(0)
+           for (x in { counter.set(0, counter[0] + 1)\n 0..<3 }) { x }
+           counter[0]
+         }",
+    );
+    assert!(matches!(val, Value::Int(1)));
+}
+
+#[test]
+fn eval_break_continue_outside_loop_are_compile_errors() {
+    assert!(check_has_compile_errors("fn main() { break }"));
+    assert!(check_has_compile_errors("fn main() { continue }"));
+}
+
 #[test]
 fn eval_if_with_comparison() {
     let val = run_ok(

--- a/crates/fmt/src/format.rs
+++ b/crates/fmt/src/format.rs
@@ -85,6 +85,10 @@ fn format_node_inner(node: &SyntaxNode) -> Doc {
         SyntaxKind::MatchArm => format_match_arm(node),
         SyntaxKind::MatchArmList => format_match_arm_list(node),
         SyntaxKind::IfExpr => format_if_expr(node),
+        SyntaxKind::WhileStmt => format_while_stmt(node),
+        SyntaxKind::ForStmt => format_for_stmt(node),
+        SyntaxKind::BreakStmt => format_break_stmt(),
+        SyntaxKind::ContinueStmt => format_continue_stmt(),
         SyntaxKind::BlockExpr => format_block_expr(node),
         SyntaxKind::RecordExpr => format_record_expr(node),
         SyntaxKind::RecordExprField => format_record_expr_field(node),
@@ -1170,10 +1174,65 @@ fn format_if_expr(node: &SyntaxNode) -> Doc {
     Doc::concat(parts)
 }
 
+fn format_while_stmt(node: &SyntaxNode) -> Doc {
+    let condition = node.children().find(|c| is_expr(c.kind()));
+    let body = find_child_node(node, SyntaxKind::BlockExpr);
+
+    let mut parts = vec![Doc::text("while"), Doc::text(" "), Doc::text("(")];
+    if let Some(cond) = condition {
+        parts.push(format_node(&cond));
+    }
+    parts.push(Doc::text(")"));
+    if let Some(block) = body {
+        parts.push(Doc::text(" "));
+        parts.push(format_node(&block));
+    }
+    Doc::concat(parts)
+}
+
+fn format_for_stmt(node: &SyntaxNode) -> Doc {
+    let pat = node.children().find(|c| is_pat(c.kind()));
+    let source = node.children().find(|c| is_expr(c.kind()));
+    let body = find_child_node(node, SyntaxKind::BlockExpr);
+
+    let mut parts = vec![Doc::text("for"), Doc::text(" "), Doc::text("(")];
+    if let Some(p) = pat {
+        parts.push(format_node(&p));
+    }
+    parts.push(Doc::text(" in "));
+    if let Some(src) = source {
+        parts.push(format_node(&src));
+    }
+    parts.push(Doc::text(")"));
+    if let Some(block) = body {
+        parts.push(Doc::text(" "));
+        parts.push(format_node(&block));
+    }
+    Doc::concat(parts)
+}
+
+fn format_break_stmt() -> Doc {
+    Doc::text("break")
+}
+
+fn format_continue_stmt() -> Doc {
+    Doc::text("continue")
+}
+
 fn format_block_expr(node: &SyntaxNode) -> Doc {
     let item_docs = comments::format_children_with_comments(
         node,
-        |c| is_expr(c.kind()) || c.kind() == SyntaxKind::LetBinding,
+        |c| {
+            is_expr(c.kind())
+                || matches!(
+                    c.kind(),
+                    SyntaxKind::LetBinding
+                        | SyntaxKind::WhileStmt
+                        | SyntaxKind::ForStmt
+                        | SyntaxKind::BreakStmt
+                        | SyntaxKind::ContinueStmt
+                )
+        },
         format_node,
     );
 

--- a/crates/fmt/tests/fmt_tests.rs
+++ b/crates/fmt/tests/fmt_tests.rs
@@ -253,6 +253,30 @@ fn fmt_if_expr() {
 }
 
 #[test]
+fn fmt_while_stmt_canonical_single_line_head() {
+    assert_fmt(
+        "fn main() -> Int { while (x<10) { x } }",
+        "fn main() -> Int {\n  while (x < 10) {\n    x\n  }\n}\n",
+    );
+}
+
+#[test]
+fn fmt_for_stmt_canonical_single_line_head() {
+    assert_fmt(
+        "fn main() -> Int { for (x in 0 ..< 10) { x } }",
+        "fn main() -> Int {\n  for (x in 0 ..< 10) {\n    x\n  }\n}\n",
+    );
+}
+
+#[test]
+fn fmt_break_continue_statements() {
+    assert_fmt(
+        "fn main() -> Int { while (true) { continue; break } }",
+        "fn main() -> Int {\n  while (true) {\n    continue\n    break\n  }\n}\n",
+    );
+}
+
+#[test]
 fn fmt_match_expr() {
     assert_fmt(
         "fn main() -> Int { match (x) { 1 => 2, _ => 3 } }",

--- a/crates/hir-def/src/body.rs
+++ b/crates/hir-def/src/body.rs
@@ -43,6 +43,7 @@ pub struct Body {
 pub enum LocalBindingOrigin {
     LetPattern,
     MatchArmPattern,
+    ForPattern,
     LambdaParam,
     ContractResult,
 }

--- a/crates/hir-def/src/body/lower.rs
+++ b/crates/hir-def/src/body/lower.rs
@@ -806,6 +806,36 @@ impl BodyLowerCtx<'_> {
                         stmts.push(Stmt::Expr(idx));
                     }
                 }
+                BlockItem::WhileStmt(ws) => {
+                    let condition = ws
+                        .condition()
+                        .map(|e| self.lower_expr(&e))
+                        .unwrap_or_else(|| self.alloc_expr(Expr::Missing));
+                    let body = ws
+                        .body()
+                        .map(|b| self.lower_block(&b))
+                        .unwrap_or_else(|| self.alloc_expr(Expr::Missing));
+                    stmts.push(Stmt::While { condition, body });
+                }
+                BlockItem::ForStmt(fs) => {
+                    let source = fs
+                        .source()
+                        .map(|e| self.lower_expr(&e))
+                        .unwrap_or_else(|| self.alloc_expr(Expr::Missing));
+                    self.push_scope();
+                    let pat = fs
+                        .pat()
+                        .map(|p| self.lower_pat(&p, LocalBindingOrigin::ForPattern))
+                        .unwrap_or_else(|| self.alloc_pat(pat::Pat::Missing));
+                    let body = fs
+                        .body()
+                        .map(|b| self.lower_block(&b))
+                        .unwrap_or_else(|| self.alloc_expr(Expr::Missing));
+                    self.pop_scope();
+                    stmts.push(Stmt::For { pat, source, body });
+                }
+                BlockItem::BreakStmt(_) => stmts.push(Stmt::Break),
+                BlockItem::ContinueStmt(_) => stmts.push(Stmt::Continue),
             }
         }
 

--- a/crates/hir-def/src/expr.rs
+++ b/crates/hir-def/src/expr.rs
@@ -160,6 +160,18 @@ pub enum Stmt {
         ty: Option<TypeRef>,
         init: ExprIdx,
     },
+    /// `while (condition) { body }`
+    While { condition: ExprIdx, body: ExprIdx },
+    /// `for (pat in source) { body }`
+    For {
+        pat: PatIdx,
+        source: ExprIdx,
+        body: ExprIdx,
+    },
+    /// `break`
+    Break,
+    /// `continue`
+    Continue,
     /// An expression statement.
     Expr(ExprIdx),
 }

--- a/crates/hir-def/tests/lower_tests.rs
+++ b/crates/hir-def/tests/lower_tests.rs
@@ -238,6 +238,65 @@ fn lower_if_expr() {
 }
 
 #[test]
+fn lower_while_for_break_continue_statements() {
+    let src = "fn foo() {
+      while (true) { continue; break }
+      for (x in 0..<3) { x }
+    }";
+    let (body, diags, _) = lower_fn_body(src);
+    assert!(
+        diags.is_empty(),
+        "unexpected lowering diagnostics: {diags:?}"
+    );
+
+    let Expr::Block { stmts, .. } = &body.exprs[body.root] else {
+        panic!("expected root Block");
+    };
+
+    assert!(
+        stmts.iter().any(|s| matches!(s, Stmt::While { .. })),
+        "expected lowered while statement, got: {stmts:?}"
+    );
+    assert!(
+        stmts.iter().any(|s| matches!(s, Stmt::For { .. })),
+        "expected lowered for statement, got: {stmts:?}"
+    );
+}
+
+#[test]
+fn lower_for_pattern_binding_preserves_pattern_shape() {
+    let src = "fn foo(rows: List<{ x: Int }>) {
+      for ({ x } in rows) { x }
+    }";
+    let (body, diags, _) = lower_fn_body(src);
+    assert!(
+        diags.is_empty(),
+        "unexpected lowering diagnostics: {diags:?}"
+    );
+
+    let Expr::Block { stmts, .. } = &body.exprs[body.root] else {
+        panic!("expected root Block");
+    };
+
+    let for_pat = stmts.iter().find_map(|stmt| {
+        if let Stmt::For { pat, .. } = stmt {
+            Some(*pat)
+        } else {
+            None
+        }
+    });
+
+    let Some(for_pat) = for_pat else {
+        panic!("expected for statement with pattern binding");
+    };
+    assert!(
+        matches!(&body.pats[for_pat], Pat::Record { .. }),
+        "expected record pattern for for-binding, got: {:?}",
+        body.pats[for_pat]
+    );
+}
+
+#[test]
 fn lower_else_if_expr_preserves_nested_else_branch() {
     let src = "fn foo() -> Int { if (true) { 1 } else if (false) { 2 } else { 3 } }";
     let (body, diags, _) = lower_fn_body(src);

--- a/crates/hir-ty/src/diagnostics.rs
+++ b/crates/hir-ty/src/diagnostics.rs
@@ -66,6 +66,14 @@ pub enum TyDiagnosticData {
     InvalidSetElement { ty: Ty },
     /// Unsortable element type used with `List.sort()`.
     UnsortableElement { ty: Ty },
+    /// `for` source expression is not traversable.
+    ForSourceNotTraversable { ty: Ty },
+    /// `break` used when not inside a loop.
+    BreakOutsideLoop,
+    /// `continue` used when not inside a loop.
+    ContinueOutsideLoop,
+    /// `for` loop binder pattern is refutable.
+    RefutableForPattern,
 }
 
 impl TyDiagnosticData {
@@ -100,6 +108,10 @@ impl TyDiagnosticData {
             TyDiagnosticData::InvalidMapKey { .. } => "E0024",
             TyDiagnosticData::InvalidSetElement { .. } => "E0028",
             TyDiagnosticData::UnsortableElement { .. } => "E0025",
+            TyDiagnosticData::ForSourceNotTraversable { .. } => "E0029",
+            TyDiagnosticData::BreakOutsideLoop => "E0030",
+            TyDiagnosticData::ContinueOutsideLoop => "E0031",
+            TyDiagnosticData::RefutableForPattern => "E0032",
         }
     }
 
@@ -235,6 +247,12 @@ impl TyDiagnosticData {
                     dt(ty),
                 )
             }
+            TyDiagnosticData::ForSourceNotTraversable { ty } => {
+                format!("for source must be traversable, found `{}`", dt(ty))
+            }
+            TyDiagnosticData::BreakOutsideLoop => "`break` used outside loop".into(),
+            TyDiagnosticData::ContinueOutsideLoop => "`continue` used outside loop".into(),
+            TyDiagnosticData::RefutableForPattern => "for loop pattern must be irrefutable".into(),
         };
         Diagnostic::error(message, span)
     }

--- a/crates/hir-ty/src/infer.rs
+++ b/crates/hir-ty/src/infer.rs
@@ -100,6 +100,8 @@ pub(crate) struct InferenceCtx<'a> {
     pub local_types: ArenaMap<la_arena::Idx<Pat>, Ty>,
     /// Depth counter for scoped Seq<-{List,Deque} compatibility in traversal inference.
     pub traversal_seq_compat_depth: usize,
+    /// Nesting depth of loop statements (`while` / `for`) during inference.
+    pub loop_depth: usize,
 }
 
 impl<'a> InferenceCtx<'a> {
@@ -115,6 +117,17 @@ impl<'a> InferenceCtx<'a> {
 
     fn traversal_seq_compat_enabled(&self) -> bool {
         self.traversal_seq_compat_depth > 0
+    }
+
+    pub(crate) fn with_loop_scope<R>(&mut self, f: impl FnOnce(&mut Self) -> R) -> R {
+        self.loop_depth += 1;
+        let out = f(self);
+        self.loop_depth -= 1;
+        out
+    }
+
+    pub(crate) fn in_loop(&self) -> bool {
+        self.loop_depth > 0
     }
 
     /// Record a diagnostic at the current expression.
@@ -385,6 +398,7 @@ pub fn infer_body(
         param_names: fn_item.params.iter().map(|p| p.name).collect(),
         local_types: ArenaMap::default(),
         traversal_seq_compat_depth: 0,
+        loop_depth: 0,
     };
 
     // Also try to bind param types to any matching pat_scopes entries.

--- a/crates/hir-ty/src/infer/expr.rs
+++ b/crates/hir-ty/src/infer/expr.rs
@@ -904,6 +904,43 @@ impl<'a> InferenceCtx<'a> {
                 Stmt::Expr(e) => {
                     self.infer_expr(*e, &Expectation::None);
                 }
+                Stmt::While { condition, body } => {
+                    self.infer_expr(*condition, &Expectation::Has(Ty::Bool));
+                    self.with_loop_scope(|ctx| {
+                        ctx.infer_expr(*body, &Expectation::None);
+                    });
+                }
+                Stmt::For { pat, source, body } => {
+                    let source_ty = self.infer_expr(*source, &Expectation::None);
+                    let source_ty_resolved = self.table.resolve_deep(&source_ty);
+                    let elem_ty = self
+                        .traversable_element_type(&source_ty_resolved)
+                        .unwrap_or_else(|| {
+                            self.push_diag(TyDiagnosticData::ForSourceNotTraversable {
+                                ty: source_ty_resolved.clone(),
+                            });
+                            Ty::Error
+                        });
+
+                    self.infer_pat(*pat, &elem_ty);
+                    if !self.is_irrefutable_let_pattern(*pat, &elem_ty) {
+                        self.push_pat_diag(*pat, TyDiagnosticData::RefutableForPattern);
+                    }
+
+                    self.with_loop_scope(|ctx| {
+                        ctx.infer_expr(*body, &Expectation::None);
+                    });
+                }
+                Stmt::Break => {
+                    if !self.in_loop() {
+                        self.push_diag(TyDiagnosticData::BreakOutsideLoop);
+                    }
+                }
+                Stmt::Continue => {
+                    if !self.in_loop() {
+                        self.push_diag(TyDiagnosticData::ContinueOutsideLoop);
+                    }
+                }
             }
         }
 
@@ -992,6 +1029,20 @@ impl<'a> InferenceCtx<'a> {
                     .all(|(sub_pat, field_ty)| self.is_irrefutable_let_pattern(*sub_pat, field_ty))
             }
         }
+    }
+
+    fn traversable_element_type(&self, source_ty: &Ty) -> Option<Ty> {
+        let Ty::Adt { def, args } = source_ty else {
+            return None;
+        };
+        let core = self.module_scope.core_types.kind_for_idx(*def)?;
+        if !matches!(
+            core,
+            CoreType::Seq | CoreType::List | CoreType::MutableList | CoreType::Deque
+        ) {
+            return None;
+        }
+        args.first().cloned()
     }
 
     fn infer_record_lit(

--- a/crates/hir-ty/tests/infer_tests.rs
+++ b/crates/hir-ty/tests/infer_tests.rs
@@ -251,6 +251,45 @@ fn infer_if_no_else_is_unit() {
 }
 
 #[test]
+fn infer_while_and_for_with_traversable_sources() {
+    check_ok(
+        "fn foo(xs: List<Int>, ys: MutableList<Int>, zs: Deque<Int>) {
+           for (x in 0..<3) { x }
+           for (x in xs) { x }
+           for (y in ys) { y }
+           for (z in zs) { z }
+           while (true) { break }
+         }",
+    );
+}
+
+#[test]
+fn err_for_source_not_traversable() {
+    check_err(
+        "fn foo() { for (x in 1) { x } }",
+        "for source must be traversable",
+    );
+}
+
+#[test]
+fn err_break_outside_loop() {
+    check_err("fn foo() { break }", "`break` used outside loop");
+}
+
+#[test]
+fn err_continue_outside_loop() {
+    check_err("fn foo() { continue }", "`continue` used outside loop");
+}
+
+#[test]
+fn err_for_pattern_must_be_irrefutable() {
+    check_err(
+        "fn foo(xs: List<Option<Int>>) { for (Some(x) in xs) { x } }",
+        "for loop pattern must be irrefutable",
+    );
+}
+
+#[test]
 fn infer_function_call() {
     check_ok("fn bar(x: Int) -> Int { x }\nfn foo() -> Int { bar(42) }");
 }

--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -765,15 +765,10 @@ mod tests {
         let a_path = dir.join("a.ky");
         let b_path = dir.join("b.ky");
 
-        std::fs::write(
-            &main_path,
-            "import a\nimport b\nfn main() -> Int { 0 }\n",
-        )
-        .expect("main file should be writable");
-        std::fs::write(&a_path, "pub type A = Clash(Int)\n")
-            .expect("a module should be writable");
-        std::fs::write(&b_path, "pub type B = Clash(Int)\n")
-            .expect("b module should be writable");
+        std::fs::write(&main_path, "import a\nimport b\nfn main() -> Int { 0 }\n")
+            .expect("main file should be writable");
+        std::fs::write(&a_path, "pub type A = Clash(Int)\n").expect("a module should be writable");
+        std::fs::write(&b_path, "pub type B = Clash(Int)\n").expect("b module should be writable");
 
         let result = check_project(&main_path);
         let has_collision = result.lowering_diagnostics.iter().any(|d| {
@@ -800,15 +795,10 @@ mod tests {
         let a_path = dir.join("a.ky");
         let b_path = dir.join("b.ky");
 
-        std::fs::write(
-            &main_path,
-            "import a\nimport b\nfn main() -> Int { 0 }\n",
-        )
-        .expect("main file should be writable");
-        std::fs::write(&a_path, "pub type A = Left(Int)\n")
-            .expect("a module should be writable");
-        std::fs::write(&b_path, "pub type B = Right(Int)\n")
-            .expect("b module should be writable");
+        std::fs::write(&main_path, "import a\nimport b\nfn main() -> Int { 0 }\n")
+            .expect("main file should be writable");
+        std::fs::write(&a_path, "pub type A = Left(Int)\n").expect("a module should be writable");
+        std::fs::write(&b_path, "pub type B = Right(Int)\n").expect("b module should be writable");
 
         let result = check_project(&main_path);
         let has_collision = result

--- a/crates/kir/src/lower/expr.rs
+++ b/crates/kir/src/lower/expr.rs
@@ -921,6 +921,37 @@ impl<'a> LoweringCtx<'a> {
                     let init_val = self.lower_expr(*init);
                     self.bind_pattern(*pat, init_val);
                 }
+                Stmt::While {
+                    condition,
+                    body: loop_body,
+                } => {
+                    // RFC 0006 phase-1 compatibility: keep KIR lowering exhaustive
+                    // without full loop CFG semantics yet.
+                    self.lower_expr(*condition);
+                    self.lower_expr(*loop_body);
+                }
+                Stmt::For {
+                    pat,
+                    source,
+                    body: loop_body,
+                } => {
+                    // RFC 0006 phase-1 compatibility: lower source/body and
+                    // seed pattern locals with a typed placeholder.
+                    self.lower_expr(*source);
+                    self.push_scope();
+                    let hole = self.next_hole_id();
+                    let elem = self.builder.push_hole(hole, vec![], self.pat_ty(*pat));
+                    self.bind_pattern(*pat, elem);
+                    self.lower_expr(*loop_body);
+                    self.pop_scope();
+                }
+                Stmt::Break | Stmt::Continue => {
+                    // RFC 0006 phase-1 compatibility: represent control-only
+                    // statements as typed holes in KIR until dedicated loop CFG
+                    // lowering lands.
+                    let hole = self.next_hole_id();
+                    self.builder.push_hole(hole, vec![], Ty::Unit);
+                }
                 Stmt::Expr(expr) => {
                     self.lower_expr(*expr);
                 }

--- a/crates/kir/tests/lower_tests.rs
+++ b/crates/kir/tests/lower_tests.rs
@@ -134,6 +134,23 @@ fn test_range_until_lowers_via_seq_range_intrinsic_path_rfc_0003() {
     assert!(out.contains("call intrinsic:seq_count("), "output:\n{out}");
 }
 
+#[test]
+fn test_loop_statements_lower_with_minimal_kir_compatibility_rfc_0006() {
+    let out = lower_and_display(
+        "import collections\n\
+         fn f() -> Int {\n\
+           let acc = collections.MutableList.new().push(0)\n\
+           for (x in 0..<10) {\n\
+             if (x == 7) { break }\n\
+             if ((x % 2) == 0) { continue }\n\
+             acc.set(0, acc[0] + x)\n\
+           }\n\
+           acc[0]\n\
+         }",
+    );
+    assert!(out.contains("@f"), "output:\n{out}");
+}
+
 // ── Unary ops ────────────────────────────────────────────────────
 
 #[test]

--- a/crates/lsp/src/completion.rs
+++ b/crates/lsp/src/completion.rs
@@ -148,13 +148,10 @@ fn try_dot_completion(
     }
 
     // Check static methods: List.new, Map.new, etc.
-    let base_type_idx = scope
-        .types
-        .iter()
-        .find_map(|(ty_name, ty_idx)| {
-            let resolved = ty_name.resolve(interner);
-            (!resolved.starts_with("$core_") && resolved == base_name).then_some(*ty_idx)
-        });
+    let base_type_idx = scope.types.iter().find_map(|(ty_name, ty_idx)| {
+        let resolved = ty_name.resolve(interner);
+        (!resolved.starts_with("$core_") && resolved == base_name).then_some(*ty_idx)
+    });
     if let Some(ty_idx) = base_type_idx {
         let owner_key = if let Some(core) = scope.core_types.kind_for_idx(ty_idx) {
             StaticOwnerKey::Core(core)

--- a/crates/lsp/src/server.rs
+++ b/crates/lsp/src/server.rs
@@ -325,9 +325,9 @@ mod tests {
     use futures::StreamExt;
     use serde_json::{Value, json};
     use tower::{Service, ServiceExt};
-    use tower_lsp::lsp_types::Url;
     use tower_lsp::LspService;
     use tower_lsp::jsonrpc::{Request, Response};
+    use tower_lsp::lsp_types::Url;
 
     use super::KyokaraLanguageServer;
 
@@ -908,12 +908,17 @@ mod tests {
             .inner()
             .set_test_on_change_delay_yields(slow_source, 256_u32);
 
-        let slow_fut = service.inner().on_change(uri.clone(), slow_source.to_string());
+        let slow_fut = service
+            .inner()
+            .on_change(uri.clone(), slow_source.to_string());
         let fast_fut = async {
             for _ in 0..4 {
                 tokio::task::yield_now().await;
             }
-            service.inner().on_change(uri.clone(), fast_source.to_string()).await;
+            service
+                .inner()
+                .on_change(uri.clone(), fast_source.to_string())
+                .await;
         };
         tokio::join!(slow_fut, fast_fut);
 

--- a/crates/parser/src/grammar/expressions.rs
+++ b/crates/parser/src/grammar/expressions.rs
@@ -25,6 +25,8 @@ const EXPR_RECOVERY: TokenSet = TokenSet::new(&[
 ]);
 const IF_HEAD_RECOVERY: TokenSet = TokenSet::new(&[LBrace, ElseKw, Semicolon, RBrace]);
 const MATCH_HEAD_RECOVERY: TokenSet = TokenSet::new(&[LBrace, Semicolon, RBrace]);
+const WHILE_HEAD_RECOVERY: TokenSet = TokenSet::new(&[LBrace, Semicolon, RBrace]);
+const FOR_HEAD_RECOVERY: TokenSet = TokenSet::new(&[RParen, LBrace, Semicolon, RBrace]);
 const RANGE_RHS_RECOVERY: TokenSet = TokenSet::new(&[
     LetKw, RBrace, Semicolon, RParen, Comma, FatArrow, TypeKw, FnKw, CapKw, PropertyKw, LeftArrow,
     PipeGt,
@@ -179,6 +181,18 @@ pub(super) fn block_expr(p: &mut Parser<'_>) -> CompletedMarker {
         if p.at(LetKw) {
             super::items::let_binding(p);
             while p.eat(Semicolon) {}
+        } else if p.at(WhileKw) {
+            while_stmt(p);
+            while p.eat(Semicolon) {}
+        } else if p.at(ForKw) {
+            for_stmt(p);
+            while p.eat(Semicolon) {}
+        } else if p.at(BreakKw) {
+            break_stmt(p);
+            while p.eat(Semicolon) {}
+        } else if p.at(ContinueKw) {
+            continue_stmt(p);
+            while p.eat(Semicolon) {}
         } else if expr(p).is_some() {
             // Expression statement — optionally followed by semicolons
             // (we don't require semicolons in the grammar)
@@ -217,6 +231,72 @@ fn if_expr(p: &mut Parser<'_>) -> CompletedMarker {
         }
     }
     m.complete(p, IfExpr)
+}
+
+/// `while '(' Expr ')' BlockExpr`
+fn while_stmt(p: &mut Parser<'_>) -> CompletedMarker {
+    let m = p.open();
+    p.bump(); // while
+    if p.eat(LParen) {
+        expr(p);
+        p.expect(RParen);
+    } else {
+        p.error_recover_parenthesized_head(
+            "while condition must be parenthesized",
+            WHILE_HEAD_RECOVERY,
+        );
+    }
+    if p.at(LBrace) {
+        block_expr(p);
+    } else {
+        p.error("expected block after while condition");
+    }
+    m.complete(p, WhileStmt)
+}
+
+/// `for '(' Pattern 'in' Expr ')' BlockExpr`
+fn for_stmt(p: &mut Parser<'_>) -> CompletedMarker {
+    let m = p.open();
+    p.bump(); // for
+    if p.eat(LParen) {
+        super::patterns::pattern(p);
+        if p.eat(InKw) {
+            expr(p);
+        } else {
+            p.error("for loop requires 'in'");
+            if can_start_expr(p.current()) {
+                expr(p);
+            } else {
+                p.recover_parenthesized_head_content(FOR_HEAD_RECOVERY);
+            }
+        }
+        p.expect(RParen);
+    } else {
+        p.error_recover_parenthesized_head(
+            "for loop head must be parenthesized",
+            FOR_HEAD_RECOVERY,
+        );
+    }
+    if p.at(LBrace) {
+        block_expr(p);
+    } else {
+        p.error("expected block after for loop head");
+    }
+    m.complete(p, ForStmt)
+}
+
+/// `break`
+fn break_stmt(p: &mut Parser<'_>) -> CompletedMarker {
+    let m = p.open();
+    p.bump(); // break
+    m.complete(p, BreakStmt)
+}
+
+/// `continue`
+fn continue_stmt(p: &mut Parser<'_>) -> CompletedMarker {
+    let m = p.open();
+    p.bump(); // continue
+    m.complete(p, ContinueStmt)
 }
 
 /// `match '(' Expr ')' MatchArmList`

--- a/crates/parser/src/syntax_kind.rs
+++ b/crates/parser/src/syntax_kind.rs
@@ -74,6 +74,14 @@ pub enum SyntaxKind {
     PropertyKw,
     /// `for`
     ForKw,
+    /// `in`
+    InKw,
+    /// `while`
+    WhileKw,
+    /// `break`
+    BreakKw,
+    /// `continue`
+    ContinueKw,
     /// `all`
     AllKw,
     /// `where`
@@ -286,6 +294,14 @@ pub enum SyntaxKind {
     MatchArmList,
     /// `if cond { … } else { … }`
     IfExpr,
+    /// `while (cond) { ... }`
+    WhileStmt,
+    /// `for (pat in source) { ... }`
+    ForStmt,
+    /// `break`
+    BreakStmt,
+    /// `continue`
+    ContinueStmt,
     /// `{ … }` block.
     BlockExpr,
     /// Record construction (`Foo { x: 1, y: 2 }`).
@@ -367,6 +383,10 @@ impl SyntaxKind {
                 | Self::ContractKw
                 | Self::PropertyKw
                 | Self::ForKw
+                | Self::InKw
+                | Self::WhileKw
+                | Self::BreakKw
+                | Self::ContinueKw
                 | Self::AllKw
                 | Self::WhereKw
                 | Self::PipeKw
@@ -463,6 +483,10 @@ impl SyntaxKind {
             "contract" => Some(Self::ContractKw),
             "property" => Some(Self::PropertyKw),
             "for" => Some(Self::ForKw),
+            "in" => Some(Self::InKw),
+            "while" => Some(Self::WhileKw),
+            "break" => Some(Self::BreakKw),
+            "continue" => Some(Self::ContinueKw),
             "where" => Some(Self::WhereKw),
             "pipe" => Some(Self::PipeKw),
             "old" => Some(Self::OldKw),

--- a/crates/parser/tests/parser_tests.rs
+++ b/crates/parser/tests/parser_tests.rs
@@ -156,8 +156,8 @@ fn nested_type_args_accept_gtgt_token() {
 fn deep_nested_type_args_accept_gtgt_plus_gt_tokens() {
     // fn f(xs: List<List<List<Int>>>) -> Int { 0 }
     let (events, errors) = parse_tokens(&[
-        FnKw, Ident, LParen, Ident, Colon, Ident, Lt, Ident, Lt, Ident, Lt, Ident, GtGt, Gt, RParen,
-        Arrow, Ident, LBrace, IntLiteral, RBrace,
+        FnKw, Ident, LParen, Ident, Colon, Ident, Lt, Ident, Lt, Ident, Lt, Ident, GtGt, Gt,
+        RParen, Arrow, Ident, LBrace, IntLiteral, RBrace,
     ]);
     assert!(
         has_no_errors(&errors),
@@ -966,6 +966,108 @@ fn block_expr_allows_semicolon_separators() {
     assert!(has_no_errors(&errors));
     assert!(has_node(&events, FnDef));
     assert!(has_node(&events, BlockExpr));
+}
+
+#[test]
+fn while_stmt_parses_in_block() {
+    // fn main() -> Unit { while (true) {} }
+    let (events, errors) = parse_tokens(&[
+        FnKw, Ident, LParen, RParen, Arrow, Ident, LBrace, WhileKw, LParen, TrueKw, RParen, LBrace,
+        RBrace, RBrace,
+    ]);
+    assert!(
+        has_no_errors(&errors),
+        "unexpected parser errors: {errors:?}"
+    );
+    assert!(has_node(&events, WhileStmt));
+}
+
+#[test]
+fn for_stmt_parses_in_block() {
+    // fn main() -> Unit { for (x in 0..<10) {} }
+    let (events, errors) = parse_tokens(&[
+        FnKw, Ident, LParen, RParen, Arrow, Ident, LBrace, ForKw, LParen, Ident, InKw, IntLiteral,
+        DotDotLt, IntLiteral, RParen, LBrace, RBrace, RBrace,
+    ]);
+    assert!(
+        has_no_errors(&errors),
+        "unexpected parser errors: {errors:?}"
+    );
+    assert!(has_node(&events, ForStmt));
+}
+
+#[test]
+fn break_and_continue_parse_in_block() {
+    // fn main() -> Unit { while (true) { continue; break; } }
+    let (events, errors) = parse_tokens(&[
+        FnKw, Ident, LParen, RParen, Arrow, Ident, LBrace, WhileKw, LParen, TrueKw, RParen, LBrace,
+        ContinueKw, Semicolon, BreakKw, Semicolon, RBrace, RBrace,
+    ]);
+    assert!(
+        has_no_errors(&errors),
+        "unexpected parser errors: {errors:?}"
+    );
+    assert!(has_node(&events, ContinueStmt));
+    assert!(has_node(&events, BreakStmt));
+}
+
+#[test]
+fn while_loop_head_missing_parens_reports_targeted_error() {
+    // fn main() -> Unit { while true { } }
+    let (_events, errors) = parse_tokens(&[
+        FnKw, Ident, LParen, RParen, Arrow, Ident, LBrace, WhileKw, TrueKw, LBrace, RBrace, RBrace,
+    ]);
+    assert_eq!(
+        errors.len(),
+        1,
+        "expected one targeted while parse error, got: {errors:?}"
+    );
+    assert!(
+        errors[0]
+            .message
+            .contains("while condition must be parenthesized"),
+        "expected targeted while diagnostic, got: {errors:?}"
+    );
+}
+
+#[test]
+fn for_loop_head_missing_parens_reports_targeted_error() {
+    // fn main() -> Unit { for x in 0..<10 {} }
+    let (_events, errors) = parse_tokens(&[
+        FnKw, Ident, LParen, RParen, Arrow, Ident, LBrace, ForKw, Ident, InKw, IntLiteral,
+        DotDotLt, IntLiteral, LBrace, RBrace, RBrace,
+    ]);
+    assert_eq!(
+        errors.len(),
+        1,
+        "expected one targeted for parse error, got: {errors:?}"
+    );
+    assert!(
+        errors[0]
+            .message
+            .contains("for loop head must be parenthesized"),
+        "expected targeted for-parens diagnostic, got: {errors:?}"
+    );
+}
+
+#[test]
+fn for_loop_head_missing_in_reports_targeted_error() {
+    // fn main() -> Unit { for (x xs) {} }
+    let (_events, errors) = parse_tokens(&[
+        FnKw, Ident, LParen, RParen, Arrow, Ident, LBrace, ForKw, LParen, Ident, Ident, RParen,
+        LBrace, RBrace, RBrace,
+    ]);
+    assert_eq!(
+        errors.len(),
+        1,
+        "expected one targeted for parse error, got: {errors:?}"
+    );
+    assert!(
+        errors
+            .iter()
+            .any(|e| e.message.contains("for loop requires 'in'")),
+        "expected targeted missing-`in` diagnostic, got: {errors:?}"
+    );
 }
 
 // ── Patterns ────────────────────────────────────────────────────────

--- a/crates/syntax/src/ast/nodes.rs
+++ b/crates/syntax/src/ast/nodes.rs
@@ -828,6 +828,73 @@ pub enum ElseBranch {
     IfExpr(IfExpr),
 }
 
+define_ast_node!(WhileStmt, WhileStmt);
+
+impl WhileStmt {
+    pub fn condition(&self) -> Option<Expr> {
+        self.syntax.children().find_map(Expr::cast)
+    }
+
+    pub fn body(&self) -> Option<BlockExpr> {
+        support::child(&self.syntax)
+    }
+}
+
+define_ast_node!(ForStmt, ForStmt);
+
+impl ForStmt {
+    pub fn pat(&self) -> Option<Pat> {
+        self.syntax.children().find_map(Pat::cast)
+    }
+
+    pub fn source(&self) -> Option<Expr> {
+        let mut after_in = false;
+        for elem in self.syntax.children_with_tokens() {
+            if let Some(tok) = elem.as_token() {
+                if tok.kind() == SyntaxKind::InKw {
+                    after_in = true;
+                    continue;
+                }
+                if after_in && tok.kind() == SyntaxKind::RParen {
+                    break;
+                }
+                continue;
+            }
+            if !after_in {
+                continue;
+            }
+            let node = elem.into_node()?;
+            if let Some(expr) = Expr::cast(node) {
+                return Some(expr);
+            }
+        }
+        None
+    }
+
+    pub fn body(&self) -> Option<BlockExpr> {
+        let mut after_head = false;
+        for elem in self.syntax.children_with_tokens() {
+            if let Some(tok) = elem.as_token() {
+                if tok.kind() == SyntaxKind::RParen {
+                    after_head = true;
+                }
+                continue;
+            }
+            if !after_head {
+                continue;
+            }
+            let node = elem.into_node()?;
+            if let Some(block) = BlockExpr::cast(node) {
+                return Some(block);
+            }
+        }
+        None
+    }
+}
+
+define_ast_node!(BreakStmt, BreakStmt);
+define_ast_node!(ContinueStmt, ContinueStmt);
+
 define_ast_node!(BlockExpr, BlockExpr);
 
 impl BlockExpr {
@@ -841,6 +908,10 @@ impl BlockExpr {
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum BlockItem {
     LetBinding(LetBinding),
+    WhileStmt(WhileStmt),
+    ForStmt(ForStmt),
+    BreakStmt(BreakStmt),
+    ContinueStmt(ContinueStmt),
     Expr(Expr),
 }
 
@@ -848,6 +919,18 @@ impl BlockItem {
     pub fn cast(node: SyntaxNode) -> Option<Self> {
         if let Some(let_b) = LetBinding::cast(node.clone()) {
             return Some(BlockItem::LetBinding(let_b));
+        }
+        if let Some(while_stmt) = WhileStmt::cast(node.clone()) {
+            return Some(BlockItem::WhileStmt(while_stmt));
+        }
+        if let Some(for_stmt) = ForStmt::cast(node.clone()) {
+            return Some(BlockItem::ForStmt(for_stmt));
+        }
+        if let Some(break_stmt) = BreakStmt::cast(node.clone()) {
+            return Some(BlockItem::BreakStmt(break_stmt));
+        }
+        if let Some(continue_stmt) = ContinueStmt::cast(node.clone()) {
+            return Some(BlockItem::ContinueStmt(continue_stmt));
         }
         Expr::cast(node).map(BlockItem::Expr)
     }

--- a/crates/syntax/src/lexer.rs
+++ b/crates/syntax/src/lexer.rs
@@ -296,6 +296,10 @@ mod tests {
             ("invariant", InvariantKw),
             ("property", PropertyKw),
             ("for", ForKw),
+            ("in", InKw),
+            ("while", WhileKw),
+            ("break", BreakKw),
+            ("continue", ContinueKw),
             ("where", WhereKw),
             ("pipe", PipeKw),
             ("old", OldKw),
@@ -315,7 +319,17 @@ mod tests {
     fn keyword_vs_ident() {
         // Prefixes/suffixes of keywords are identifiers, not keywords.
         let idents = [
-            "modules", "letx", "fns", "iff", "returned", "trueish", "all",
+            "modules",
+            "letx",
+            "fns",
+            "iff",
+            "returned",
+            "trueish",
+            "inbox",
+            "whiley",
+            "breaker",
+            "continues",
+            "all",
         ];
         for text in idents {
             let tokens = lex_kinds(text);

--- a/crates/syntax/tests/integration_tests.rs
+++ b/crates/syntax/tests/integration_tests.rs
@@ -2,7 +2,7 @@
 #![allow(clippy::unwrap_used)]
 
 use kyokara_syntax::ast::AstNode;
-use kyokara_syntax::ast::nodes::{ElseBranch, FnDef, IfExpr, SourceFile};
+use kyokara_syntax::ast::nodes::{ElseBranch, FnDef, ForStmt, IfExpr, SourceFile};
 use kyokara_syntax::{SyntaxKind, parse};
 
 /// Helper: parse source, check no errors, return CST debug string.
@@ -175,6 +175,59 @@ fn roundtrip_module_and_import() {
 #[test]
 fn roundtrip_if_else() {
     let src = "let x = if (true) { 1 } else { 2 }";
+    let green = parse_ok(src);
+    assert_eq!(green_text(&green), src);
+}
+
+#[test]
+fn roundtrip_while_stmt() {
+    let src = "fn main() -> Int { let i = 0; while (i < 10) { i }; i }";
+    let green = parse_ok(src);
+    assert_eq!(green_text(&green), src);
+}
+
+#[test]
+fn roundtrip_for_stmt_with_pattern_binding() {
+    let src = "fn main() -> Int { let acc = 0; for (x in 0..<10) { x }; acc }";
+    let green = parse_ok(src);
+    assert_eq!(green_text(&green), src);
+}
+
+#[test]
+fn parse_for_stmt_with_block_source_keeps_distinct_source_and_body() {
+    let src = "fn main() -> Int { for (x in { let y = 1; y..<3 }) { x } }";
+    let result = parse(src);
+    assert!(
+        result.errors.is_empty(),
+        "unexpected parse errors for for-with-block-source: {:?}",
+        result.errors
+    );
+
+    let root = kyokara_syntax::SyntaxNode::new_root(result.green);
+    let sf = SourceFile::cast(root).expect("parsed root should cast to SourceFile");
+    let for_stmt = sf
+        .syntax()
+        .descendants()
+        .find_map(ForStmt::cast)
+        .expect("expected for statement");
+
+    let source = for_stmt
+        .source()
+        .expect("expected source expression in for statement");
+    let body = for_stmt
+        .body()
+        .expect("expected body block in for statement");
+
+    assert_ne!(
+        source.syntax().text_range(),
+        body.syntax().text_range(),
+        "for source and body must point to distinct syntax nodes"
+    );
+}
+
+#[test]
+fn roundtrip_break_and_continue_in_nested_loops() {
+    let src = "fn main() -> Int { while (true) { for (x in 0..<10) { if (x == 3) { continue } else { break } }; break }; 0 }";
     let green = parse_ok(src);
     assert_eq!(green_text(&green), src);
 }
@@ -506,6 +559,61 @@ fn parse_if_without_parenthesized_condition_reports_targeted_error() {
         result.errors
     );
     assert_eq!(green_text(&result.green), src);
+}
+
+#[test]
+fn parse_while_without_parenthesized_condition_reports_targeted_error() {
+    let src = "fn main() -> Int { while true { 0 }; 0 }";
+    let result = parse(src);
+    assert_eq!(
+        result.errors.len(),
+        1,
+        "expected one targeted while parse error, got: {:?}",
+        result.errors
+    );
+    assert!(
+        result.errors[0]
+            .message
+            .contains("while condition must be parenthesized"),
+        "expected while-parenthesized diagnostic, got: {:?}",
+        result.errors
+    );
+}
+
+#[test]
+fn parse_for_without_parenthesized_head_reports_targeted_error() {
+    let src = "fn main() -> Int { for x in 0..<10 { 0 }; 0 }";
+    let result = parse(src);
+    assert_eq!(
+        result.errors.len(),
+        1,
+        "expected one targeted for parse error, got: {:?}",
+        result.errors
+    );
+    assert!(
+        result.errors[0]
+            .message
+            .contains("for loop head must be parenthesized"),
+        "expected for-parenthesized diagnostic, got: {:?}",
+        result.errors
+    );
+}
+
+#[test]
+fn parse_for_missing_in_reports_targeted_error() {
+    let src = "fn main() -> Int { for (x 0..<10) { 0 }; 0 }";
+    let result = parse(src);
+    assert_eq!(
+        result.errors.len(),
+        1,
+        "expected one targeted for parse error, got: {:?}",
+        result.errors
+    );
+    assert!(
+        result.errors[0].message.contains("for loop requires 'in'"),
+        "expected missing `in` diagnostic, got: {:?}",
+        result.errors
+    );
 }
 
 #[test]

--- a/docs/design-v0.md
+++ b/docs/design-v0.md
@@ -189,7 +189,45 @@ fn currency_symbol(c: Currency) -> String {
 
 Compiler enforces exhaustiveness.
 
-### 2.7 Contracts
+### 2.7 Loop control
+
+```kyokara
+import collections
+
+fn sum_odds(n: Int) -> Int {
+  let acc = collections.MutableList.new().push(0)
+  for (x in 0..<n) {
+    if ((x % 2) == 0) { continue }
+    if (x > 1000) { break }
+    acc.set(0, acc[0] + x)
+  }
+  acc[0]
+}
+
+fn count_positive(xs: List<Int>) -> Int {
+  let acc = collections.MutableList.new().push(0)
+  for (x in xs) {
+    if (x > 0) { acc.set(0, acc[0] + 1) }
+  }
+  acc[0]
+}
+
+fn non_empty_line_count(s: String) -> Int {
+  let acc = collections.MutableList.new().push(0)
+  for (line in s.lines()) {
+    if (line.len() > 0) { acc.set(0, acc[0] + 1) }
+  }
+  acc[0]
+}
+```
+
+Rules:
+* statement-only loop/control forms: `while (cond) { ... }`, `for (pattern in source) { ... }`, `break`, `continue`
+* parentheses and braces are mandatory in loop heads/bodies
+* `for` source must be traversable (`start..<end`, collections, and producer chains)
+* `for` pattern uses full pattern grammar but must be irrefutable (refutable patterns are type errors)
+
+### 2.8 Contracts
 
 ```kyokara
 fn withdraw(acct: Account, amt: Money) -> Result<Account, WithdrawError>
@@ -217,7 +255,7 @@ fn withdraw(acct: Account, amt: Money) -> Result<Account, WithdrawError>
 
 `old(expr)` refers to pre-state.
 
-### 2.8 Property-based tests
+### 2.9 Property-based tests
 
 ```kyokara
 property sort_idempotent(xs: List<Int> <- Gen.auto()) {
@@ -245,7 +283,7 @@ where (x > 0)
 
 The `where` expression is lowered as a precondition on the property body. Candidates that violate the constraint are discarded (with a budget of 100x the requested test count). The shrinker respects `where` constraints: shrunk counterexamples always satisfy the predicate. Unsatisfiable constraints (all candidates discarded) are reported as errors. Refined types in non-property contexts (regular functions, type aliases) are still rejected.
 
-### 2.9 Typed holes + partial compilation
+### 2.10 Typed holes + partial compilation
 
 Holes are legal syntax:
 

--- a/llms-full.txt
+++ b/llms-full.txt
@@ -123,6 +123,24 @@ fn currency_symbol(c: Currency) -> String {
 
 Compiler enforces exhaustiveness.
 
+### Loop Control
+
+```kyokara
+import collections
+
+fn sum_odds(n: Int) -> Int {
+  let acc = collections.MutableList.new().push(0)
+  for (x in 0..<n) {
+    if ((x % 2) == 0) { continue }
+    if (x > 1000) { break }
+    acc.set(0, acc[0] + x)
+  }
+  acc[0]
+}
+```
+
+Loop/control syntax is statement-only: `while (cond) { ... }`, `for (pattern in source) { ... }`, `break`, `continue`. Parentheses and braces are mandatory. `for` sources must be traversable (ranges, collections, and producer chains like `s.lines()`), and `for` patterns use full pattern grammar but must be irrefutable.
+
 ### Contracts
 
 ```kyokara

--- a/llms.txt
+++ b/llms.txt
@@ -19,6 +19,7 @@
 - Typed holes: `_` compiles to structured hole specs with expected type, effects, and constraints
 - Pipeline operator: `x |> f(a: 1)` desugars to `f(x, a: 1)`
 - Error propagation: `expr?` desugars to early-return match on `Result`
+- Loop control surface: `while (cond) { ... }`, `for (pattern in source) { ... }`, `break`, `continue`; `for` patterns support destructuring but must be irrefutable, and `for` sources are any traversables (ranges, collections, producer chains)
 - No null, no exceptions: `Option<T>` and `Result<T, E>` only (builtin types, available without imports)
 
 ## Compiler Architecture

--- a/spec/grammar.md
+++ b/spec/grammar.md
@@ -43,7 +43,8 @@ Ident            <- [a-zA-Z_] [a-zA-Z0-9_]*
 Keyword          <- 'module' / 'import' / 'as' / 'type' / 'fn' / 'let' / 'pub'
                   / 'match' / 'cap' / 'effect' / 'with' / 'pipe' / 'contract'
                   / 'requires' / 'ensures' / 'invariant'
-                  / 'property' / 'for' / 'all' / 'where'
+                  / 'property' / 'for' / 'all' / 'where' / 'in'
+                  / 'while' / 'break' / 'continue'
                   / 'old' / 'true' / 'false' / 'if' / 'else' / 'return'
 
 # Operators
@@ -188,23 +189,25 @@ Operator precedence (lowest to highest):
 | Precedence | Operators | Associativity |
 |---|---|---|
 | 1 | `\|>` | Left |
-| 2 | `\|\|` | Left |
-| 3 | `&&` | Left |
-| 4 | `==` `!=` | Left |
-| 5 | `<` `>` `<=` `>=` | Left |
-| 6 | `\|` | Left |
-| 7 | `^` | Left |
-| 8 | `&` | Left |
-| 9 | `<<` `>>` | Left |
-| 10 | `+` `-` | Left |
-| 11 | `*` `/` `%` | Left |
-| 12 | Unary `!` `-` `~` | Prefix |
-| 13 | Postfix `?` `.` `()` `[]` | Postfix |
+| 2 | `..<` | Left |
+| 3 | `\|\|` | Left |
+| 4 | `&&` | Left |
+| 5 | `==` `!=` | Left |
+| 6 | `<` `>` `<=` `>=` | Left |
+| 7 | `\|` | Left |
+| 8 | `^` | Left |
+| 9 | `&` | Left |
+| 10 | `<<` `>>` | Left |
+| 11 | `+` `-` | Left |
+| 12 | `*` `/` `%` | Left |
+| 13 | Unary `!` `-` `~` | Prefix |
+| 14 | Postfix `?` `.` `()` `[]` | Postfix |
 
 ```peg
 Expr               <- PipelineExpr
 
-PipelineExpr       <- OrExpr ('|>' OrExpr)*
+PipelineExpr       <- RangeExpr ('|>' RangeExpr)*
+RangeExpr          <- OrExpr ('..<' OrExpr)*
 OrExpr             <- AndExpr ('||' AndExpr)*
 AndExpr            <- EqualityExpr ('&&' EqualityExpr)*
 EqualityExpr       <- ComparisonExpr (('==' / '!=') ComparisonExpr)*
@@ -246,8 +249,13 @@ LiteralExpr        <- IntLiteral / FloatLiteral / StringLiteral
 IdentExpr          <- Ident
 PathExpr           <- Path
 ParenExpr          <- '(' Expr ')'
-BlockExpr          <- '{' (LetBinding / Expr)* Expr? '}'
+BlockExpr          <- '{' BlockItem* Expr? '}'
+BlockItem          <- LetBinding / WhileStmt / ForStmt / BreakStmt / ContinueStmt / Expr
 IfExpr             <- 'if' '(' Expr ')' BlockExpr ('else' (IfExpr / BlockExpr))?
+WhileStmt          <- 'while' '(' Expr ')' BlockExpr
+ForStmt            <- 'for' '(' Pattern 'in' Expr ')' BlockExpr
+BreakStmt          <- 'break'
+ContinueStmt       <- 'continue'
 MatchExpr          <- 'match' '(' Expr ')' MatchArmList
 # Match arms accept optional commas; leading `|` is rejected.
 MatchArmList       <- '{' (MatchArm (',' MatchArm)* ','?)? '}'
@@ -287,7 +295,8 @@ All keywords listed above are reserved and cannot be used as identifiers.
 
 ```
 all      as       cap      contract  effect   else     ensures
-false    fn       for      if        import   invariant let
-match    module   old      pipe      property pub      requires
-return   true     type     where     with
+false    fn       for      if        import   in        invariant
+let      match    module   old       pipe     property  pub
+requires return   true     type      where    while     with
+break    continue
 ```


### PR DESCRIPTION
## Summary
Implements RFC 0006 loop/control surface end-to-end:
- `while (cond) { ... }`
- `for (pattern in source) { ... }` (destructuring supported)
- `break` / `continue`

## What changed
- Parser/syntax/fmt support for loop/control statements, including targeted parse diagnostics and anti-cascade recovery.
- HIR lowering support (`Stmt::While/For/Break/Continue`).
- Type-checking support:
  - traversable-source requirement for `for`
  - irrefutable-pattern requirement for `for`
  - `break` / `continue` outside-loop diagnostics
- Eval runtime semantics for while/for/break/continue (nearest-loop behavior, return propagation, source evaluated once).
- KIR phase-1 compatibility for new statement variants (non-panicking exhaustive lowering).
- Docs sync (`spec/grammar.md`, `README.md`, `docs/design-v0.md`, `llms.txt`, `llms-full.txt`).
- Added/updated comprehensive tests across parser/syntax/fmt/hir-def/hir-ty/eval/api/kir.

## Follow-up
Created KIR-fidelity follow-up issue for full loop CFG semantics:
- https://github.com/kyokaralang/kyokara/issues/363

## Validation
- `cargo test -p kyokara-parser`
- `cargo test -p kyokara-syntax`
- `cargo test -p kyokara-fmt`
- `cargo test -p kyokara-hir-def`
- `cargo test -p kyokara-hir-ty`
- `cargo test -p kyokara-eval`
- `cargo test -p kyokara-api`
- `cargo test -p kyokara-kir`
- full `cargo test`
