### PR TITLE
docs: simplify trait derive syntax

### DIFF
--- a/docs/grammar.md
+++ b/docs/grammar.md
@@ -315,7 +315,7 @@ It is a design target for review and tightening, not current parser behavior.
 
 ```peg
 # Planned additions to Keyword:
-# 'trait' / 'impl' / 'deriving'
+# 'trait' / 'impl' / 'derive'
 # `Self` is reserved in trait declarations and impl blocks as the self-type placeholder.
 
 TraitRef             <- Path TypeArgList?
@@ -329,7 +329,7 @@ PlannedItem          <- 'pub'? (PlannedTypeDef
                        / ImplDef
 
 PlannedTypeDef       <- 'type' Ident TypeParamList? DeriveClause? '=' TypeBody
-DeriveClause         <- 'deriving' '(' TraitRef (',' TraitRef)* ','? ')'
+DeriveClause         <- 'derive' '(' TraitRef (',' TraitRef)* ','? ')'
 
 TraitDef             <- 'trait' Ident TypeParamList? SupertraitList? '{' TraitMethodSig* '}'
 SupertraitList       <- ':' TraitRef ('+' TraitRef)*
@@ -354,7 +354,7 @@ pub trait Show {
   fn show(self) -> String
 }
 
-type Point deriving (Eq, Hash) = { x: Int, y: Int }
+type Point derive(Eq, Hash) = { x: Int, y: Int }
 
 impl Show for Point {
   fn show(self) -> String {
@@ -362,15 +362,15 @@ impl Show for Point {
   }
 }
 
-fn less<T: Ord>(a: T, b: T) -> Bool {
-  Ord.compare(a, b) < 0
+fn debug_point(p: Point) -> String {
+  Show.show(p)
 }
 ```
 
 Why this example is canonical:
 
 1. `trait` declaration stays small.
-2. `deriving(...)` shows nominal conformance with no extra boilerplate.
+2. `derive(...)` shows nominal conformance with no extra boilerplate.
 3. `impl Show for Point` shows explicit user conformance.
-4. `Ord.compare(a, b)` shows the qualified trait-call rule.
-5. The only generic syntax needed for power is `fn less<T: Ord>(...)`.
+4. `Show.show(p)` shows the qualified trait-call rule.
+5. Generic bounds stay available elsewhere, but the first example does not force readers into them.

--- a/docs/rfcs/0011-static-trait-system-and-constraint-semantics.md
+++ b/docs/rfcs/0011-static-trait-system-and-constraint-semantics.md
@@ -14,7 +14,7 @@ This RFC defines:
 1. Explicit `trait` declarations.
 2. Explicit `impl` blocks.
 3. Generic trait bounds using `T: Trait` syntax.
-4. Optional `deriving(...)` for eligible nominal types.
+4. Optional `derive(...)` for eligible nominal types.
 5. Qualified trait calls such as `Ord.compare(a, b)`.
 6. Static trait resolution with deterministic coherence rules.
 
@@ -59,7 +59,7 @@ This is inconsistent with Kyokara's design goals:
 
 This RFC adds the following language surface:
 
-1. New reserved keywords: `trait`, `impl`, and `deriving`.
+1. New reserved keywords: `trait`, `impl`, and `derive`.
 2. `Self` is reserved in trait declarations and impl blocks as the self-type placeholder.
 3. New item kinds: trait declarations and impl blocks.
 4. A derive clause on nominal type declarations.
@@ -67,7 +67,7 @@ This RFC adds the following language surface:
 Canonical grammar additions:
 
 ```peg
-Keyword          <- ... / 'trait' / 'impl' / 'deriving'
+Keyword          <- ... / 'trait' / 'impl' / 'derive'
 
 TraitRef         <- Path TypeArgList?
 
@@ -80,7 +80,7 @@ Item             <- 'pub'? (TypeDef
                  / ImplDef
 
 TypeDef          <- 'type' Ident TypeParamList? DeriveClause? '=' TypeBody
-DeriveClause     <- 'deriving' '(' TraitRef (',' TraitRef)* ','? ')'
+DeriveClause     <- 'derive' '(' TraitRef (',' TraitRef)* ','? ')'
 
 TraitDef         <- 'trait' Ident TypeParamList? SupertraitList? '{' TraitMethodSig* '}'
 SupertraitList   <- ':' TraitRef ('+' TraitRef)*
@@ -94,7 +94,7 @@ Notes:
 
 1. `for` is already reserved elsewhere in the language, so impl syntax reuses the existing token.
 2. The grammar above is the normative surface contract; exact parser production factoring may differ internally.
-3. `deriving(...)` attaches only to nominal `type` declarations, never to anonymous structural records.
+3. `derive(...)` attaches only to nominal `type` declarations, never to anonymous structural records.
 4. Qualified trait calls reuse the existing qualified-call syntax surface; this RFC changes resolution policy, not the punctuation of calls.
 5. `impl` blocks are not independently `pub`; visibility is attached to traits, types, and ordinary items, not to impl blocks themselves.
 
@@ -176,7 +176,7 @@ Reason:
 Canonical usage summary:
 
 ```kyokara
-type Point deriving (Eq, Ord, Hash, Show) = { x: Int, y: Int }
+type Point derive(Eq, Ord, Hash, Show) = { x: Int, y: Int }
 
 fn clamp<T: Ord>(x: T, lo: T, hi: T) -> T {
   if (Ord.compare(x, lo) < 0) {
@@ -221,9 +221,9 @@ Phase-1 rule:
 Nominal record and ADT types may opt into synthesized conformances:
 
 ```kyokara
-type Point deriving (Eq, Ord, Hash, Show) = { x: Int, y: Int }
+type Point derive(Eq, Ord, Hash, Show) = { x: Int, y: Int }
 
-type Token deriving (Eq, Hash, Show) =
+type Token derive(Eq, Hash, Show) =
   | IntLit(Int)
   | Ident(String)
 ```
@@ -246,7 +246,7 @@ Phase-1 restriction:
 Structural-record boundary example:
 
 ```kyokara
-type Point deriving (Eq, Hash) = { x: Int, y: Int }
+type Point derive(Eq, Hash) = { x: Int, y: Int }
 
 let ok: Set<Point> = ...
 // Rejected in phase 1: Set<{ x: Int, y: Int }>
@@ -409,7 +409,7 @@ RFC 0012 depends on this RFC for `Ord`-based priority typing.
 
 ## Acceptance criteria
 
-1. The trait surface is fully specified: `trait`, `impl`, bounds, and `deriving(...)`.
+1. The trait surface is fully specified: `trait`, `impl`, bounds, and `derive(...)`.
 2. Coherence and resolution rules are explicit and non-ambient.
 3. Phase-1 trait usage is sufficient to replace current ad-hoc collection constraint checks.
 4. Deferred features are explicitly listed so later phases extend, rather than redesign, the model.


### PR DESCRIPTION
## Summary
- rename the planned trait derive clause from `deriving(...)` to `derive(...)`
- simplify the minimal grammar example so it shows trait + derive + impl + qualified call without forcing generic syntax first
- keep the rest of the trait surface unchanged

## Testing
- git diff --check