### PR TITLE
fmt: preserve visibility and canonical ADT variants

### DIFF
--- a/crates/fmt/src/format.rs
+++ b/crates/fmt/src/format.rs
@@ -310,7 +310,9 @@ fn format_path(node: &SyntaxNode) -> Doc {
 // ── Type definitions ────────────────────────────────────────────────
 
 fn format_type_def(node: &SyntaxNode) -> Doc {
-    let mut parts = vec![Doc::text("type"), Doc::text(" ")];
+    let mut parts = item_visibility_prefix(node);
+    parts.push(Doc::text("type"));
+    parts.push(Doc::text(" "));
 
     if let Some(name) = find_ident(node) {
         parts.push(format_token(&name));
@@ -390,12 +392,14 @@ fn is_pat(kind: SyntaxKind) -> bool {
 fn format_variant_list(node: &SyntaxNode) -> Doc {
     let variants = child_nodes(node, SyntaxKind::Variant);
     let mut parts = Vec::new();
-    for v in &variants {
-        parts.push(Doc::concat(vec![
-            Doc::HardLine,
-            Doc::text("  | "),
-            format_node(v),
-        ]));
+    for (idx, v) in variants.iter().enumerate() {
+        parts.push(Doc::HardLine);
+        if idx == 0 {
+            parts.push(Doc::text("  "));
+        } else {
+            parts.push(Doc::text("  | "));
+        }
+        parts.push(format_node(v));
     }
     Doc::concat(parts)
 }
@@ -473,7 +477,9 @@ fn format_record_field(node: &SyntaxNode) -> Doc {
 // ── Function definitions ────────────────────────────────────────────
 
 fn format_fn_def(node: &SyntaxNode) -> Doc {
-    let mut parts = vec![Doc::text("fn"), Doc::text(" ")];
+    let mut parts = item_visibility_prefix(node);
+    parts.push(Doc::text("fn"));
+    parts.push(Doc::text(" "));
     let mut has_sections = false;
 
     if let Some(name) = find_ident(node) {
@@ -641,7 +647,9 @@ fn format_cap_def(node: &SyntaxNode) -> Doc {
         return verbatim(node);
     }
 
-    let mut parts = vec![Doc::text("effect"), Doc::text(" ")];
+    let mut parts = item_visibility_prefix(node);
+    parts.push(Doc::text("effect"));
+    parts.push(Doc::text(" "));
 
     if let Some(name) = find_ident(node) {
         parts.push(format_token(&name));
@@ -672,6 +680,18 @@ fn format_property_def(node: &SyntaxNode) -> Doc {
     }
 
     Doc::concat(parts)
+}
+
+fn item_visibility_prefix(node: &SyntaxNode) -> Vec<Doc> {
+    if node
+        .children_with_tokens()
+        .filter_map(|it| it.into_token())
+        .any(|tok| tok.kind() == SyntaxKind::PubKw)
+    {
+        vec![Doc::text("pub"), Doc::text(" ")]
+    } else {
+        Vec::new()
+    }
 }
 
 fn format_property_param_list(node: &SyntaxNode) -> Doc {

--- a/crates/fmt/tests/fmt_tests.rs
+++ b/crates/fmt/tests/fmt_tests.rs
@@ -111,6 +111,14 @@ fn fmt_fn_multiple() {
 }
 
 #[test]
+fn fmt_pub_fn_preserved() {
+    assert_fmt_parse_ok(
+        "pub fn add(x: Int, y: Int) -> Int { x + y }",
+        "pub fn add(x: Int, y: Int) -> Int {\n  x + y\n}\n",
+    );
+}
+
+#[test]
 fn fmt_fn_with_contract_section() {
     assert_fmt(
         "fn inc(x: Int) -> Int contract requires (x > 0) ensures (result > x) { x + 1 }",
@@ -137,7 +145,7 @@ fn fmt_type_alias() {
 fn fmt_type_adt() {
     assert_fmt(
         "type Option = Some(Int) | None",
-        "type Option =\n  | Some(Int)\n  | None\n",
+        "type Option =\n  Some(Int)\n  | None\n",
     );
 }
 
@@ -145,8 +153,21 @@ fn fmt_type_adt() {
 fn fmt_type_adt_multiple_fields() {
     assert_fmt(
         "type Result = Ok(Int) | Err(String)",
-        "type Result =\n  | Ok(Int)\n  | Err(String)\n",
+        "type Result =\n  Ok(Int)\n  | Err(String)\n",
     );
+}
+
+#[test]
+fn fmt_pub_type_preserved() {
+    assert_fmt_parse_ok(
+        "pub type Result = Ok(Int) | Err(String)",
+        "pub type Result =\n  Ok(Int)\n  | Err(String)\n",
+    );
+}
+
+#[test]
+fn fmt_pub_effect_preserved() {
+    assert_fmt_parse_ok("pub effect Net", "pub effect Net\n");
 }
 
 // ── Expressions ─────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- preserve `pub` visibility when formatting exported items
- format multiline ADT variants in parser-valid canonical syntax
- add regression coverage for pub items and multiline ADT formatting

## Validation
- cargo test -p kyokara-fmt --test fmt_tests
- cargo test
- repo-wide fmt -> check roundtrip sweep on all valid in-repo .ky sources plus AoC 2024 day21-day25 repro files (69 valid roots, 0 failures)
