### PR TITLE
docs: add trait and priority queue RFCs

### DIFF
--- a/docs/rfcs/0004-module-taxonomy-and-capability-boundaries.md
+++ b/docs/rfcs/0004-module-taxonomy-and-capability-boundaries.md
@@ -74,7 +74,7 @@ Specialized pure APIs live in modules and are imported explicitly.
 Initial policy:
 
 1. `Deque` should be exposed via `collections` (not prelude-global).
-2. `PriorityQueue` should be introduced in `collections` directly.
+2. The priority-queue family should be introduced in `collections` directly.
 3. Future specialized structures (for example `BitSet`) should follow the same rule.
 
 #### Tier C: Effect modules
@@ -90,7 +90,7 @@ APIs that can perform side effects remain module-qualified and capability-scoped
 Canonical placement for specialized collection constructors:
 
 1. `collections.Deque.new()`
-2. `collections.PriorityQueue.new_min()` (or final canonical constructor naming once fixed)
+2. `collections.MutablePriorityQueue.new_min()` (first shipped surface; see RFC 0011)
 
 Once a value exists, behavior remains owner methods:
 
@@ -152,7 +152,7 @@ Only ubiquitous primitives should be prelude-global. Specialized pure APIs shoul
 
 1. Move `Deque` constructor surface to `collections` namespace.
 2. Keep method behavior unchanged.
-3. Introduce `PriorityQueue` directly under `collections`.
+3. Introduce the priority-queue family directly under `collections`, with `MutablePriorityQueue` shipping first per RFC 0011.
 4. Update docs/examples/completions to module-first specialized collection references.
 
 No migration-hint policy is required in v0 unless explicitly chosen.

--- a/docs/rfcs/0009-collection-surface-normalization.md
+++ b/docs/rfcs/0009-collection-surface-normalization.md
@@ -70,11 +70,11 @@ All collection constructors are canonically under `collections`:
 2. `collections.Map.new()`
 3. `collections.Set.new()`
 4. `collections.Deque.new()`
-5. `collections.PriorityQueue.new_min()` / `new_max()` (final constructor details in the corresponding feature RFC)
+5. `collections.PriorityQueue.new_min()` / `new_max()` (reserved for a future immutable mirror if one is justified)
 6. `collections.MutableList.new()`
 7. `collections.MutableMap.new()`
 8. `collections.MutableSet.new()`
-9. `collections.MutablePriorityQueue.new_min()` / `new_max()`
+9. `collections.MutablePriorityQueue.new_min()` / `new_max()` (defined by RFC 0011)
 
 Global/type-local constructor spellings for collections become non-canonical.
 
@@ -161,6 +161,13 @@ This RFC strengthens RFC 0004 by removing the remaining placement split between 
 
 This RFC keeps their naming principle (`Mutable*`) and generalizes placement symmetry across immutable + mutable collection families.
 
+### RFC 0011
+
+RFC 0011 resolves the priority-queue rollout question for v1:
+
+1. `MutablePriorityQueue` ships first.
+2. Any immutable `PriorityQueue` mirror remains follow-up work, not v1 surface.
+
 ## Migration Policy (v0 freeze window)
 
 Because the language surface is not frozen yet:
@@ -180,4 +187,3 @@ Because the language surface is not frozen yet:
 
 1. Should non-canonical constructor spellings be hard errors immediately or staged via warning + autofix first?
 2. Should formatter auto-rewrite non-canonical collection constructor forms to `collections.*` in v0?
-3. For `PriorityQueue`, should v0 ship mutable-only first or both immutable and mutable from day one?

--- a/docs/rfcs/0010-rust-like-trait-system.md
+++ b/docs/rfcs/0010-rust-like-trait-system.md
@@ -1,0 +1,268 @@
+# RFC 0010: Rust-like Trait System and Constraint Semantics
+
+- Status: Draft
+- Owner: Language Design
+- Tracking issue: [#253](https://github.com/kyokaralang/kyokara/issues/253)
+- Last updated: 2026-03-07
+
+## Summary
+
+Add a Rust-like trait system to Kyokara as the canonical replacement for hardcoded type-class-like allowlists.
+
+This RFC defines:
+
+1. Explicit `trait` declarations.
+2. Explicit `impl` blocks.
+3. Generic trait bounds using `T: Trait` syntax.
+4. Optional `deriving(...)` for eligible nominal types.
+5. Static trait resolution with deterministic coherence rules.
+
+The immediate implementation target is the subset needed to replace current ad-hoc `hashable` / `sortable` checks and to give `Map` / `Set` / ordered collection APIs first-class type constraints. The RFC also fixes the long-term surface so later phases do not redesign the model.
+
+## Motivation
+
+Kyokara currently encodes several semantic constraints directly in compiler internals:
+
+1. `Map` / `Set` keys and elements use hardcoded hashability allowlists.
+2. `List.sort()` / `binary_search()` use hardcoded orderability allowlists.
+3. Equality and comparison behavior are partly hardcoded to primitive families.
+4. User-defined types cannot opt into these capabilities.
+
+This is inconsistent with Kyokara's design goals:
+
+1. rules should be explicit and mechanically checkable,
+2. library constraints should be representable in the language itself,
+3. user-defined types should be able to participate in core APIs without compiler edits.
+
+## Design goals
+
+1. Keep the surface explicit and static.
+2. Make conformance discoverable from source, not ambient resolution.
+3. Support trait-bounded stdlib APIs without introducing trait objects or runtime dictionary lookup in v1.
+4. Give user-defined nominal types a canonical path to `Eq` / `Ord` / `Hash` / `Show`.
+5. Preserve room for phased implementation without revisiting the language model.
+
+## Non-goals
+
+1. Dynamic trait objects or existentials in phase 1.
+2. Runtime reflection over traits.
+3. Specialization, negative impls, or open-ended blanket impls in phase 1.
+4. Solving all numeric-semantic edge cases in the first implementation phase.
+5. Designing collection-specific APIs in this RFC.
+
+## Proposal
+
+### P1. Trait declaration surface
+
+Traits are declared explicitly:
+
+```kyokara
+pub trait Eq {
+  fn eq(self, other: Self) -> Bool
+}
+
+pub trait Ord: Eq {
+  fn compare(self, other: Self) -> Int
+}
+
+pub trait Hash: Eq {
+  fn hash(self) -> Int
+}
+
+pub trait Show {
+  fn show(self) -> String
+}
+```
+
+Rules:
+
+1. Trait methods are declarations only in phase 1; default method bodies are deferred.
+2. Supertrait requirements use `:` with `+` for multiple parents when needed.
+3. Traits live in the same namespace tier as other type-level items; imports control visibility, not resolution authority.
+
+### P2. Impl surface
+
+Conformance is declared explicitly:
+
+```kyokara
+impl Eq for Int {
+  fn eq(self, other: Self) -> Bool { ... }
+}
+
+impl<T: Eq> Eq for Box<T> {
+  fn eq(self, other: Self) -> Bool { ... }
+}
+```
+
+Rules:
+
+1. Impl blocks are the only user-written way to establish trait conformance.
+2. Generic impl headers may carry bounds.
+3. Method signatures in an impl must exactly match the trait declaration after substituting `Self` and type parameters.
+4. All required methods must be implemented in phase 1.
+
+### P3. Trait bounds
+
+Trait bounds use Rust-like inline syntax:
+
+```kyokara
+fn contains<K: Hash + Eq, V>(m: Map<K, V>, key: K) -> Bool { ... }
+fn sort<T: Ord>(xs: List<T>) -> List<T> { ... }
+```
+
+Phase-1 rule:
+
+1. Inline bounds are canonical.
+2. `where`-clause trait bounds are deferred.
+3. Bound checking is compile-time only.
+
+### P4. Deriving
+
+Nominal record and ADT types may opt into synthesized conformances:
+
+```kyokara
+type Point deriving (Eq, Ord, Hash, Show) = { x: Int, y: Int }
+
+type Token deriving (Eq, Hash, Show) =
+  | IntLit(Int)
+  | Ident(String)
+```
+
+Derive rules:
+
+1. Deriving is explicit; there is no automatic conformance for user-defined types.
+2. A derive succeeds only if every contained field or payload already satisfies the required trait bounds.
+3. Derived `Eq` compares variant/tag first, then fields/payloads structurally.
+4. Derived `Ord` uses declaration order for variants, then lexicographic field/payload comparison.
+5. Derived `Hash` includes variant/tag identity and field/payload hashes in declaration order.
+6. Derived `Show` emits a stable source-oriented textual form suitable for diagnostics and debugging.
+
+Phase-1 restriction:
+
+1. Deriving applies to nominal ADTs and nominal record aliases.
+2. Anonymous structural record literals do not receive user-written impls in phase 1.
+
+### P5. Resolution and coherence
+
+Trait resolution is static and explicit.
+
+Rules:
+
+1. Imports make traits and impl-bearing types visible; imports do not change which impl is selected when multiple candidates would exist.
+2. At most one applicable impl may exist for a given `(Trait, Type)` after substitution.
+3. Ambiguous impl sets are compile errors.
+4. The coherence rule for phase 1 is Rust-like or stricter: an impl is legal only if the trait or the self type is defined in the current project.
+5. The project may not define overlapping impls.
+6. There is no runtime instance search or ambient dictionary selection.
+
+### P6. Builtin trait set and phase split
+
+Core named traits in this RFC:
+
+1. `Eq`
+2. `Ord`
+3. `Hash`
+4. `Show`
+
+To preserve existing numeric behavior without overloading `Eq` / `Ord`, the architecture also reserves:
+
+1. `PartialEq`
+2. `PartialOrd`
+
+Phase split:
+
+1. Phase 1 must fully support `Eq`, `Ord`, `Hash`, and `Show` for collection and conformance use.
+2. `PartialEq` / `PartialOrd` are part of the long-term architecture so float-compatible operator semantics have a stable home.
+3. Numeric-operator migration onto the trait system can land in a later implementation phase without redesigning the trait surface.
+
+### P7. Builtin conformances
+
+Phase-1 builtin defaults:
+
+1. `Int`, `Bool`, `String`, `Char`, `Unit` implement `Eq`, `Ord`, `Hash`, and `Show` where semantically valid.
+2. `Float` implements `Show` in phase 1 and participates in later partial-order work under `PartialEq` / `PartialOrd`.
+3. Builtin container constraints use traits, not hardcoded allowlists:
+   - `Map<K, V>` and `Set<T>` require `K: Hash + Eq` / `T: Hash + Eq`
+   - ordered collection operations require `Ord`
+4. Existing builtin methods such as `to_string()` remain surface conveniences; `Show` becomes the underlying capability model for future generalized display.
+
+Phase-1 compatibility note:
+
+1. Current primitive float operators and float sort behavior remain temporary compatibility behavior until the later numeric-semantics phase retargets them cleanly.
+2. This RFC locks the architectural home for that later work instead of forcing a second trait redesign.
+
+### P8. Compiler/runtime integration targets
+
+The first implementation phase under this RFC must absorb current hardcoded constraint locations for:
+
+1. `Map` / `Set` hashability checks.
+2. `List.sort()` and `binary_search()` orderability checks.
+3. Trait-bounded type inference and diagnostics.
+4. Derived conformance generation for user nominal types.
+
+Later phases under the same RFC may extend trait-driven behavior to:
+
+1. equality and comparison operators,
+2. formatting / interpolation,
+3. broader generic stdlib APIs.
+
+### P9. Diagnostics
+
+The trait system must provide explicit diagnostics for:
+
+1. missing required trait bounds,
+2. unknown traits,
+3. duplicate or conflicting impls,
+4. illegal orphan/coherence violations,
+5. failed derives due to missing field/payload conformances,
+6. attempted use of deferred features such as trait objects.
+
+Diagnostics should stay structured and mechanically actionable, consistent with RFC 0001.
+
+## Phase-1 implementation contract
+
+Phase 1 is successful when:
+
+1. user-defined nominal types can derive or implement `Eq` / `Ord` / `Hash` / `Show`,
+2. `Map` / `Set` no longer depend on hardcoded key allowlists for conforming user types,
+3. `List.sort()` / `binary_search()` can accept conforming user types,
+4. trait bounds participate in type-checking and error reporting,
+5. no runtime trait objects or dynamic dispatch are required.
+
+## Deferred features
+
+These are deliberately deferred beyond phase 1 but remain compatible with this RFC:
+
+1. trait objects / existential values,
+2. default method bodies,
+3. specialization,
+4. negative impls,
+5. broad blanket impls,
+6. `where` clauses for bounds,
+7. operator retargeting for float-compatible partial-order semantics.
+
+## RFC alignment
+
+### RFC 0001
+
+This RFC strengthens RFC 0001's explicitness and mechanically-checkable rules:
+
+1. constraints become source-visible,
+2. conformance becomes explicit,
+3. stdlib behavior no longer depends on hidden allowlists.
+
+### RFC 0009
+
+This RFC is the prerequisite for any future ordered/hash-constrained collection that wants first-class user-defined key or priority types.
+
+### RFC 0011
+
+RFC 0011 depends on this RFC for `Ord`-based priority typing.
+
+## Acceptance criteria
+
+1. The trait surface is fully specified: `trait`, `impl`, bounds, and `deriving(...)`.
+2. Coherence and resolution rules are explicit and non-ambient.
+3. Phase-1 trait usage is sufficient to replace current ad-hoc collection constraint checks.
+4. Deferred features are explicitly listed so later phases extend, rather than redesign, the model.
+5. Priority-queue design can depend on `Ord` without reopening the trait surface.

--- a/docs/rfcs/0011-mutable-priorityqueue-surface.md
+++ b/docs/rfcs/0011-mutable-priorityqueue-surface.md
@@ -1,0 +1,188 @@
+# RFC 0011: MutablePriorityQueue Surface
+
+- Status: Draft
+- Owner: Language Design
+- Tracking issue: [#257](https://github.com/kyokaralang/kyokara/issues/257)
+- Depends on: RFC 0010
+- Last updated: 2026-03-07
+
+## Summary
+
+Define the first shipped priority-queue surface for Kyokara as a mutable collection under `collections`.
+
+This RFC locks:
+
+1. mutable-only v1 scope,
+2. queue-first API rather than a raw heap API,
+3. explicit min/max construction,
+4. `Ord`-bounded generic priority types,
+5. deterministic tie behavior.
+
+## Motivation
+
+Weighted frontier workloads such as Dijkstra, A*, and best-first search need efficient prioritized extraction without manual linear scans.
+
+The language already has persistent collections and specialized mutable collections. The first priority-queue feature should match that model:
+
+1. explicit constructor placement under `collections`,
+2. explicit `Mutable*` naming for alias-visible mutation,
+3. predictable deterministic behavior,
+4. no hidden min/max default.
+
+## Design goals
+
+1. Make pathfinding-style worklists direct to express.
+2. Keep the surface small and explicit.
+3. Reuse the `Mutable*` naming law already established for other alias-visible collections.
+4. Avoid dragging raw heap or comparator policy into the first shipped surface.
+5. Keep the implementation free to use a single heap engine under the hood.
+
+## Non-goals
+
+1. Shipping an immutable `PriorityQueue` in v1.
+2. Shipping a raw `Heap`, `MinHeap`, or `MaxHeap` user-facing API in v1.
+3. Constructor-time comparator closures.
+4. Decrease-key, update-priority, merge, or indexed-heap operations.
+5. Traversal APIs beyond what is required for queue inspection and mutation.
+
+## Proposal
+
+### P1. Type and placement
+
+Add one new builtin mutable collection type:
+
+1. `MutablePriorityQueue<P, T>` where `P: Ord`
+
+Canonical constructor placement:
+
+```kyokara
+import collections
+
+let pq = collections.MutablePriorityQueue.new_min<Int, String>()
+```
+
+No global constructor aliases.
+
+### P2. Constructor surface
+
+The v1 constructor family is:
+
+1. `collections.MutablePriorityQueue.new_min<P: Ord, T>()`
+2. `collections.MutablePriorityQueue.new_max<P: Ord, T>()`
+
+Rules:
+
+1. Direction is explicit at construction time.
+2. There is no bare `new()` with an implicit default.
+3. The implementation may share one internal heap engine for both directions.
+
+### P3. Canonical method surface
+
+The v1 surface is:
+
+1. `pq.push(priority, value) -> MutablePriorityQueue<P, T>`
+2. `pq.peek() -> Option<{ priority: P, value: T }>`
+3. `pq.pop() -> Option<{ priority: P, value: T }>`
+4. `pq.len() -> Int`
+5. `pq.is_empty() -> Bool`
+
+Method semantics:
+
+1. `push` mutates alias-visible state and returns self for chaining, matching other `Mutable*` collections.
+2. `peek` is non-destructive.
+3. `pop` removes the selected element and returns only the removed pair, not a rest-structure payload.
+
+### P4. Ordering and determinism
+
+Selection rule:
+
+1. `new_min()` returns the smallest priority first.
+2. `new_max()` returns the largest priority first.
+
+Tie-breaking rule:
+
+1. Equal priorities are resolved by insertion order.
+2. Earlier inserted items are returned first among equal-priority entries.
+3. This rule is part of the semantic contract, not an implementation accident.
+
+Reason:
+
+1. deterministic execution is better for humans, tests, replay, and AI agents.
+
+### P5. Type constraints
+
+Priority type requirements:
+
+1. `P` must satisfy `Ord` from RFC 0010.
+2. Value type `T` is unconstrained.
+3. The first implementation phase may use the subset of `Ord`-conforming builtin types and later automatically widens as RFC 0010 implementations land.
+
+### P6. Mutation model
+
+`MutablePriorityQueue` follows the existing mutable-collection rule:
+
+1. updates are alias-visible,
+2. constructors and methods remain pure APIs with no capability gate,
+3. mutability is signaled only by the `Mutable*` type name.
+
+### P7. Explicit out-of-scope surface
+
+The following are intentionally not in v1:
+
+1. `PriorityQueue<P, T>` immutable mirror type,
+2. `Heap`, `MinHeap`, `MaxHeap`, `MutableMinHeap`, `MutableMaxHeap`,
+3. `decrease_key`, `update_priority`, `merge`, `drain`, `iter`, or bulk-build helpers,
+4. custom comparator closures,
+5. traversal combinators.
+
+## Canonical examples
+
+```kyokara
+import collections
+
+fn frontier_demo() -> String {
+  let pq = collections.MutablePriorityQueue.new_min<Int, String>()
+    .push(5, "far")
+    .push(1, "near")
+    .push(1, "nearer")
+
+  match (pq.pop()) {
+    Some(item) => item.value,
+    None => "none",
+  }
+}
+```
+
+Expected behavior:
+
+1. first `pop()` returns priority `1`, value `"near"`,
+2. second `pop()` returns priority `1`, value `"nearer"`,
+3. insertion order is preserved within equal-priority ties.
+
+## RFC alignment
+
+### RFC 0004
+
+This RFC uses the specialized-collection placement rule:
+
+1. constructor surface is under `collections.*`.
+
+### RFC 0009
+
+This RFC resolves RFC 0009's priority-queue scope question:
+
+1. priority queue ships mutable-only first,
+2. `MutablePriorityQueue` is the first canonical shipped type,
+3. any future immutable mirror remains follow-up work.
+
+### RFC 0010
+
+This RFC depends on RFC 0010 for `Ord`-bounded priority typing and should not be implemented before RFC 0010 is accepted.
+
+## Acceptance criteria
+
+1. One canonical mutable priority-queue surface is documented.
+2. Min/max direction is explicit and never implicit.
+3. Tie behavior is deterministic and insertion-stable.
+4. The v1 scope is explicitly mutable-only.
+5. Dijkstra/A*-style workloads are expressible without linear frontier scans once the feature is implemented.


### PR DESCRIPTION
## Summary
- add RFC 0010 for a Rust-like trait system and constraint semantics
- add RFC 0011 for the downstream mutable priority-queue surface
- align RFC 0004 and RFC 0009 with the new priority-queue sequencing and mutable-only-first decision
- update issues #253 and #257 to reflect the RFC dependency chain

## Testing
- git diff --check

## Notes
- docs/issues only; no code or test behavior changed