### PR TITLE
fmt: preserve zero-arg call arg lists

### DIFF
--- a/crates/fmt/src/format.rs
+++ b/crates/fmt/src/format.rs
@@ -1010,6 +1010,10 @@ fn format_arg_list(node: &SyntaxNode) -> Doc {
         }
     }
 
+    if arg_docs.is_empty() {
+        return Doc::text("()");
+    }
+
     Doc::group(Doc::concat(vec![
         Doc::text("("),
         Doc::indent(

--- a/crates/fmt/tests/fmt_tests.rs
+++ b/crates/fmt/tests/fmt_tests.rs
@@ -245,6 +245,14 @@ fn fmt_call_expr() {
 }
 
 #[test]
+fn fmt_zero_arg_call_expr() {
+    assert_fmt_parse_ok(
+        "fn main(xs: List<Int>) -> List<Int> { xs.to_list() }",
+        "fn main(xs: List<Int>) -> List<Int> {\n  xs.to_list()\n}\n",
+    );
+}
+
+#[test]
 fn fmt_index_expr_simple_parse_ok() {
     assert_fmt_parse_ok(
         "fn main(xs: List<Int>) -> Int { xs[0] }",
@@ -273,6 +281,14 @@ fn fmt_lambda_body_index_expr_preserved() {
     assert_fmt_parse_ok(
         "fn keep(xs: List<Int>, ys: MutableList<Bool>, v: Int, n: Int) -> List<Int> { xs.filter(fn(x: Int) => ys[v * n + x]).to_list() }",
         "fn keep(xs: List<Int>, ys: MutableList<Bool>, v: Int, n: Int) -> List<Int> {\n  xs.filter(fn(x: Int) => ys[v * n + x]).to_list()\n}\n",
+    );
+}
+
+#[test]
+fn fmt_zero_arg_call_after_wrapped_chain_preserved() {
+    assert_fmt_parse_ok(
+        "fn main(input: String) -> List<String> { input.lines().map(fn(line: String) => line.trim()).filter(fn(line: String) => line.len() > 0).to_list() }",
+        "fn main(input: String) -> List<String> {\n  input.lines().map(fn(line: String) => line.trim()).filter(fn(line: String) => line.len() > 0).to_list()\n}\n",
     );
 }
 


### PR DESCRIPTION
## Summary
- preserve empty arg lists as `()` in formatter output
- add zero-arg call regression tests, including the wrapped `...filter(...).to_list()` AoC shape
- verify the AoC 2024 day21-day25 formatter repro now stays parse-clean through the real CLI

Follow-up to #377.

## Validation
- `cargo test -p kyokara-fmt --test fmt_tests -- --nocapture`
- `cargo test -p kyokara-fmt`
- CLI end-to-end: format + check throwaway copies of AoC 2024 day21-day25