### PR TITLE
docs: codify count predicate family law

### DIFF
--- a/docs/rfcs/0001-api-surface-law.md
+++ b/docs/rfcs/0001-api-surface-law.md
@@ -136,6 +136,26 @@ Non-canonical aliases must not be introduced as parallel public APIs:
 Do not ship duplicate entrypoints for the same semantic operation.
 Do not rely on type/arity overload ambiguity as the primary API shape.
 
+### L7A. Family-completing arity variants (`MAY`, constrained)
+
+A small fixed arity family on one API name is allowed only when all of the
+following are true:
+
+1. each arity encodes a distinct, obvious operation
+2. arity alone selects semantics mechanically; type-directed overload resolution is not required
+3. the family completes an established query/terminal set and is the least-surprising predicted form
+4. no parallel synonym name is introduced for the same operation
+5. docs/examples/diagnostics specify the full family explicitly
+
+Canonical example:
+
+- `xs.count()` counts all elements
+- `xs.count(f)` counts matching elements
+
+Non-canonical parallel synonym:
+
+- `xs.count_if(f)`
+
 ### L8. No implicit coercions (`MUST`)
 
 Type changes are explicit in API usage.
@@ -213,7 +233,8 @@ Canonical consequences:
 - integer ranges use `start..<end` (constructor surface)
 - stateful sources use `seed.unfold(step)` (constructor surface)
 - `List`/`Deque` expose storage methods and traversal methods directly
-- traversal transforms/terminals (`map/filter/enumerate/zip/chunks/windows/fold/count/to_list`) are callable on collection and producer values
+- traversal transforms/terminals (`map/filter/enumerate/zip/chunks/windows/fold/any/all/find/count/to_list`) are callable on collection and producer values
+- `count` is a constrained arity family under `L7A`: `count()` for all elements, `count(predicate)` for matching elements
 - producer traversal APIs stay traversal-capable (`String.split/lines/chars`, `Map.keys/values`, `Set.values`)
 
 ## Visibility policy (canonical decision)
@@ -244,6 +265,7 @@ The following can be enforced by lints/tooling:
 7. forbidden global intrinsic spellings resolving in user scope
 8. core method/static/constructor dispatch keyed by surface names instead of owner identity
 9. unqualified user constructors colliding with reserved core constructor names while reservation is active
+10. arity families that are not explicitly documented and justified under `L7A`
 
 ## API-surface conformance checklist
 
@@ -251,7 +273,7 @@ Use this checklist in PRs that add or change stdlib/intrinsic/public APIs.
 
 ### A. New API checklist
 
-- [ ] Canonical spelling is unique (`L1`, `L7`).
+- [ ] Canonical spelling is unique, or any constrained arity family is explicitly justified under `L7A`.
 - [ ] Placement follows owner rule (method vs module vs type constructor) (`L2`, `L5`).
 - [ ] Canonical form is namespaced (not a runtime global) (`L3`).
 - [ ] Effectful behavior is capability-scoped (`L4`).
@@ -268,7 +290,7 @@ Use this checklist in PRs that add or change stdlib/intrinsic/public APIs.
 ### B. API change checklist
 
 - [ ] Parameter order in existing APIs is unchanged unless breaking change is explicitly approved (`L10`, `L15`).
-- [ ] No new synonym/overload path is introduced (`L1`, `L7`).
+- [ ] No new synonym path is introduced, and any arity family remains within the `L7A` guardrails.
 - [ ] Existing canonical call sites remain valid or have migration guidance (`L15`).
 - [ ] Deprecation/migration notes are included when behavior or naming changes (`L15`).
 - [ ] Docs and machine-facing outputs are updated in the same PR.

--- a/docs/rfcs/0002-collection-first-traversal-surface.md
+++ b/docs/rfcs/0002-collection-first-traversal-surface.md
@@ -77,7 +77,20 @@ Canonical user forms:
 10. `xs.all(f)`
 11. `xs.find(f)`
 12. `xs.count()`
-13. `xs.to_list()`
+13. `xs.count(f)`
+14. `xs.to_list()`
+
+Predicate terminal query family:
+
+1. `xs.any(f)` asks whether any element matches
+2. `xs.all(f)` asks whether all elements match
+3. `xs.find(f)` returns the first matching element
+4. `xs.count()` counts all elements
+5. `xs.count(f)` counts matching elements
+
+`xs.filter(f).count()` remains valid composition when the filtered traversal is
+also reused, but `xs.count(f)` is the canonical direct count query because it
+completes the terminal predicate family and satisfies RFC 0001 `L7A`.
 
 These operations are available on traversal-capable values, including:
 
@@ -168,6 +181,20 @@ After:
 let ok = ranges.any(fn(r: IdRange) => id >= r.start && id <= r.end)
 ```
 
+### Example C: predicate count
+
+Before:
+
+```kyokara
+let fits = pairs.filter(fn(p: Pair) => p.left <= p.right).count()
+```
+
+After:
+
+```kyokara
+let fits = pairs.count(fn(p: Pair) => p.left <= p.right)
+```
+
 ## RFC 0001 Amendment
 
 This RFC supersedes RFC 0001 `L18` as currently written.
@@ -221,7 +248,8 @@ Decision: reject permanent dual surface.
 1. Day-to-day traversal code never requires `seq()`.
 2. Common previous near-miss (`List.enumerate`) is valid by construction.
 3. No loss of traversal expressiveness compared with current `Seq` surface.
-4. RFC 0001 law text updated to reflect canonical model.
+4. `count()` and `count(predicate)` are both explicitly documented as the terminal count family.
+5. RFC 0001 law text updated to reflect canonical model and the `L7A` family-completion rule.
 
 ## Follow-up
 


### PR DESCRIPTION
## Summary
- update RFC 0001 with a constrained family-completing arity rule
- encode `count()` / `count(predicate)` as the concrete example
- update RFC 0002 so traversal docs match the revised API law

## Testing
- git diff --check