### PR TITLE
fmt: preserve indexed subexpressions

### DIFF
--- a/crates/fmt/src/format.rs
+++ b/crates/fmt/src/format.rs
@@ -78,6 +78,7 @@ fn format_node_inner(node: &SyntaxNode) -> Doc {
         SyntaxKind::CallExpr => format_call_expr(node),
         SyntaxKind::NamedArg => format_named_arg(node),
         SyntaxKind::ArgList => format_arg_list(node),
+        SyntaxKind::IndexExpr => format_index_expr(node),
         SyntaxKind::FieldExpr => format_field_expr(node),
         SyntaxKind::PipelineExpr => format_pipeline_expr(node),
         SyntaxKind::PropagateExpr => format_propagate_expr(node),
@@ -359,6 +360,7 @@ fn is_expr(kind: SyntaxKind) -> bool {
             | SyntaxKind::BinaryExpr
             | SyntaxKind::UnaryExpr
             | SyntaxKind::CallExpr
+            | SyntaxKind::IndexExpr
             | SyntaxKind::FieldExpr
             | SyntaxKind::PipelineExpr
             | SyntaxKind::PropagateExpr
@@ -982,6 +984,20 @@ fn format_call_expr(node: &SyntaxNode) -> Doc {
         parts.push(format_node(&al));
     }
     Doc::concat(parts)
+}
+
+fn format_index_expr(node: &SyntaxNode) -> Doc {
+    let exprs: Vec<SyntaxNode> = node.children().filter(|c| is_expr(c.kind())).collect();
+    if exprs.len() == 2 {
+        Doc::concat(vec![
+            format_node(&exprs[0]),
+            Doc::text("["),
+            format_node(&exprs[1]),
+            Doc::text("]"),
+        ])
+    } else {
+        verbatim(node)
+    }
 }
 
 fn format_arg_list(node: &SyntaxNode) -> Doc {

--- a/crates/fmt/tests/fmt_tests.rs
+++ b/crates/fmt/tests/fmt_tests.rs
@@ -245,6 +245,54 @@ fn fmt_call_expr() {
 }
 
 #[test]
+fn fmt_index_expr_simple_parse_ok() {
+    assert_fmt_parse_ok(
+        "fn main(xs: List<Int>) -> Int { xs[0] }",
+        "fn main(xs: List<Int>) -> Int {\n  xs[0]\n}\n",
+    );
+}
+
+#[test]
+fn fmt_method_receiver_with_index_expr_preserved() {
+    assert_fmt_parse_ok(
+        "fn main() -> String { let out = collections.MutableList.new().push(\"\") let _o = out.set(0, out[0].concat(\"x\")) out[0] }",
+        "fn main() -> String {\n  let out = collections.MutableList.new().push(\"\")\n  let _o = out.set(0, out[0].concat(\"x\"))\n  out[0]\n}\n",
+    );
+}
+
+#[test]
+fn fmt_call_arg_index_expr_preserved() {
+    assert_fmt_parse_ok(
+        "fn main() -> Int { let best = collections.MutableList.new().push(0) let cost = collections.MutableList.new().push(42) let _b = best.set(0, cost[0]) best[0] }",
+        "fn main() -> Int {\n  let best = collections.MutableList.new().push(0)\n  let cost = collections.MutableList.new().push(42)\n  let _b = best.set(0, cost[0])\n  best[0]\n}\n",
+    );
+}
+
+#[test]
+fn fmt_lambda_body_index_expr_preserved() {
+    assert_fmt_parse_ok(
+        "fn keep(xs: List<Int>, ys: MutableList<Bool>, v: Int, n: Int) -> List<Int> { xs.filter(fn(x: Int) => ys[v * n + x]).to_list() }",
+        "fn keep(xs: List<Int>, ys: MutableList<Bool>, v: Int, n: Int) -> List<Int> {\n  xs.filter(fn(x: Int) => ys[v * n + x]).to_list()\n}\n",
+    );
+}
+
+#[test]
+fn fmt_unary_operand_index_expr_preserved() {
+    assert_fmt_parse_ok(
+        "fn main(feeds: MutableList<Bool>) -> Bool { !feeds[0] }",
+        "fn main(feeds: MutableList<Bool>) -> Bool {\n  !feeds[0]\n}\n",
+    );
+}
+
+#[test]
+fn fmt_record_field_index_expr_preserved() {
+    assert_fmt_parse_ok(
+        "fn main(part1: MutableList<Int>) -> Totals { Totals { part1: part1[0], part2: 0 } }",
+        "fn main(part1: MutableList<Int>) -> Totals {\n  Totals { part1: part1[0], part2: 0 }\n}\n",
+    );
+}
+
+#[test]
 fn fmt_if_expr() {
     assert_fmt(
         "fn main() -> Int { if (true) { 1 } else { 2 } }",


### PR DESCRIPTION
## Summary
- treat `IndexExpr` as a real expression in the formatter
- add formatter regression tests for the AoC-derived corruption cases
- preserve indexed subexpressions in method receivers, call args, lambda bodies, unary operands, and record fields

Fixes #377.

## Validation
- `cargo test -p kyokara-fmt --test fmt_tests -- --nocapture`
- `cargo test -p kyokara-fmt`