### PR TITLE
Implement RFC 0011 static traits and witnessed collections

### DIFF
--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -848,7 +848,7 @@ fn build_module_symbol_graph(
             let type_params: Vec<String> = type_item
                 .type_params
                 .iter()
-                .map(|n| n.resolve(interner).to_owned())
+                .map(|n| n.name.resolve(interner).to_owned())
                 .collect();
             let (kind, fields, variants) = match &type_item.kind {
                 TypeDefKind::Alias(TypeRef::Record {
@@ -1419,6 +1419,7 @@ fn resolved_symbol_id(
             ))
         }
         ResolvedName::Import(_)
+        | ResolvedName::Trait(_)
         | ResolvedName::Module(_)
         | ResolvedName::StaticMethodType(_)
         | ResolvedName::Local(_) => None,

--- a/crates/api/tests/api_tests.rs
+++ b/crates/api/tests/api_tests.rs
@@ -4601,23 +4601,17 @@ fn check_map_valid_key_types_have_no_map_key_diagnostic() {
 // ── List binary_search element type diagnostics (E0025) ─────────────
 
 #[test]
-fn check_list_binary_search_unsortable_element_reports_e0025() {
-    let output = check(
-        r#"fn main() -> Int {
-            let needle = collections.List.new().push(1)
-            let xs = collections.List.new().push(needle)
-            xs.binary_search(needle)
-        }"#,
-        "test.ky",
-    );
+fn check_list_binary_search_list_elements_have_no_e0025() {
+    assert_check_no_diagnostics(
+        r#"import collections
 
-    assert!(
-        output
-            .diagnostics
-            .iter()
-            .any(|d| d.code == "E0025" && d.message.contains("cannot be sorted")),
-        "expected E0025 unsortable element diagnostic, got: {:?}",
-        output.diagnostics
+        fn main() -> Int {
+            let a = collections.List.new().push(1)
+            let b = collections.List.new().push(1).push(2)
+            let xs = collections.List.new().push(a).push(b)
+            xs.binary_search(b)
+        }"#,
+        "list binary_search list elements",
     );
 }
 
@@ -4816,7 +4810,9 @@ fn check_seq_frequencies_canonical_surface_has_no_diagnostics() {
 #[test]
 fn check_seq_frequencies_non_hashable_element_reports_e0024() {
     let output = check(
-        r#"type P = { x: Int }
+        r#"import collections
+
+        type P = { x: Int }
 
         fn main() -> Int {
             let counts = collections.List.new().push(P { x: 1 }).frequencies()

--- a/crates/cli/tests/fixtures/parity/single_list_binary_search_unsortable/expect.json
+++ b/crates/cli/tests/fixtures/parity/single_list_binary_search_unsortable/expect.json
@@ -2,12 +2,11 @@
   "project": false,
   "entry": "main.ky",
   "check": {
-    "ok": false,
-    "codes_all": ["E0025"],
-    "messages_all": ["cannot be sorted"]
+    "ok": true,
+    "codes_all": []
   },
   "run": {
-    "ok": false,
-    "stderr_contains": ["cannot be sorted"]
+    "ok": true,
+    "stdout_contains": ["0"]
   }
 }

--- a/crates/eval/src/interpreter.rs
+++ b/crates/eval/src/interpreter.rs
@@ -1,7 +1,9 @@
 //! Core tree-walking interpreter.
 
 use std::cmp::Ordering;
+use std::collections::hash_map::DefaultHasher;
 use std::collections::VecDeque;
+use std::hash::{Hash, Hasher};
 use std::rc::Rc;
 
 use kyokara_hir_def::body::{Body, LocalSlotRef};
@@ -22,7 +24,7 @@ use crate::env::Env;
 use crate::error::RuntimeError;
 use crate::intrinsics::{self, Args, IntrinsicFn};
 use crate::manifest::CapabilityManifest;
-use crate::value::{FnValue, MapKey, SeqPlan, SeqSource, Value};
+use crate::value::{FnValue, MapValue, SeqPlan, SeqSource, SetValue, Value};
 
 /// Tree-walking interpreter state.
 pub struct Interpreter {
@@ -158,15 +160,15 @@ enum SeqSourceIter {
         next_start: usize,
     },
     MapKeys {
-        entries: Rc<indexmap::IndexMap<MapKey, Value>>,
+        entries: Rc<MapValue>,
         idx: usize,
     },
     MapValues {
-        entries: Rc<indexmap::IndexMap<MapKey, Value>>,
+        entries: Rc<MapValue>,
         idx: usize,
     },
     SetValues {
-        entries: Rc<indexmap::IndexSet<MapKey>>,
+        entries: Rc<SetValue>,
         idx: usize,
     },
 }
@@ -855,6 +857,599 @@ impl Interpreter {
             })
     }
 
+    fn trait_method_dispatch_fn_idx(
+        &self,
+        trait_name: Name,
+        method_name: Name,
+        recv: &Value,
+    ) -> Option<FnItemIdx> {
+        self.item_tree.impls.iter().find_map(|(_, impl_item)| {
+            let impl_trait_name = impl_item.trait_ref.path.last()?;
+            if impl_trait_name != trait_name || !self.type_ref_matches_value(&impl_item.self_ty, recv)
+            {
+                return None;
+            }
+            impl_item.methods.iter().copied().find(|&fn_idx| {
+                self.item_tree.functions[fn_idx].name == method_name
+            })
+        })
+    }
+
+    fn type_ref_matches_value(&self, ty: &TypeRef, value: &Value) -> bool {
+        let TypeRef::Path { path, .. } = ty else {
+            return false;
+        };
+        let Some(name) = path.last() else {
+            return false;
+        };
+        match value {
+            Value::Int(_) => name.resolve(&self.interner) == "Int",
+            Value::Float(_) => name.resolve(&self.interner) == "Float",
+            Value::String(_) => name.resolve(&self.interner) == "String",
+            Value::Char(_) => name.resolve(&self.interner) == "Char",
+            Value::Bool(_) => name.resolve(&self.interner) == "Bool",
+            Value::Unit => name.resolve(&self.interner) == "Unit",
+            Value::Adt { type_idx, .. } => name == self.item_tree.types[*type_idx].name,
+            Value::Record {
+                type_idx: Some(type_idx),
+                ..
+            } => name == self.item_tree.types[*type_idx].name,
+            Value::Record { type_idx: None, .. } => false,
+            Value::List(_) => name.resolve(&self.interner) == "List",
+            Value::MutableList(_) => name.resolve(&self.interner) == "MutableList",
+            Value::Deque(_) => name.resolve(&self.interner) == "Deque",
+            Value::BitSet(_) => name.resolve(&self.interner) == "BitSet",
+            Value::MutableBitSet(_) => name.resolve(&self.interner) == "MutableBitSet",
+            Value::Map(_) => name.resolve(&self.interner) == "Map",
+            Value::MutableMap(_) => name.resolve(&self.interner) == "MutableMap",
+            Value::Set(_) => name.resolve(&self.interner) == "Set",
+            Value::MutableSet(_) => name.resolve(&self.interner) == "MutableSet",
+            Value::Seq(_) => name.resolve(&self.interner) == "Seq",
+            Value::Fn(_) => false,
+        }
+    }
+
+    fn call_trait_qualified(
+        &mut self,
+        trait_name: Name,
+        method_name: Name,
+        args: &[CallArg],
+        arg_values: Vec<Value>,
+    ) -> Result<Value, RuntimeError> {
+        let Some(&trait_idx) = self.module_scope.traits.get(&trait_name) else {
+            return Err(RuntimeError::UnresolvedName(
+                trait_name.resolve(&self.interner).to_string(),
+            ));
+        };
+        let trait_item = &self.item_tree.traits[trait_idx];
+        let Some(method) = trait_item.methods.iter().find(|method| method.name == method_name) else {
+            return Err(RuntimeError::TypeError(format!(
+                "trait `{}` has no method `{}`",
+                trait_name.resolve(&self.interner),
+                method_name.resolve(&self.interner)
+            )));
+        };
+        let param_names: Vec<Name> = method.params.iter().map(|param| param.name).collect();
+        let callee_name = format!(
+            "trait method `{}.{}`",
+            trait_name.resolve(&self.interner),
+            method_name.resolve(&self.interner)
+        );
+        let bound_args =
+            self.bind_call_values_for_param_names(&callee_name, args, arg_values, &param_names)?;
+        let Some(receiver) = bound_args.first() else {
+            return Err(RuntimeError::ArityMismatch {
+                callee: callee_name,
+                expected: method.params.len(),
+                actual: 0,
+            });
+        };
+        if let Some(fn_idx) = self.trait_method_dispatch_fn_idx(trait_name, method_name, receiver) {
+            return self.call_fn(fn_idx, bound_args);
+        }
+        self.call_builtin_trait_method(trait_name, method_name, bound_args)
+    }
+
+    fn call_builtin_trait_method(
+        &mut self,
+        trait_name: Name,
+        method_name: Name,
+        args: Args,
+    ) -> Result<Value, RuntimeError> {
+        match (
+            trait_name.resolve(&self.interner),
+            method_name.resolve(&self.interner),
+            args.as_slice(),
+        ) {
+            ("Eq", "eq", [lhs, rhs]) => Ok(Value::Bool(self.trait_eq_values(lhs, rhs)?)),
+            ("Ord", "compare", [lhs, rhs]) => Ok(Value::Int(self.trait_compare_values(lhs, rhs)?)),
+            ("Hash", "hash", [value]) => Ok(Value::Int(self.trait_hash_value(value)?)),
+            ("Show", "show", [value]) => Ok(Value::String(self.trait_show_value(value)?)),
+            _ => Err(RuntimeError::TypeError(format!(
+                "unsupported trait call `{}.{}`",
+                trait_name.resolve(&self.interner),
+                method_name.resolve(&self.interner)
+            ))),
+        }
+    }
+
+    fn trait_eq_values(&mut self, lhs: &Value, rhs: &Value) -> Result<bool, RuntimeError> {
+        if let Some(fn_idx) = self.resolve_named_trait_method("Eq", "eq", lhs) {
+            let value = self.call_fn(fn_idx, smallvec::smallvec![lhs.clone(), rhs.clone()])?;
+            let Value::Bool(result) = value else {
+                return Err(RuntimeError::TypeError("Eq.eq must return Bool".into()));
+            };
+            return Ok(result);
+        }
+
+        match (lhs, rhs) {
+            (Value::Int(a), Value::Int(b)) => Ok(a == b),
+            (Value::String(a), Value::String(b)) => Ok(a == b),
+            (Value::Char(a), Value::Char(b)) => Ok(a == b),
+            (Value::Bool(a), Value::Bool(b)) => Ok(a == b),
+            (Value::Unit, Value::Unit) => Ok(true),
+            (
+                Value::Adt {
+                    type_idx: t1,
+                    variant: v1,
+                    fields: f1,
+                },
+                Value::Adt {
+                    type_idx: t2,
+                    variant: v2,
+                    fields: f2,
+                },
+            ) => {
+                if t1 != t2 || v1 != v2 || f1.len() != f2.len() {
+                    return Ok(false);
+                }
+                for (lhs_field, rhs_field) in f1.iter().zip(f2.iter()) {
+                    if !self.trait_eq_values(lhs_field, rhs_field)? {
+                        return Ok(false);
+                    }
+                }
+                Ok(true)
+            }
+            (Value::Record { fields: f1, .. }, Value::Record { fields: f2, .. }) => {
+                if f1.len() != f2.len() {
+                    return Ok(false);
+                }
+                let mut lhs_fields: Vec<_> = f1.iter().collect();
+                let mut rhs_fields: Vec<_> = f2.iter().collect();
+                lhs_fields.sort_by(|(lhs_name, _), (rhs_name, _)| {
+                    lhs_name.resolve(&self.interner).cmp(rhs_name.resolve(&self.interner))
+                });
+                rhs_fields.sort_by(|(lhs_name, _), (rhs_name, _)| {
+                    lhs_name.resolve(&self.interner).cmp(rhs_name.resolve(&self.interner))
+                });
+                for ((lhs_name, lhs_value), (rhs_name, rhs_value)) in
+                    lhs_fields.into_iter().zip(rhs_fields.into_iter())
+                {
+                    if lhs_name != rhs_name || !self.trait_eq_values(lhs_value, rhs_value)? {
+                        return Ok(false);
+                    }
+                }
+                Ok(true)
+            }
+            (Value::List(lhs), Value::List(rhs)) => self.trait_eq_slice(lhs, rhs),
+            (Value::MutableList(lhs), Value::MutableList(rhs)) => {
+                let lhs_items = lhs.snapshot();
+                let rhs_items = rhs.snapshot();
+                self.trait_eq_slice(lhs_items.as_ref(), rhs_items.as_ref())
+            }
+            (Value::Deque(lhs), Value::Deque(rhs)) => {
+                if lhs.len() != rhs.len() {
+                    return Ok(false);
+                }
+                for (lhs_value, rhs_value) in lhs.iter().zip(rhs.iter()) {
+                    if !self.trait_eq_values(lhs_value, rhs_value)? {
+                        return Ok(false);
+                    }
+                }
+                Ok(true)
+            }
+            (Value::BitSet(lhs), Value::BitSet(rhs)) => Ok(lhs == rhs),
+            (Value::Map(lhs), Value::Map(rhs)) => Ok(lhs == rhs),
+            (Value::Set(lhs), Value::Set(rhs)) => Ok(lhs == rhs),
+            (Value::MutableMap(lhs), Value::MutableMap(rhs)) => Ok(*lhs.borrow() == *rhs.borrow()),
+            (Value::MutableSet(lhs), Value::MutableSet(rhs)) => Ok(*lhs.borrow() == *rhs.borrow()),
+            (Value::MutableBitSet(lhs), Value::MutableBitSet(rhs)) => {
+                Ok(lhs.snapshot() == rhs.snapshot())
+            }
+            (Value::Fn(_), Value::Fn(_)) => Err(RuntimeError::TypeError(
+                "functions do not implement Eq".into(),
+            )),
+            (Value::Seq(_), Value::Seq(_)) => Err(RuntimeError::TypeError(
+                "Seq does not implement Eq".into(),
+            )),
+            _ => Ok(false),
+        }
+    }
+
+    fn trait_eq_slice(&mut self, lhs: &[Value], rhs: &[Value]) -> Result<bool, RuntimeError> {
+        if lhs.len() != rhs.len() {
+            return Ok(false);
+        }
+        for (lhs_value, rhs_value) in lhs.iter().zip(rhs.iter()) {
+            if !self.trait_eq_values(lhs_value, rhs_value)? {
+                return Ok(false);
+            }
+        }
+        Ok(true)
+    }
+
+    fn trait_compare_values(&mut self, lhs: &Value, rhs: &Value) -> Result<i64, RuntimeError> {
+        if let Some(fn_idx) = self.resolve_named_trait_method("Ord", "compare", lhs) {
+            let value = self.call_fn(fn_idx, smallvec::smallvec![lhs.clone(), rhs.clone()])?;
+            let Value::Int(result) = value else {
+                return Err(RuntimeError::TypeError(
+                    "Ord.compare must return Int".into(),
+                ));
+            };
+            return Ok(result);
+        }
+
+        let ord = match (lhs, rhs) {
+            (Value::Int(a), Value::Int(b)) => a.cmp(b),
+            (Value::String(a), Value::String(b)) => a.cmp(b),
+            (Value::Char(a), Value::Char(b)) => a.cmp(b),
+            (Value::Bool(a), Value::Bool(b)) => a.cmp(b),
+            (Value::Unit, Value::Unit) => Ordering::Equal,
+            (
+                Value::Adt {
+                    type_idx: t1,
+                    variant: v1,
+                    fields: f1,
+                },
+                Value::Adt {
+                    type_idx: t2,
+                    variant: v2,
+                    fields: f2,
+                },
+            ) if t1 == t2 => {
+                let variant_ord = v1.cmp(v2);
+                if variant_ord != Ordering::Equal {
+                    variant_ord
+                } else {
+                    self.trait_compare_slices(f1, f2)?
+                }
+            }
+            (Value::Record { fields: f1, .. }, Value::Record { fields: f2, .. }) => {
+                let mut lhs_fields: Vec<_> = f1.iter().collect();
+                let mut rhs_fields: Vec<_> = f2.iter().collect();
+                lhs_fields.sort_by(|(lhs_name, _), (rhs_name, _)| {
+                    lhs_name.resolve(&self.interner).cmp(rhs_name.resolve(&self.interner))
+                });
+                rhs_fields.sort_by(|(lhs_name, _), (rhs_name, _)| {
+                    lhs_name.resolve(&self.interner).cmp(rhs_name.resolve(&self.interner))
+                });
+                let name_ord = lhs_fields
+                    .iter()
+                    .map(|(name, _)| name.resolve(&self.interner))
+                    .cmp(rhs_fields.iter().map(|(name, _)| name.resolve(&self.interner)));
+                if name_ord != Ordering::Equal {
+                    name_ord
+                } else {
+                    let lhs_values: Vec<_> = lhs_fields.into_iter().map(|(_, value)| value.clone()).collect();
+                    let rhs_values: Vec<_> = rhs_fields.into_iter().map(|(_, value)| value.clone()).collect();
+                    self.trait_compare_slices_refs(&lhs_values, &rhs_values)?
+                }
+            }
+            (Value::List(lhs), Value::List(rhs)) => self.trait_compare_slices(lhs, rhs)?,
+            (Value::MutableList(lhs), Value::MutableList(rhs)) => {
+                let lhs_items = lhs.snapshot();
+                let rhs_items = rhs.snapshot();
+                self.trait_compare_slices(lhs_items.as_ref(), rhs_items.as_ref())?
+            }
+            (Value::Deque(lhs), Value::Deque(rhs)) => {
+                let lhs_values: Vec<_> = lhs.iter().cloned().collect();
+                let rhs_values: Vec<_> = rhs.iter().cloned().collect();
+                self.trait_compare_slices_refs(&lhs_values, &rhs_values)?
+            }
+            (Value::BitSet(lhs), Value::BitSet(rhs)) => lhs.words().cmp(&rhs.words()),
+            _ => {
+                return Err(RuntimeError::TypeError(
+                    "value does not implement Ord".into(),
+                ));
+            }
+        };
+
+        Ok(match ord {
+            Ordering::Less => -1,
+            Ordering::Equal => 0,
+            Ordering::Greater => 1,
+        })
+    }
+
+    fn trait_compare_slices(&mut self, lhs: &[Value], rhs: &[Value]) -> Result<Ordering, RuntimeError> {
+        self.trait_compare_slices_refs(lhs, rhs)
+    }
+
+    fn trait_compare_slices_refs(
+        &mut self,
+        lhs: &[Value],
+        rhs: &[Value],
+    ) -> Result<Ordering, RuntimeError> {
+        for (lhs_value, rhs_value) in lhs.iter().zip(rhs.iter()) {
+            let ord = self.trait_compare_values(lhs_value, rhs_value)?;
+            match ord.cmp(&0) {
+                Ordering::Equal => {}
+                non_eq => return Ok(non_eq),
+            }
+        }
+        Ok(lhs.len().cmp(&rhs.len()))
+    }
+
+    fn trait_hash_value(&mut self, value: &Value) -> Result<i64, RuntimeError> {
+        if let Some(fn_idx) = self.resolve_named_trait_method("Hash", "hash", value) {
+            let value = self.call_fn(fn_idx, smallvec::smallvec![value.clone()])?;
+            let Value::Int(result) = value else {
+                return Err(RuntimeError::TypeError(
+                    "Hash.hash must return Int".into(),
+                ));
+            };
+            return Ok(result);
+        }
+
+        let mut hasher = DefaultHasher::new();
+        self.write_builtin_trait_hash(value, &mut hasher)?;
+        Ok(i64::from_ne_bytes(hasher.finish().to_ne_bytes()))
+    }
+
+    fn write_builtin_trait_hash(
+        &mut self,
+        value: &Value,
+        hasher: &mut DefaultHasher,
+    ) -> Result<(), RuntimeError> {
+        match value {
+            Value::Int(n) => {
+                0u8.hash(hasher);
+                n.hash(hasher);
+            }
+            Value::String(s) => {
+                1u8.hash(hasher);
+                s.hash(hasher);
+            }
+            Value::Char(c) => {
+                2u8.hash(hasher);
+                c.hash(hasher);
+            }
+            Value::Bool(b) => {
+                3u8.hash(hasher);
+                b.hash(hasher);
+            }
+            Value::Unit => {
+                4u8.hash(hasher);
+            }
+            Value::Adt {
+                type_idx,
+                variant,
+                fields,
+            } => {
+                5u8.hash(hasher);
+                self.item_tree.types[*type_idx]
+                    .name
+                    .resolve(&self.interner)
+                    .hash(hasher);
+                variant.hash(hasher);
+                for field in fields {
+                    self.trait_hash_value(field)?.hash(hasher);
+                }
+            }
+            Value::Record { type_idx, fields } => {
+                6u8.hash(hasher);
+                if let Some(type_idx) = type_idx {
+                    self.item_tree.types[*type_idx]
+                        .name
+                        .resolve(&self.interner)
+                        .hash(hasher);
+                }
+                let mut sorted_fields: Vec<_> = fields.iter().collect();
+                sorted_fields.sort_by(|(lhs_name, _), (rhs_name, _)| {
+                    lhs_name.resolve(&self.interner).cmp(rhs_name.resolve(&self.interner))
+                });
+                for (name, value) in sorted_fields {
+                    name.resolve(&self.interner).hash(hasher);
+                    self.trait_hash_value(value)?.hash(hasher);
+                }
+            }
+            Value::List(items) => {
+                7u8.hash(hasher);
+                for item in items.iter() {
+                    self.trait_hash_value(item)?.hash(hasher);
+                }
+            }
+            Value::Deque(items) => {
+                8u8.hash(hasher);
+                for item in items.iter() {
+                    self.trait_hash_value(item)?.hash(hasher);
+                }
+            }
+            Value::BitSet(bitset) => {
+                9u8.hash(hasher);
+                bitset.size_bits().hash(hasher);
+                bitset.words().hash(hasher);
+            }
+            Value::Map(entries) => {
+                10u8.hash(hasher);
+                let mut entry_hashes: Vec<u64> = entries
+                    .entries()
+                    .iter()
+                    .map(|entry| {
+                        let mut entry_hasher = DefaultHasher::new();
+                        entry.hash.hash(&mut entry_hasher);
+                        self.trait_hash_value(&entry.key)?.hash(&mut entry_hasher);
+                        self.trait_hash_value(&entry.value)?.hash(&mut entry_hasher);
+                        Ok(entry_hasher.finish())
+                    })
+                    .collect::<Result<_, RuntimeError>>()?;
+                entry_hashes.sort_unstable();
+                entry_hashes.hash(hasher);
+            }
+            Value::Set(entries) => {
+                11u8.hash(hasher);
+                let mut entry_hashes: Vec<u64> = entries
+                    .entries()
+                    .iter()
+                    .map(|entry| {
+                        let mut entry_hasher = DefaultHasher::new();
+                        entry.hash.hash(&mut entry_hasher);
+                        self.trait_hash_value(&entry.value)?.hash(&mut entry_hasher);
+                        Ok(entry_hasher.finish())
+                    })
+                    .collect::<Result<_, RuntimeError>>()?;
+                entry_hashes.sort_unstable();
+                entry_hashes.hash(hasher);
+            }
+            Value::MutableList(_)
+            | Value::MutableMap(_)
+            | Value::MutableSet(_)
+            | Value::MutableBitSet(_)
+            | Value::Seq(_)
+            | Value::Fn(_)
+            | Value::Float(_) => {
+                return Err(RuntimeError::TypeError(
+                    "value does not implement Hash".into(),
+                ));
+            }
+        }
+        Ok(())
+    }
+
+    fn trait_show_value(&mut self, value: &Value) -> Result<String, RuntimeError> {
+        if let Some(fn_idx) = self.resolve_named_trait_method("Show", "show", value) {
+            let value = self.call_fn(fn_idx, smallvec::smallvec![value.clone()])?;
+            let Value::String(result) = value else {
+                return Err(RuntimeError::TypeError(
+                    "Show.show must return String".into(),
+                ));
+            };
+            return Ok(result);
+        }
+
+        match value {
+            Value::Int(n) => Ok(n.to_string()),
+            Value::Float(f) => Ok(f.to_string()),
+            Value::String(s) => Ok(s.clone()),
+            Value::Char(c) => Ok(c.to_string()),
+            Value::Bool(b) => Ok(b.to_string()),
+            Value::Unit => Ok("()".to_string()),
+            Value::Adt {
+                type_idx,
+                variant,
+                fields,
+            } => {
+                let type_item = &self.item_tree.types[*type_idx];
+                let TypeDefKind::Adt { variants } = &type_item.kind else {
+                    return Ok(value.display(&self.interner));
+                };
+                let variant_name = variants
+                    .get(*variant)
+                    .map(|variant| variant.name.resolve(&self.interner).to_string())
+                    .unwrap_or("<variant>".to_string());
+                if fields.is_empty() {
+                    return Ok(variant_name);
+                }
+                let mut shown_fields = Vec::with_capacity(fields.len());
+                for field in fields {
+                    shown_fields.push(self.trait_show_value(field)?);
+                }
+                Ok(format!("{variant_name}({})", shown_fields.join(", ")))
+            }
+            Value::Record { fields, .. } => {
+                let mut shown_fields = Vec::with_capacity(fields.len());
+                for (name, value) in fields {
+                    let field_name = name.resolve(&self.interner).to_string();
+                    let shown_value = self.trait_show_value(value)?;
+                    shown_fields.push(format!("{field_name}: {shown_value}"));
+                }
+                shown_fields.sort();
+                Ok(format!("{{ {} }}", shown_fields.join(", ")))
+            }
+            Value::List(items) => Ok(format!(
+                "[{}]",
+                items.iter()
+                    .map(|item| self.trait_show_value(item))
+                    .collect::<Result<Vec<_>, _>>()?
+                    .join(", ")
+            )),
+            Value::Deque(items) => Ok(format!(
+                "Deque([{}])",
+                items.iter()
+                    .map(|item| self.trait_show_value(item))
+                    .collect::<Result<Vec<_>, _>>()?
+                    .join(", ")
+            )),
+            Value::Seq(_) => Ok("<seq>".to_string()),
+            _ => Ok(value.display(&self.interner)),
+        }
+    }
+
+    fn resolve_named_trait_method(
+        &self,
+        trait_name: &str,
+        method_name: &str,
+        recv: &Value,
+    ) -> Option<FnItemIdx> {
+        self.item_tree.impls.iter().find_map(|(_, impl_item)| {
+            let impl_trait_name = impl_item.trait_ref.path.last()?;
+            if impl_trait_name.resolve(&self.interner) != trait_name
+                || !self.type_ref_matches_value(&impl_item.self_ty, recv)
+            {
+                return None;
+            }
+            impl_item.methods.iter().copied().find(|&fn_idx| {
+                self.item_tree.functions[fn_idx].name.resolve(&self.interner) == method_name
+            })
+        })
+    }
+
+    fn hash_for_collection_key(&mut self, value: &Value) -> Result<i64, RuntimeError> {
+        self.trait_hash_value(value)
+    }
+
+    fn map_get_value(
+        &mut self,
+        entries: &MapValue,
+        key: &Value,
+    ) -> Result<Option<Value>, RuntimeError> {
+        let hash = self.hash_for_collection_key(key)?;
+        entries.get_cloned_with(hash, key, &mut |lhs, rhs| self.trait_eq_values(lhs, rhs))
+    }
+
+    fn map_contains_value(
+        &mut self,
+        entries: &MapValue,
+        key: &Value,
+    ) -> Result<bool, RuntimeError> {
+        let hash = self.hash_for_collection_key(key)?;
+        entries.contains_with(hash, key, &mut |lhs, rhs| self.trait_eq_values(lhs, rhs))
+    }
+
+    fn map_insert_value(
+        &mut self,
+        entries: &MapValue,
+        key: Value,
+        value: Value,
+    ) -> Result<MapValue, RuntimeError> {
+        let hash = self.hash_for_collection_key(&key)?;
+        entries.insert_persistent_with(
+            hash,
+            key,
+            value,
+            &mut |lhs, rhs| self.trait_eq_values(lhs, rhs),
+        )
+    }
+
+    fn set_contains_value(
+        &mut self,
+        entries: &SetValue,
+        value: &Value,
+    ) -> Result<bool, RuntimeError> {
+        let hash = self.hash_for_collection_key(value)?;
+        entries.contains_with(hash, value, &mut |lhs, rhs| self.trait_eq_values(lhs, rhs))
+    }
+
     fn param_names_for_fn_value(&self, fv: &FnValue) -> Option<Vec<Name>> {
         match fv {
             FnValue::User(fn_idx) => Some(self.param_names_for_fn_idx(*fn_idx)),
@@ -1241,6 +1836,18 @@ impl Interpreter {
                         && path.is_single()
                     {
                         let seg = path.segments[0];
+
+                        if self.module_scope.traits.contains_key(&seg) {
+                            let source_order = self.args_in_source_order(&args);
+                            let mut arg_values = Vec::with_capacity(source_order.len());
+                            for idx in &source_order {
+                                let v = eval_propagate!(self, env, body, *idx);
+                                arg_values.push(v);
+                            }
+                            return self
+                                .call_trait_qualified(seg, field_name, &args, arg_values)
+                                .map(ControlFlow::Value);
+                        }
 
                         // Module-qualified call: io.println(s), math.min(a, b)
                         if self.module_scope.imported_modules.contains(&seg)
@@ -1643,6 +2250,18 @@ impl Interpreter {
                         && path.is_single()
                     {
                         let seg = path.segments[0];
+
+                        if self.module_scope.traits.contains_key(&seg) {
+                            let source_order = self.args_in_source_order(args);
+                            let mut arg_values = Vec::with_capacity(source_order.len());
+                            for idx in &source_order {
+                                let v = eval_propagate_shared!(self, body, *idx);
+                                arg_values.push(v);
+                            }
+                            return self
+                                .call_trait_qualified(seg, field_name, args, arg_values)
+                                .map(ControlFlow::Value);
+                        }
 
                         // Module-qualified call: io.println(s)
                         if self.module_scope.imported_modules.contains(&seg)
@@ -2791,21 +3410,21 @@ impl Interpreter {
                 Self::next_string_char(s.as_str(), next_start).map(Value::Char)
             }
             SeqSourceIter::MapKeys { entries, idx } => {
-                let out = entries.get_index(*idx).map(|(key, _)| key.to_value());
+                let out = entries.key_at(*idx);
                 if out.is_some() {
                     *idx += 1;
                 }
                 out
             }
             SeqSourceIter::MapValues { entries, idx } => {
-                let out = entries.get_index(*idx).map(|(_, value)| value.clone());
+                let out = entries.value_at(*idx);
                 if out.is_some() {
                     *idx += 1;
                 }
                 out
             }
             SeqSourceIter::SetValues { entries, idx } => {
-                let out = entries.get_index(*idx).map(MapKey::to_value);
+                let out = entries.value_at(*idx);
                 if out.is_some() {
                     *idx += 1;
                 }
@@ -3034,8 +3653,8 @@ impl Interpreter {
                     Ok(())
                 }
                 SeqSource::MapKeys(entries) => {
-                    for key in entries.keys() {
-                        match emit(self, key.to_value())? {
+                    for entry in entries.entries() {
+                        match emit(self, entry.key.clone())? {
                             Continue => {}
                             Break => return Ok(()),
                         }
@@ -3043,8 +3662,8 @@ impl Interpreter {
                     Ok(())
                 }
                 SeqSource::MapValues(entries) => {
-                    for value in entries.values().cloned() {
-                        match emit(self, value)? {
+                    for entry in entries.entries() {
+                        match emit(self, entry.value.clone())? {
                             Continue => {}
                             Break => return Ok(()),
                         }
@@ -3052,8 +3671,8 @@ impl Interpreter {
                     Ok(())
                 }
                 SeqSource::SetValues(entries) => {
-                    for key in entries.iter() {
-                        match emit(self, key.to_value())? {
+                    for entry in entries.entries() {
+                        match emit(self, entry.value.clone())? {
                             Continue => {}
                             Break => return Ok(()),
                         }
@@ -3384,16 +4003,102 @@ impl Interpreter {
                 xs.set(idx, updated);
                 Ok(Value::MutableList(xs.clone()))
             }
+            IntrinsicFn::MapInsert => {
+                let mut args = args.into_iter();
+                let Value::Map(mut entries) = args.next().ok_or(RuntimeError::TypeError(
+                    "map_insert: missing map argument".into(),
+                ))?
+                else {
+                    return Err(RuntimeError::TypeError("map_insert expects a Map".into()));
+                };
+                let key = args.next().ok_or(RuntimeError::TypeError(
+                    "map_insert: missing key argument".into(),
+                ))?;
+                let value = args.next().ok_or(RuntimeError::TypeError(
+                    "map_insert: missing value argument".into(),
+                ))?;
+                if self.map_get_value(&entries, &key)? == Some(value.clone()) {
+                    return Ok(Value::Map(entries));
+                }
+                let hash = self.hash_for_collection_key(&key)?;
+                Rc::make_mut(&mut entries).insert_with(hash, key, value, &mut |lhs, rhs| {
+                    self.trait_eq_values(lhs, rhs)
+                })?;
+                Ok(Value::Map(entries))
+            }
+            IntrinsicFn::MapContains => {
+                let Value::Map(entries) = &args[0] else {
+                    return Err(RuntimeError::TypeError("map_contains expects a Map".into()));
+                };
+                Ok(Value::Bool(self.map_contains_value(entries, &args[1])?))
+            }
+            IntrinsicFn::MapRemove => {
+                let mut args = args.into_iter();
+                let Value::Map(mut entries) = args.next().ok_or(RuntimeError::TypeError(
+                    "map_remove: missing map argument".into(),
+                ))?
+                else {
+                    return Err(RuntimeError::TypeError("map_remove expects a Map".into()));
+                };
+                let key = args.next().ok_or(RuntimeError::TypeError(
+                    "map_remove: missing key argument".into(),
+                ))?;
+                if !self.map_contains_value(&entries, &key)? {
+                    return Ok(Value::Map(entries));
+                }
+                let hash = self.hash_for_collection_key(&key)?;
+                Rc::make_mut(&mut entries).remove_with(hash, &key, &mut |lhs, rhs| {
+                    self.trait_eq_values(lhs, rhs)
+                })?;
+                Ok(Value::Map(entries))
+            }
+            IntrinsicFn::MapLen => {
+                let Value::Map(entries) = &args[0] else {
+                    return Err(RuntimeError::TypeError("map_len expects a Map".into()));
+                };
+                Ok(Value::Int(entries.len() as i64))
+            }
+            IntrinsicFn::MapKeys => {
+                let Value::Map(entries) = &args[0] else {
+                    return Err(RuntimeError::TypeError("map_keys expects a Map".into()));
+                };
+                Ok(Value::seq_source(SeqSource::MapKeys(entries.clone())))
+            }
+            IntrinsicFn::MapValues => {
+                let Value::Map(entries) = &args[0] else {
+                    return Err(RuntimeError::TypeError("map_values expects a Map".into()));
+                };
+                Ok(Value::seq_source(SeqSource::MapValues(entries.clone())))
+            }
+            IntrinsicFn::MapIsEmpty => {
+                let Value::Map(entries) = &args[0] else {
+                    return Err(RuntimeError::TypeError("map_is_empty expects a Map".into()));
+                };
+                Ok(Value::Bool(entries.is_empty()))
+            }
             IntrinsicFn::MapGet => {
                 let Value::Map(entries) = &args[0] else {
                     return Err(RuntimeError::TypeError("map_get expects a Map".into()));
                 };
-                let key = MapKey::from_value(&args[1])?;
-                if let Some(v) = entries.get(&key) {
+                if let Some(v) = self.map_get_value(entries, &args[1])? {
                     self.make_some(v.clone())
                 } else {
                     self.make_none()
                 }
+            }
+            IntrinsicFn::MutableMapInsert => {
+                let Value::MutableMap(entries) = &args[0] else {
+                    return Err(RuntimeError::TypeError(
+                        "mutable_map_insert expects a MutableMap".into(),
+                    ));
+                };
+                let key = args[1].clone();
+                let value = args[2].clone();
+                let hash = self.hash_for_collection_key(&key)?;
+                entries.borrow_mut().insert_with(hash, key, value, &mut |lhs, rhs| {
+                    self.trait_eq_values(lhs, rhs)
+                })?;
+                Ok(Value::MutableMap(entries.clone()))
             }
             IntrinsicFn::MutableMapGet => {
                 let Value::MutableMap(entries) = &args[0] else {
@@ -3401,12 +4106,193 @@ impl Interpreter {
                         "mutable_map_get expects a MutableMap".into(),
                     ));
                 };
-                let key = MapKey::from_value(&args[1])?;
-                if let Some(v) = entries.borrow().get(&key) {
+                let borrowed = entries.borrow();
+                if let Some(v) = self.map_get_value(&borrowed, &args[1])? {
                     self.make_some(v.clone())
                 } else {
                     self.make_none()
                 }
+            }
+            IntrinsicFn::MutableMapContains => {
+                let Value::MutableMap(entries) = &args[0] else {
+                    return Err(RuntimeError::TypeError(
+                        "mutable_map_contains expects a MutableMap".into(),
+                    ));
+                };
+                let borrowed = entries.borrow();
+                Ok(Value::Bool(self.map_contains_value(&borrowed, &args[1])?))
+            }
+            IntrinsicFn::MutableMapRemove => {
+                let Value::MutableMap(entries) = &args[0] else {
+                    return Err(RuntimeError::TypeError(
+                        "mutable_map_remove expects a MutableMap".into(),
+                    ));
+                };
+                let hash = self.hash_for_collection_key(&args[1])?;
+                entries.borrow_mut().remove_with(hash, &args[1], &mut |lhs, rhs| {
+                    self.trait_eq_values(lhs, rhs)
+                })?;
+                Ok(Value::MutableMap(entries.clone()))
+            }
+            IntrinsicFn::MutableMapLen => {
+                let Value::MutableMap(entries) = &args[0] else {
+                    return Err(RuntimeError::TypeError(
+                        "mutable_map_len expects a MutableMap".into(),
+                    ));
+                };
+                Ok(Value::Int(entries.borrow().len() as i64))
+            }
+            IntrinsicFn::MutableMapKeys => {
+                let Value::MutableMap(entries) = &args[0] else {
+                    return Err(RuntimeError::TypeError(
+                        "mutable_map_keys expects a MutableMap".into(),
+                    ));
+                };
+                Ok(Value::seq_source(SeqSource::MapKeys(Rc::new(
+                    entries.borrow().clone(),
+                ))))
+            }
+            IntrinsicFn::MutableMapValues => {
+                let Value::MutableMap(entries) = &args[0] else {
+                    return Err(RuntimeError::TypeError(
+                        "mutable_map_values expects a MutableMap".into(),
+                    ));
+                };
+                Ok(Value::seq_source(SeqSource::MapValues(Rc::new(
+                    entries.borrow().clone(),
+                ))))
+            }
+            IntrinsicFn::MutableMapIsEmpty => {
+                let Value::MutableMap(entries) = &args[0] else {
+                    return Err(RuntimeError::TypeError(
+                        "mutable_map_is_empty expects a MutableMap".into(),
+                    ));
+                };
+                Ok(Value::Bool(entries.borrow().is_empty()))
+            }
+            IntrinsicFn::SetInsert => {
+                let mut args = args.into_iter();
+                let Value::Set(mut entries) = args.next().ok_or(RuntimeError::TypeError(
+                    "set_insert: missing set argument".into(),
+                ))?
+                else {
+                    return Err(RuntimeError::TypeError("set_insert expects a Set".into()));
+                };
+                let value = args.next().ok_or(RuntimeError::TypeError(
+                    "set_insert: missing element argument".into(),
+                ))?;
+                if self.set_contains_value(&entries, &value)? {
+                    return Ok(Value::Set(entries));
+                }
+                let hash = self.hash_for_collection_key(&value)?;
+                Rc::make_mut(&mut entries).insert_with(hash, value, &mut |lhs, rhs| {
+                    self.trait_eq_values(lhs, rhs)
+                })?;
+                Ok(Value::Set(entries))
+            }
+            IntrinsicFn::SetContains => {
+                let Value::Set(entries) = &args[0] else {
+                    return Err(RuntimeError::TypeError("set_contains expects a Set".into()));
+                };
+                Ok(Value::Bool(self.set_contains_value(entries, &args[1])?))
+            }
+            IntrinsicFn::SetRemove => {
+                let mut args = args.into_iter();
+                let Value::Set(mut entries) = args.next().ok_or(RuntimeError::TypeError(
+                    "set_remove: missing set argument".into(),
+                ))?
+                else {
+                    return Err(RuntimeError::TypeError("set_remove expects a Set".into()));
+                };
+                let value = args.next().ok_or(RuntimeError::TypeError(
+                    "set_remove: missing element argument".into(),
+                ))?;
+                if !self.set_contains_value(&entries, &value)? {
+                    return Ok(Value::Set(entries));
+                }
+                let hash = self.hash_for_collection_key(&value)?;
+                Rc::make_mut(&mut entries).remove_with(hash, &value, &mut |lhs, rhs| {
+                    self.trait_eq_values(lhs, rhs)
+                })?;
+                Ok(Value::Set(entries))
+            }
+            IntrinsicFn::SetLen => {
+                let Value::Set(entries) = &args[0] else {
+                    return Err(RuntimeError::TypeError("set_len expects a Set".into()));
+                };
+                Ok(Value::Int(entries.len() as i64))
+            }
+            IntrinsicFn::SetIsEmpty => {
+                let Value::Set(entries) = &args[0] else {
+                    return Err(RuntimeError::TypeError("set_is_empty expects a Set".into()));
+                };
+                Ok(Value::Bool(entries.is_empty()))
+            }
+            IntrinsicFn::SetValues => {
+                let Value::Set(entries) = &args[0] else {
+                    return Err(RuntimeError::TypeError("set_values expects a Set".into()));
+                };
+                Ok(Value::seq_source(SeqSource::SetValues(entries.clone())))
+            }
+            IntrinsicFn::MutableSetInsert => {
+                let Value::MutableSet(entries) = &args[0] else {
+                    return Err(RuntimeError::TypeError(
+                        "mutable_set_insert expects a MutableSet".into(),
+                    ));
+                };
+                let value = args[1].clone();
+                let hash = self.hash_for_collection_key(&value)?;
+                entries
+                    .borrow_mut()
+                    .insert_with(hash, value, &mut |lhs, rhs| self.trait_eq_values(lhs, rhs))?;
+                Ok(Value::MutableSet(entries.clone()))
+            }
+            IntrinsicFn::MutableSetContains => {
+                let Value::MutableSet(entries) = &args[0] else {
+                    return Err(RuntimeError::TypeError(
+                        "mutable_set_contains expects a MutableSet".into(),
+                    ));
+                };
+                let borrowed = entries.borrow();
+                Ok(Value::Bool(self.set_contains_value(&borrowed, &args[1])?))
+            }
+            IntrinsicFn::MutableSetRemove => {
+                let Value::MutableSet(entries) = &args[0] else {
+                    return Err(RuntimeError::TypeError(
+                        "mutable_set_remove expects a MutableSet".into(),
+                    ));
+                };
+                let hash = self.hash_for_collection_key(&args[1])?;
+                entries.borrow_mut().remove_with(hash, &args[1], &mut |lhs, rhs| {
+                    self.trait_eq_values(lhs, rhs)
+                })?;
+                Ok(Value::MutableSet(entries.clone()))
+            }
+            IntrinsicFn::MutableSetLen => {
+                let Value::MutableSet(entries) = &args[0] else {
+                    return Err(RuntimeError::TypeError(
+                        "mutable_set_len expects a MutableSet".into(),
+                    ));
+                };
+                Ok(Value::Int(entries.borrow().len() as i64))
+            }
+            IntrinsicFn::MutableSetIsEmpty => {
+                let Value::MutableSet(entries) = &args[0] else {
+                    return Err(RuntimeError::TypeError(
+                        "mutable_set_is_empty expects a MutableSet".into(),
+                    ));
+                };
+                Ok(Value::Bool(entries.borrow().is_empty()))
+            }
+            IntrinsicFn::MutableSetValues => {
+                let Value::MutableSet(entries) = &args[0] else {
+                    return Err(RuntimeError::TypeError(
+                        "mutable_set_values expects a MutableSet".into(),
+                    ));
+                };
+                Ok(Value::seq_source(SeqSource::SetValues(Rc::new(
+                    entries.borrow().clone(),
+                ))))
             }
             IntrinsicFn::SeqMap => {
                 let plan = self.require_traversal_plan(&args[0], "seq_map")?;
@@ -3512,10 +4398,10 @@ impl Interpreter {
             }
             IntrinsicFn::SeqFrequencies => {
                 let plan = self.require_traversal_plan(&args[0], "seq_frequencies")?;
-                let mut entries = indexmap::IndexMap::new();
-                self.seq_for_each(&plan, &mut |_interp, item| {
-                    let key = MapKey::from_value(&item)?;
-                    let next = match entries.get(&key) {
+                let mut entries = MapValue::new();
+                let mut state = self.seq_iter_from_plan(&plan)?;
+                while let Some(item) = self.seq_iter_next(&mut state)? {
+                    let next = match self.map_get_value(&entries, &item)? {
                         Some(Value::Int(n)) => {
                             n.checked_add(1).ok_or(RuntimeError::IntegerOverflow)?
                         }
@@ -3526,9 +4412,8 @@ impl Interpreter {
                         }
                         None => 1,
                     };
-                    entries.insert(key, Value::Int(next));
-                    Ok(())
-                })?;
+                    entries = self.map_insert_value(&entries, item, Value::Int(next))?;
+                }
                 Ok(Value::Map(Rc::new(entries)))
             }
             IntrinsicFn::SeqAny => {
@@ -3645,6 +4530,37 @@ impl Interpreter {
                     type_idx: None,
                 };
                 self.make_some(payload)
+            }
+            IntrinsicFn::ListSort => {
+                let Value::List(xs) = &args[0] else {
+                    return Err(RuntimeError::TypeError("list_sort expects a List".into()));
+                };
+                let mut cmp = |a: &Value, b: &Value| {
+                    let ord = self.trait_compare_values(a, b)?;
+                    Ok(ord.cmp(&0))
+                };
+                let items = stable_merge_sort_by(xs.as_ref(), &mut cmp)?;
+                Ok(Value::list(items))
+            }
+            IntrinsicFn::ListBinarySearch => {
+                let Value::List(xs) = &args[0] else {
+                    return Err(RuntimeError::TypeError(
+                        "list_binary_search expects a List".into(),
+                    ));
+                };
+                let needle = &args[1];
+                let mut lo = 0usize;
+                let mut hi = xs.len();
+                while lo < hi {
+                    let mid = lo + (hi - lo) / 2;
+                    let ord = self.trait_compare_values(&xs[mid], needle)?;
+                    match ord.cmp(&0) {
+                        Ordering::Less => lo = mid + 1,
+                        Ordering::Greater => hi = mid,
+                        Ordering::Equal => return Ok(Value::Int(mid as i64)),
+                    }
+                }
+                Ok(Value::Int(-(lo as i64) - 1))
             }
             IntrinsicFn::ListSortBy => {
                 let Value::List(xs) = &args[0] else {
@@ -3895,7 +4811,7 @@ impl Interpreter {
         }
     }
 
-    fn eval_index(&self, base: Value, index: Value) -> Result<Value, RuntimeError> {
+    fn eval_index(&mut self, base: Value, index: Value) -> Result<Value, RuntimeError> {
         match (&base, &index) {
             (Value::List(items), Value::Int(i)) => {
                 let i = *i;
@@ -3951,15 +4867,12 @@ impl Interpreter {
                 }
             }
             (Value::Map(entries), key) => {
-                let k = MapKey::from_value(key)?;
-                entries.get(&k).cloned().ok_or(RuntimeError::KeyNotFound)
+                self.map_get_value(entries, key)?
+                    .ok_or(RuntimeError::KeyNotFound)
             }
             (Value::MutableMap(entries), key) => {
-                let k = MapKey::from_value(key)?;
-                entries
-                    .borrow()
-                    .get(&k)
-                    .cloned()
+                let borrowed = entries.borrow();
+                self.map_get_value(&borrowed, key)?
                     .ok_or(RuntimeError::KeyNotFound)
             }
             _ => Err(RuntimeError::TypeError(
@@ -4706,6 +5619,7 @@ mod tests {
     use smallvec::smallvec;
 
     use super::*;
+    use crate::value::MapKey;
 
     fn make_test_interpreter_and_body() -> (Interpreter, Body, TypeItemIdx, Name, Name) {
         let mut interner = Interner::new();
@@ -4719,6 +5633,7 @@ mod tests {
             name: opt_name,
             is_pub: true,
             type_params: Vec::new(),
+            derives: Vec::new(),
             kind: TypeDefKind::Adt {
                 variants: vec![
                     VariantDef {
@@ -5713,9 +6628,9 @@ mod tests {
             "string lines iterator should reuse the source string"
         );
 
-        let mut map_entries = indexmap::IndexMap::new();
-        map_entries.insert(MapKey::Int(1), Value::Int(10));
-        let map_entries = Rc::new(map_entries);
+        let map_entries = Rc::new(MapValue::from_primitive_indexmap(
+            indexmap::IndexMap::from([(MapKey::Int(1), Value::Int(10))]),
+        ));
         let map_plan = SeqPlan::Source(SeqSource::MapKeys(map_entries.clone()));
         let SeqIterState::Source(SeqSourceIter::MapKeys { entries, .. }) = interp
             .seq_iter_from_plan(&map_plan)
@@ -5728,9 +6643,9 @@ mod tests {
             "map-keys iterator should reuse map storage"
         );
 
-        let mut set_entries = indexmap::IndexSet::new();
-        set_entries.insert(MapKey::Int(1));
-        let set_entries = Rc::new(set_entries);
+        let set_entries = Rc::new(SetValue::from_primitive_indexset(
+            indexmap::IndexSet::from([MapKey::Int(1)]),
+        ));
         let set_plan = SeqPlan::Source(SeqSource::SetValues(set_entries.clone()));
         let SeqIterState::Source(SeqSourceIter::SetValues { entries, .. }) = interp
             .seq_iter_from_plan(&set_plan)

--- a/crates/eval/src/intrinsics.rs
+++ b/crates/eval/src/intrinsics.rs
@@ -216,7 +216,13 @@ impl IntrinsicFn {
                 | IntrinsicFn::MutableListPop
                 | IntrinsicFn::MutableListGet
                 | IntrinsicFn::MutableListUpdate
+                | IntrinsicFn::MutableMapInsert
                 | IntrinsicFn::MutableMapGet
+                | IntrinsicFn::MutableMapContains
+                | IntrinsicFn::MutableMapRemove
+                | IntrinsicFn::MutableSetInsert
+                | IntrinsicFn::MutableSetContains
+                | IntrinsicFn::MutableSetRemove
                 | IntrinsicFn::DequePopFront
                 | IntrinsicFn::DequePopBack
                 | IntrinsicFn::SeqMap
@@ -235,8 +241,16 @@ impl IntrinsicFn {
                 | IntrinsicFn::SeqAll
                 | IntrinsicFn::SeqFind
                 | IntrinsicFn::SeqToList
+                | IntrinsicFn::MapInsert
+                | IntrinsicFn::MapContains
                 | IntrinsicFn::MapGet
+                | IntrinsicFn::MapRemove
+                | IntrinsicFn::SetInsert
+                | IntrinsicFn::SetContains
+                | IntrinsicFn::SetRemove
+                | IntrinsicFn::ListSort
                 | IntrinsicFn::ListSortBy
+                | IntrinsicFn::ListBinarySearch
                 | IntrinsicFn::OptionUnwrapOr
                 | IntrinsicFn::OptionMapOr
                 | IntrinsicFn::OptionMap
@@ -650,7 +664,11 @@ impl IntrinsicFn {
                     ));
                 };
                 let key = MapKey::from_value(&key_value)?;
-                entries.borrow_mut().insert(key, value);
+                let hash = key.primitive_hash();
+                let key_value = key.to_value();
+                entries
+                    .borrow_mut()
+                    .insert_with(hash, key_value, value, &mut |lhs, rhs| Ok(lhs == rhs))?;
                 Ok(Value::MutableMap(entries))
             }
             IntrinsicFn::MutableMapContains => {
@@ -660,7 +678,13 @@ impl IntrinsicFn {
                     ));
                 };
                 let key = MapKey::from_value(&args[1])?;
-                Ok(Value::Bool(entries.borrow().contains_key(&key)))
+                let hash = key.primitive_hash();
+                let key_value = key.to_value();
+                Ok(Value::Bool(entries.borrow().contains_with(
+                    hash,
+                    &key_value,
+                    &mut |lhs, rhs| Ok(lhs == rhs),
+                )?))
             }
             IntrinsicFn::MutableMapRemove => {
                 let mut args = args;
@@ -676,7 +700,13 @@ impl IntrinsicFn {
                     ));
                 };
                 let key = MapKey::from_value(&key_value)?;
-                entries.borrow_mut().shift_remove(&key);
+                let hash = key.primitive_hash();
+                let key_value = key.to_value();
+                entries.borrow_mut().remove_with(
+                    hash,
+                    &key_value,
+                    &mut |lhs, rhs| Ok(lhs == rhs),
+                )?;
                 Ok(Value::MutableMap(entries))
             }
             IntrinsicFn::MutableMapLen => {
@@ -730,7 +760,11 @@ impl IntrinsicFn {
                     ));
                 };
                 let elem = MapKey::from_value(&elem_value)?;
-                entries.borrow_mut().insert(elem);
+                let hash = elem.primitive_hash();
+                let elem_value = elem.to_value();
+                entries
+                    .borrow_mut()
+                    .insert_with(hash, elem_value, &mut |lhs, rhs| Ok(lhs == rhs))?;
                 Ok(Value::MutableSet(entries))
             }
             IntrinsicFn::MutableSetContains => {
@@ -740,7 +774,13 @@ impl IntrinsicFn {
                     ));
                 };
                 let elem = MapKey::from_value(&args[1])?;
-                Ok(Value::Bool(entries.borrow().contains(&elem)))
+                let hash = elem.primitive_hash();
+                let elem_value = elem.to_value();
+                Ok(Value::Bool(entries.borrow().contains_with(
+                    hash,
+                    &elem_value,
+                    &mut |lhs, rhs| Ok(lhs == rhs),
+                )?))
             }
             IntrinsicFn::MutableSetRemove => {
                 let mut args = args;
@@ -756,7 +796,13 @@ impl IntrinsicFn {
                     ));
                 };
                 let elem = MapKey::from_value(&elem_value)?;
-                entries.borrow_mut().shift_remove(&elem);
+                let hash = elem.primitive_hash();
+                let elem_value = elem.to_value();
+                entries.borrow_mut().remove_with(
+                    hash,
+                    &elem_value,
+                    &mut |lhs, rhs| Ok(lhs == rhs),
+                )?;
                 Ok(Value::MutableSet(entries))
             }
             IntrinsicFn::MutableSetLen => {
@@ -1021,10 +1067,17 @@ impl IntrinsicFn {
                     return Err(RuntimeError::TypeError("map_insert expects a Map".into()));
                 };
                 let key = MapKey::from_value(&key_value)?;
+                let hash = key.primitive_hash();
+                let key_value = key.to_value();
                 if entries.get(&key) == Some(&value) {
                     return Ok(Value::Map(entries));
                 }
-                Rc::make_mut(&mut entries).insert(key, value);
+                Rc::make_mut(&mut entries).insert_with(
+                    hash,
+                    key_value,
+                    value,
+                    &mut |lhs, rhs| Ok(lhs == rhs),
+                )?;
                 Ok(Value::Map(entries))
             }
             IntrinsicFn::MapContains => {
@@ -1032,7 +1085,13 @@ impl IntrinsicFn {
                     return Err(RuntimeError::TypeError("map_contains expects a Map".into()));
                 };
                 let key = MapKey::from_value(&args[1])?;
-                Ok(Value::Bool(entries.contains_key(&key)))
+                let hash = key.primitive_hash();
+                let key_value = key.to_value();
+                Ok(Value::Bool(entries.contains_with(
+                    hash,
+                    &key_value,
+                    &mut |lhs, rhs| Ok(lhs == rhs),
+                )?))
             }
             IntrinsicFn::MapRemove => {
                 let mut args = args;
@@ -1046,10 +1105,16 @@ impl IntrinsicFn {
                     return Err(RuntimeError::TypeError("map_remove expects a Map".into()));
                 };
                 let key = MapKey::from_value(&key_value)?;
-                if !entries.contains_key(&key) {
+                let hash = key.primitive_hash();
+                let key_value = key.to_value();
+                if entries.get(&key).is_none() {
                     return Ok(Value::Map(entries));
                 }
-                Rc::make_mut(&mut entries).shift_remove(&key);
+                Rc::make_mut(&mut entries).remove_with(
+                    hash,
+                    &key_value,
+                    &mut |lhs, rhs| Ok(lhs == rhs),
+                )?;
                 Ok(Value::Map(entries))
             }
             IntrinsicFn::MapLen => {
@@ -1090,10 +1155,16 @@ impl IntrinsicFn {
                     return Err(RuntimeError::TypeError("set_insert expects a Set".into()));
                 };
                 let elem = MapKey::from_value(&elem_value)?;
+                let hash = elem.primitive_hash();
+                let elem_value = elem.to_value();
                 if entries.contains(&elem) {
                     return Ok(Value::Set(entries));
                 }
-                Rc::make_mut(&mut entries).insert(elem);
+                Rc::make_mut(&mut entries).insert_with(
+                    hash,
+                    elem_value,
+                    &mut |lhs, rhs| Ok(lhs == rhs),
+                )?;
                 Ok(Value::Set(entries))
             }
             IntrinsicFn::SetContains => {
@@ -1101,7 +1172,13 @@ impl IntrinsicFn {
                     return Err(RuntimeError::TypeError("set_contains expects a Set".into()));
                 };
                 let elem = MapKey::from_value(&args[1])?;
-                Ok(Value::Bool(entries.contains(&elem)))
+                let hash = elem.primitive_hash();
+                let elem_value = elem.to_value();
+                Ok(Value::Bool(entries.contains_with(
+                    hash,
+                    &elem_value,
+                    &mut |lhs, rhs| Ok(lhs == rhs),
+                )?))
             }
             IntrinsicFn::SetRemove => {
                 let mut args = args;
@@ -1115,10 +1192,16 @@ impl IntrinsicFn {
                     return Err(RuntimeError::TypeError("set_remove expects a Set".into()));
                 };
                 let elem = MapKey::from_value(&elem_value)?;
+                let hash = elem.primitive_hash();
+                let elem_value = elem.to_value();
                 if !entries.contains(&elem) {
                     return Ok(Value::Set(entries));
                 }
-                Rc::make_mut(&mut entries).shift_remove(&elem);
+                Rc::make_mut(&mut entries).remove_with(
+                    hash,
+                    &elem_value,
+                    &mut |lhs, rhs| Ok(lhs == rhs),
+                )?;
                 Ok(Value::Set(entries))
             }
             IntrinsicFn::SetLen => {

--- a/crates/eval/src/lib.rs
+++ b/crates/eval/src/lib.rs
@@ -12,7 +12,8 @@ pub mod value;
 
 use kyokara_hir::{
     ModulePath, activate_synthetic_imports, check_module, check_project, collect_item_tree,
-    register_builtin_intrinsics, register_builtin_methods, register_builtin_types,
+    register_builtin_intrinsics, register_builtin_methods, register_builtin_traits,
+    register_builtin_types,
     register_static_methods, register_synthetic_modules,
 };
 use kyokara_intern::Interner;
@@ -137,6 +138,11 @@ pub fn run_with_manifest(
 
     // 4. Register builtin types (Option, Result) before intrinsics and type-checking.
     register_builtin_types(
+        &mut item_result.tree,
+        &mut item_result.module_scope,
+        &mut interner,
+    );
+    register_builtin_traits(
         &mut item_result.tree,
         &mut item_result.module_scope,
         &mut interner,

--- a/crates/eval/src/value.rs
+++ b/crates/eval/src/value.rs
@@ -1,6 +1,7 @@
 //! Runtime value representation.
 
 use std::cell::RefCell;
+use std::collections::HashMap;
 use std::collections::VecDeque;
 use std::rc::Rc;
 
@@ -57,6 +58,407 @@ impl MapKey {
 
     pub fn display(&self, _interner: &Interner) -> String {
         self.to_value().display(_interner)
+    }
+
+    pub fn primitive_hash(&self) -> i64 {
+        primitive_map_key_hash(self)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MapEntry {
+    pub hash: i64,
+    pub key: Value,
+    pub value: Value,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct MapValue {
+    entries: Vec<MapEntry>,
+    buckets: HashMap<i64, Vec<usize>>,
+}
+
+impl PartialEq for MapValue {
+    fn eq(&self, other: &Self) -> bool {
+        if self.entries.len() != other.entries.len() {
+            return false;
+        }
+
+        self.entries.iter().all(|entry| {
+            other
+                .entries
+                .iter()
+                .find(|candidate| candidate.hash == entry.hash && candidate.key == entry.key)
+                .is_some_and(|candidate| candidate.value == entry.value)
+        })
+    }
+}
+
+impl Eq for MapValue {}
+
+impl MapValue {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn from_primitive_indexmap(entries: IndexMap<MapKey, Value>) -> Self {
+        let entries = entries
+            .into_iter()
+            .map(|(key, value)| MapEntry {
+                hash: primitive_map_key_hash(&key),
+                key: key.to_value(),
+                value,
+            })
+            .collect();
+        Self::from_entries(entries)
+    }
+
+    pub fn from_entries(entries: Vec<MapEntry>) -> Self {
+        let mut buckets: HashMap<i64, Vec<usize>> = HashMap::new();
+        for (idx, entry) in entries.iter().enumerate() {
+            buckets.entry(entry.hash).or_default().push(idx);
+        }
+        Self { entries, buckets }
+    }
+
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    pub fn key_at(&self, idx: usize) -> Option<Value> {
+        self.entries.get(idx).map(|entry| entry.key.clone())
+    }
+
+    pub fn value_at(&self, idx: usize) -> Option<Value> {
+        self.entries.get(idx).map(|entry| entry.value.clone())
+    }
+
+    pub fn entries(&self) -> &[MapEntry] {
+        &self.entries
+    }
+
+    pub fn find_index_with<E>(
+        &self,
+        hash: i64,
+        key: &Value,
+        eq: &mut E,
+    ) -> Result<Option<usize>, RuntimeError>
+    where
+        E: FnMut(&Value, &Value) -> Result<bool, RuntimeError>,
+    {
+        let Some(indices) = self.buckets.get(&hash) else {
+            return Ok(None);
+        };
+        for &idx in indices {
+            let entry = &self.entries[idx];
+            if eq(&entry.key, key)? {
+                return Ok(Some(idx));
+            }
+        }
+        Ok(None)
+    }
+
+    pub fn get_cloned_with<E>(
+        &self,
+        hash: i64,
+        key: &Value,
+        eq: &mut E,
+    ) -> Result<Option<Value>, RuntimeError>
+    where
+        E: FnMut(&Value, &Value) -> Result<bool, RuntimeError>,
+    {
+        Ok(self
+            .find_index_with(hash, key, eq)?
+            .map(|idx| self.entries[idx].value.clone()))
+    }
+
+    pub fn contains_with<E>(
+        &self,
+        hash: i64,
+        key: &Value,
+        eq: &mut E,
+    ) -> Result<bool, RuntimeError>
+    where
+        E: FnMut(&Value, &Value) -> Result<bool, RuntimeError>,
+    {
+        Ok(self.find_index_with(hash, key, eq)?.is_some())
+    }
+
+    pub fn insert_persistent_with<E>(
+        &self,
+        hash: i64,
+        key: Value,
+        value: Value,
+        eq: &mut E,
+    ) -> Result<Self, RuntimeError>
+    where
+        E: FnMut(&Value, &Value) -> Result<bool, RuntimeError>,
+    {
+        let mut entries = self.entries.clone();
+        if let Some(idx) = self.find_index_with(hash, &key, eq)? {
+            if entries[idx].value == value {
+                return Ok(self.clone());
+            }
+            entries[idx].value = value;
+            return Ok(Self::from_entries(entries));
+        }
+        entries.push(MapEntry { hash, key, value });
+        Ok(Self::from_entries(entries))
+    }
+
+    pub fn remove_persistent_with<E>(
+        &self,
+        hash: i64,
+        key: &Value,
+        eq: &mut E,
+    ) -> Result<Self, RuntimeError>
+    where
+        E: FnMut(&Value, &Value) -> Result<bool, RuntimeError>,
+    {
+        let Some(idx) = self.find_index_with(hash, key, eq)? else {
+            return Ok(self.clone());
+        };
+        let mut entries = self.entries.clone();
+        entries.remove(idx);
+        Ok(Self::from_entries(entries))
+    }
+
+    pub fn insert_with<E>(
+        &mut self,
+        hash: i64,
+        key: Value,
+        value: Value,
+        eq: &mut E,
+    ) -> Result<(), RuntimeError>
+    where
+        E: FnMut(&Value, &Value) -> Result<bool, RuntimeError>,
+    {
+        if let Some(idx) = self.find_index_with(hash, &key, eq)? {
+            self.entries[idx].value = value;
+        } else {
+            self.entries.push(MapEntry { hash, key, value });
+        }
+        *self = Self::from_entries(self.entries.clone());
+        Ok(())
+    }
+
+    pub fn remove_with<E>(
+        &mut self,
+        hash: i64,
+        key: &Value,
+        eq: &mut E,
+    ) -> Result<(), RuntimeError>
+    where
+        E: FnMut(&Value, &Value) -> Result<bool, RuntimeError>,
+    {
+        if let Some(idx) = self.find_index_with(hash, key, eq)? {
+            self.entries.remove(idx);
+            *self = Self::from_entries(self.entries.clone());
+        }
+        Ok(())
+    }
+
+    pub fn get(&self, key: &MapKey) -> Option<&Value> {
+        let hash = key.primitive_hash();
+        let key_value = key.to_value();
+        self.buckets.get(&hash).and_then(|indices| {
+            indices.iter().find_map(|&idx| {
+                let entry = &self.entries[idx];
+                (entry.key == key_value).then_some(&entry.value)
+            })
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SetEntry {
+    pub hash: i64,
+    pub value: Value,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct SetValue {
+    entries: Vec<SetEntry>,
+    buckets: HashMap<i64, Vec<usize>>,
+}
+
+impl PartialEq for SetValue {
+    fn eq(&self, other: &Self) -> bool {
+        if self.entries.len() != other.entries.len() {
+            return false;
+        }
+
+        self.entries.iter().all(|entry| {
+            other
+                .entries
+                .iter()
+                .any(|candidate| candidate.hash == entry.hash && candidate.value == entry.value)
+        })
+    }
+}
+
+impl Eq for SetValue {}
+
+impl SetValue {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub fn from_primitive_indexset(entries: IndexSet<MapKey>) -> Self {
+        let entries = entries
+            .into_iter()
+            .map(|value| SetEntry {
+                hash: primitive_map_key_hash(&value),
+                value: value.to_value(),
+            })
+            .collect();
+        Self::from_entries(entries)
+    }
+
+    pub fn from_entries(entries: Vec<SetEntry>) -> Self {
+        let mut buckets: HashMap<i64, Vec<usize>> = HashMap::new();
+        for (idx, entry) in entries.iter().enumerate() {
+            buckets.entry(entry.hash).or_default().push(idx);
+        }
+        Self { entries, buckets }
+    }
+
+    pub fn len(&self) -> usize {
+        self.entries.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    pub fn value_at(&self, idx: usize) -> Option<Value> {
+        self.entries.get(idx).map(|entry| entry.value.clone())
+    }
+
+    pub fn entries(&self) -> &[SetEntry] {
+        &self.entries
+    }
+
+    pub fn find_index_with<E>(
+        &self,
+        hash: i64,
+        value: &Value,
+        eq: &mut E,
+    ) -> Result<Option<usize>, RuntimeError>
+    where
+        E: FnMut(&Value, &Value) -> Result<bool, RuntimeError>,
+    {
+        let Some(indices) = self.buckets.get(&hash) else {
+            return Ok(None);
+        };
+        for &idx in indices {
+            let entry = &self.entries[idx];
+            if eq(&entry.value, value)? {
+                return Ok(Some(idx));
+            }
+        }
+        Ok(None)
+    }
+
+    pub fn contains_with<E>(
+        &self,
+        hash: i64,
+        value: &Value,
+        eq: &mut E,
+    ) -> Result<bool, RuntimeError>
+    where
+        E: FnMut(&Value, &Value) -> Result<bool, RuntimeError>,
+    {
+        Ok(self.find_index_with(hash, value, eq)?.is_some())
+    }
+
+    pub fn insert_persistent_with<E>(
+        &self,
+        hash: i64,
+        value: Value,
+        eq: &mut E,
+    ) -> Result<Self, RuntimeError>
+    where
+        E: FnMut(&Value, &Value) -> Result<bool, RuntimeError>,
+    {
+        if self.find_index_with(hash, &value, eq)?.is_some() {
+            return Ok(self.clone());
+        }
+        let mut entries = self.entries.clone();
+        entries.push(SetEntry { hash, value });
+        Ok(Self::from_entries(entries))
+    }
+
+    pub fn remove_persistent_with<E>(
+        &self,
+        hash: i64,
+        value: &Value,
+        eq: &mut E,
+    ) -> Result<Self, RuntimeError>
+    where
+        E: FnMut(&Value, &Value) -> Result<bool, RuntimeError>,
+    {
+        let Some(idx) = self.find_index_with(hash, value, eq)? else {
+            return Ok(self.clone());
+        };
+        let mut entries = self.entries.clone();
+        entries.remove(idx);
+        Ok(Self::from_entries(entries))
+    }
+
+    pub fn insert_with<E>(&mut self, hash: i64, value: Value, eq: &mut E) -> Result<(), RuntimeError>
+    where
+        E: FnMut(&Value, &Value) -> Result<bool, RuntimeError>,
+    {
+        if self.find_index_with(hash, &value, eq)?.is_none() {
+            self.entries.push(SetEntry { hash, value });
+            *self = Self::from_entries(self.entries.clone());
+        }
+        Ok(())
+    }
+
+    pub fn remove_with<E>(
+        &mut self,
+        hash: i64,
+        value: &Value,
+        eq: &mut E,
+    ) -> Result<(), RuntimeError>
+    where
+        E: FnMut(&Value, &Value) -> Result<bool, RuntimeError>,
+    {
+        if let Some(idx) = self.find_index_with(hash, value, eq)? {
+            self.entries.remove(idx);
+            *self = Self::from_entries(self.entries.clone());
+        }
+        Ok(())
+    }
+
+    pub fn contains(&self, key: &MapKey) -> bool {
+        let hash = key.primitive_hash();
+        let key_value = key.to_value();
+        self.buckets.get(&hash).is_some_and(|indices| {
+            indices.iter().any(|&idx| self.entries[idx].value == key_value)
+        })
+    }
+}
+
+fn primitive_map_key_hash(key: &MapKey) -> i64 {
+    match key {
+        MapKey::Int(n) => *n,
+        MapKey::String(s) => {
+            let mut hash = 0i64;
+            for byte in s.as_bytes() {
+                hash = hash.wrapping_mul(31).wrapping_add(i64::from(*byte));
+            }
+            hash
+        }
+        MapKey::Char(c) => i64::from(u32::from(*c)),
+        MapKey::Bool(b) => i64::from(*b),
+        MapKey::Unit => 0,
     }
 }
 
@@ -422,13 +824,13 @@ pub enum Value {
     List(Rc<Vec<Value>>),
     BitSet(BitSetValue),
     MutableList(MutableListValue),
-    MutableMap(Rc<RefCell<IndexMap<MapKey, Value>>>),
-    MutableSet(Rc<RefCell<IndexSet<MapKey>>>),
+    MutableMap(Rc<RefCell<MapValue>>),
+    MutableSet(Rc<RefCell<SetValue>>),
     MutableBitSet(MutableBitSetValue),
     Deque(Rc<VecDeque<Value>>),
     Seq(Rc<SeqPlan>),
-    Map(Rc<IndexMap<MapKey, Value>>),
-    Set(Rc<IndexSet<MapKey>>),
+    Map(Rc<MapValue>),
+    Set(Rc<SetValue>),
     Fn(Box<FnValue>),
 }
 
@@ -460,9 +862,9 @@ pub enum SeqSource {
     StringSplit { s: Rc<String>, delim: Rc<String> },
     StringLines { s: Rc<String> },
     StringChars { s: Rc<String> },
-    MapKeys(Rc<IndexMap<MapKey, Value>>),
-    MapValues(Rc<IndexMap<MapKey, Value>>),
-    SetValues(Rc<IndexSet<MapKey>>),
+    MapKeys(Rc<MapValue>),
+    MapValues(Rc<MapValue>),
+    SetValues(Rc<SetValue>),
     BitSetValues(BitSetValue),
 }
 
@@ -564,11 +966,15 @@ impl Value {
     }
 
     pub fn mutable_map(entries: IndexMap<MapKey, Value>) -> Self {
-        Value::MutableMap(Rc::new(RefCell::new(entries)))
+        Value::MutableMap(Rc::new(RefCell::new(MapValue::from_primitive_indexmap(
+            entries,
+        ))))
     }
 
     pub fn mutable_set(entries: IndexSet<MapKey>) -> Self {
-        Value::MutableSet(Rc::new(RefCell::new(entries)))
+        Value::MutableSet(Rc::new(RefCell::new(SetValue::from_primitive_indexset(
+            entries,
+        ))))
     }
 
     pub fn mutable_bitset(size_bits: usize) -> Self {
@@ -588,11 +994,11 @@ impl Value {
     }
 
     pub fn map(entries: IndexMap<MapKey, Value>) -> Self {
-        Value::Map(Rc::new(entries))
+        Value::Map(Rc::new(MapValue::from_primitive_indexmap(entries)))
     }
 
     pub fn set(entries: IndexSet<MapKey>) -> Self {
-        Value::Set(Rc::new(entries))
+        Value::Set(Rc::new(SetValue::from_primitive_indexset(entries)))
     }
 
     pub fn display(&self, interner: &Interner) -> String {
@@ -658,16 +1064,24 @@ impl Value {
             Value::MutableMap(entries) => {
                 let fs: Vec<String> = entries
                     .borrow()
+                    .entries()
                     .iter()
-                    .map(|(k, v)| format!("{}: {}", k.display(interner), v.display(interner)))
+                    .map(|entry| {
+                        format!(
+                            "{}: {}",
+                            entry.key.display(interner),
+                            entry.value.display(interner)
+                        )
+                    })
                     .collect();
                 format!("MutableMap({{{}}})", fs.join(", "))
             }
             Value::MutableSet(entries) => {
                 let fs: Vec<String> = entries
                     .borrow()
+                    .entries()
                     .iter()
-                    .map(|k| k.display(interner))
+                    .map(|entry| entry.value.display(interner))
                     .collect();
                 format!("MutableSet(#{{{}}})", fs.join(", "))
             }
@@ -684,13 +1098,24 @@ impl Value {
             Value::Seq(_) => "<seq>".to_string(),
             Value::Map(entries) => {
                 let fs: Vec<String> = entries
+                    .entries()
                     .iter()
-                    .map(|(k, v)| format!("{}: {}", k.display(interner), v.display(interner)))
+                    .map(|entry| {
+                        format!(
+                            "{}: {}",
+                            entry.key.display(interner),
+                            entry.value.display(interner)
+                        )
+                    })
                     .collect();
                 format!("{{{}}}", fs.join(", "))
             }
             Value::Set(entries) => {
-                let fs: Vec<String> = entries.iter().map(|k| k.display(interner)).collect();
+                let fs: Vec<String> = entries
+                    .entries()
+                    .iter()
+                    .map(|entry| entry.value.display(interner))
+                    .collect();
                 format!("#{{{}}}", fs.join(", "))
             }
             Value::Fn(_) => "<function>".to_string(),

--- a/crates/eval/tests/eval_tests.rs
+++ b/crates/eval/tests/eval_tests.rs
@@ -139,6 +139,121 @@ fn eval_pipe_identifier_is_allowed_and_pipeline_still_runs() {
 }
 
 #[test]
+fn eval_builtin_trait_qualified_call() {
+    let val = run_ok("fn main() -> Int { Ord.compare(3, 1) }");
+    assert!(matches!(val, Value::Int(1)));
+}
+
+#[test]
+fn eval_user_impl_trait_qualified_call() {
+    let val = run_ok(
+        "trait Show { fn show(self) -> String }\n\
+         type Point = { x: Int }\n\
+         impl Show for Point { fn show(self) -> String { \"p\" } }\n\
+         fn main() -> String {\n\
+             let p: Point = Point { x: 1 }\n\
+             Show.show(p)\n\
+         }",
+    );
+    assert!(matches!(val, Value::String(ref s) if s == "p"));
+}
+
+#[test]
+fn eval_map_supports_derived_key_type() {
+    let val = run_ok(
+        "import collections\n\
+         type Point derive(Eq, Hash) = { x: Int, y: Int }\n\
+         fn main() -> Int {\n\
+             let p: Point = Point { x: 1, y: 2 }\n\
+             let m = collections.Map.new().insert(p, 7)\n\
+             if (m.contains(p)) { m[p] } else { 0 }\n\
+         }",
+    );
+    assert_eq!(val, Value::Int(7));
+}
+
+#[test]
+fn eval_mutable_map_supports_derived_key_type() {
+    let val = run_ok(
+        "import collections\n\
+         type Point derive(Eq, Hash) = { x: Int, y: Int }\n\
+         fn main() -> Int {\n\
+             let p: Point = Point { x: 1, y: 2 }\n\
+             let m = collections.MutableMap.new().insert(p, 11)\n\
+             if (m.contains(p)) { m[p] } else { 0 }\n\
+         }",
+    );
+    assert_eq!(val, Value::Int(11));
+}
+
+#[test]
+fn eval_set_and_frequencies_support_derived_hash_eq_types() {
+    let val = run_ok(
+        "import collections\n\
+         type Point derive(Eq, Hash) = { x: Int }\n\
+         fn main() -> Int {\n\
+             let p: Point = Point { x: 3 }\n\
+             let s = collections.Set.new().insert(p)\n\
+             let counts = collections.List.new().push(p).push(p).frequencies()\n\
+             if (s.contains(p)) { counts[p] } else { 0 }\n\
+         }",
+    );
+    assert_eq!(val, Value::Int(2));
+}
+
+#[test]
+fn eval_mutable_set_supports_derived_hash_eq_type() {
+    let val = run_ok(
+        "import collections\n\
+         type Point derive(Eq, Hash) = { x: Int }\n\
+         fn main() -> Int {\n\
+             let p: Point = Point { x: 3 }\n\
+             let s = collections.MutableSet.new().insert(p)\n\
+             if (s.contains(p)) { s.len() } else { 0 }\n\
+         }",
+    );
+    assert_eq!(val, Value::Int(1));
+}
+
+#[test]
+fn eval_manual_eq_hash_impls_drive_collection_behavior() {
+    let val = run_ok(
+        "import collections\n\
+         type Key = { raw: Int }\n\
+         impl Eq for Key {\n\
+             fn eq(self, other: Key) -> Bool { self.raw % 2 == other.raw % 2 }\n\
+         }\n\
+         impl Hash for Key {\n\
+             fn hash(self) -> Int { self.raw % 2 }\n\
+         }\n\
+         fn main() -> Int {\n\
+             let a: Key = Key { raw: 1 }\n\
+             let b: Key = Key { raw: 3 }\n\
+             let m = collections.Map.new().insert(a, 10).insert(b, 20)\n\
+             m.len() * 100 + m[a]\n\
+         }",
+    );
+    assert_eq!(val, Value::Int(120));
+}
+
+#[test]
+fn eval_list_sort_and_binary_search_support_user_ord() {
+    let val = run_ok(
+        "import collections\n\
+         type Point derive(Eq, Ord) = { x: Int }\n\
+         fn main() -> Int {\n\
+             let a: Point = Point { x: 3 }\n\
+             let b: Point = Point { x: 1 }\n\
+             let c: Point = Point { x: 2 }\n\
+             let xs = collections.List.new().push(a).push(b).push(c).sort()\n\
+             let needle: Point = Point { x: 2 }\n\
+             xs[0].x * 100 + xs[1].x * 10 + xs.binary_search(needle)\n\
+         }",
+    );
+    assert_eq!(val, Value::Int(121));
+}
+
+#[test]
 fn eval_literal_bool_true() {
     let val = run_ok("fn main() -> Bool { true }");
     assert!(matches!(val, Value::Bool(true)));
@@ -5959,38 +6074,37 @@ fn eval_list_sort_bools() {
 }
 
 #[test]
-fn eval_list_sort_floats() {
-    let val = run_ok(
-        "fn main() -> Float {
+fn eval_list_sort_floats_rejected() {
+    let err = run_err(
+        "fn main() -> Int {
             let xs = collections.List.new().push(3.0).push(1.0).push(2.0)
             let sorted = xs.sort()
-            match (sorted.get(0)) {
-                Some(x) => x
-                None => -1.0
-            }
+            sorted.len()
         }",
     );
-    assert_eq!(val, Value::Float(1.0));
+    assert!(
+        err.contains("cannot be sorted"),
+        "expected compile-time sort rejection, got: {err}"
+    );
 }
 
 #[test]
-fn eval_list_sort_floats_with_nan() {
-    // NaN sorts to end via f64::total_cmp
-    let val = run_ok(
-        r#"fn main() -> Float {
+fn eval_list_sort_floats_with_nan_rejected() {
+    let err = run_err(
+        r#"fn main() -> Int {
             let nan = match ("NaN".parse_float()) {
                 Ok(f) => f
                 Err(_) => 0.0
             }
             let xs = collections.List.new().push(nan).push(1.0).push(2.0)
             let sorted = xs.sort()
-            match (sorted.get(0)) {
-                Some(x) => x
-                None => -1.0
-            }
+            sorted.len()
         }"#,
     );
-    assert_eq!(val, Value::Float(1.0));
+    assert!(
+        err.contains("cannot be sorted"),
+        "expected compile-time sort rejection, got: {err}"
+    );
 }
 
 #[test]
@@ -6009,19 +6123,20 @@ fn eval_list_sort_chars() {
 }
 
 #[test]
-fn eval_list_sort_unsortable() {
-    let err = run_err(
+fn eval_list_sort_lists_lexicographically() {
+    let val = run_ok(
         "fn main() -> Int {
-            let inner = collections.List.new().push(1)
-            let xs = collections.List.new().push(inner)
+            let a = collections.List.new().push(1)
+            let b = collections.List.new().push(1).push(2)
+            let xs = collections.List.new().push(b).push(a)
             let sorted = xs.sort()
-            sorted.len()
+            match (sorted.get(0)) {
+                Some(inner) => inner.len()
+                None => -1
+            }
         }",
     );
-    assert!(
-        err.contains("cannot be sorted"),
-        "expected compile-time sort rejection, got: {err}"
-    );
+    assert_eq!(val, Value::Int(1));
 }
 
 #[test]
@@ -6049,18 +6164,17 @@ fn eval_list_binary_search_empty_returns_negative_one() {
 }
 
 #[test]
-fn eval_list_binary_search_unsortable() {
-    let err = run_err(
+fn eval_list_binary_search_lists() {
+    let val = run_ok(
         "fn main() -> Int {
-            let needle = collections.List.new().push(1)
-            let xs = collections.List.new().push(needle)
+            let a = collections.List.new().push(1)
+            let b = collections.List.new().push(1).push(2)
+            let xs = collections.List.new().push(a).push(b)
+            let needle = collections.List.new().push(1).push(2)
             xs.binary_search(needle)
         }",
     );
-    assert!(
-        err.contains("cannot be sorted"),
-        "expected compile-time binary_search rejection, got: {err}"
-    );
+    assert_eq!(val, Value::Int(1));
 }
 
 // ── list_sort_by tests ──────────────────────────────────────────────
@@ -6474,7 +6588,8 @@ fn main() -> Int {
         .frequencies()
     let d = collections.Deque.new().push_back(1).push_back(2).push_back(1).frequencies()
     let e = (0..<4).frequencies()
-    let empty = collections.List.new().frequencies()
+    let empty_src: List<Int> = collections.List.new()
+    let empty = empty_src.frequencies()
     let ordered = a.keys().to_list()
     if (
         a.get(3).unwrap_or(0) == 2
@@ -7977,18 +8092,15 @@ fn eval_map_float_key_rejected_at_compile_time() {
 }
 
 #[test]
-fn eval_map_list_key_rejected_at_compile_time() {
-    let err = run_err(
+fn eval_map_list_key_allowed_when_elements_are_hashable() {
+    let val = run_ok(
         "fn main() -> Int {
             let xs = collections.List.new().push(1)
             let m = collections.Map.new().insert(xs, 1)
-            0
+            m.get(xs).unwrap_or(0)
         }",
     );
-    assert!(
-        err.contains("cannot be used as a map key"),
-        "expected compile-time map key rejection, got: {err}"
-    );
+    assert_eq!(val, Value::Int(1));
 }
 
 #[test]
@@ -8133,18 +8245,15 @@ fn eval_set_float_element_rejected_at_compile_time() {
 }
 
 #[test]
-fn eval_set_list_element_rejected_at_compile_time() {
-    let err = run_err(
+fn eval_set_list_element_allowed_when_elements_are_hashable() {
+    let val = run_ok(
         r#"fn main() -> Int {
             let xs = collections.List.new().push(1)
             let s = collections.Set.new().insert(xs)
-            s.len()
+            if (s.contains(xs)) { s.len() } else { 0 }
         }"#,
     );
-    assert!(
-        err.contains("cannot be used as a set element"),
-        "expected compile-time set element rejection, got: {err}"
-    );
+    assert_eq!(val, Value::Int(1));
 }
 
 #[test]
@@ -8390,18 +8499,20 @@ fn main() -> Int {
 // ── List.sort() element type compile-time rejection ─────────────
 
 #[test]
-fn eval_list_sort_unsortable_list_of_lists() {
-    let err = run_err(
+fn eval_list_sort_list_of_lists_is_allowed() {
+    let val = run_ok(
         "fn main() -> Int {
-            let xs = collections.List.new().push(collections.List.new())
+            let a: List<Int> = collections.List.new()
+            let b = collections.List.new().push(1)
+            let xs = collections.List.new().push(b).push(a)
             let sorted = xs.sort()
-            0
+            match (sorted.get(0)) {
+                Some(inner) => inner.len()
+                None => -1
+            }
         }",
     );
-    assert!(
-        err.contains("cannot be sorted"),
-        "expected compile-time sort rejection, got: {err}"
-    );
+    assert_eq!(val, Value::Int(0));
 }
 
 #[test]
@@ -8437,15 +8548,15 @@ fn eval_list_sort_unsortable_list_of_maps() {
 
 #[test]
 fn eval_list_sort_valid_types_no_rejection() {
-    // Guard test: sortable types (Int, Float, String, Char, Bool) should NOT be rejected
+    // Guard test: sortable builtin and structural value types should NOT be rejected.
     run_ok(
         r#"fn main() -> Bool {
             let ints = collections.List.new().push(3).push(1).push(2).sort()
-            let floats = collections.List.new().push(3.0).push(1.0).push(2.0).sort()
             let strings = collections.List.new().push("c").push("a").push("b").sort()
             let chars = collections.List.new().push('c').push('a').push('b').sort()
             let bools = collections.List.new().push(true).push(false).sort()
-            ints.len() == 3 && floats.len() == 3 && strings.len() == 3 && chars.len() == 3 && bools.len() == 2
+            let lists = collections.List.new().push(collections.List.new().push(1)).push(collections.List.new()).sort()
+            ints.len() == 3 && strings.len() == 3 && chars.len() == 3 && bools.len() == 2 && lists.len() == 2
         }"#,
     );
 }

--- a/crates/hir-def/src/body/lower.rs
+++ b/crates/hir-def/src/body/lower.rs
@@ -12,9 +12,9 @@ use kyokara_syntax::SyntaxKind;
 use kyokara_syntax::ast::AstNode;
 use kyokara_syntax::ast::nodes::{
     self, ArgList, AssignStmt, BinaryExpr, BlockExpr, BlockItem, CallExpr, ElseBranch, FieldExpr,
-    FnDef, IfExpr, IndexExpr, LambdaExpr, LiteralExpr, MatchExpr, NamedArg, OldExpr, PathExpr,
-    PipelineExpr, PropagateExpr, PropertyDef, RecordExpr, ReturnExpr, TypeExpr, UnaryExpr,
-    VarBinding,
+    FnDef, IfExpr, ImplDef, ImplMethodDef, IndexExpr, LambdaExpr, LiteralExpr, MatchExpr, NamedArg,
+    OldExpr, PathExpr, PipelineExpr, PropagateExpr, PropertyDef, RecordExpr, ReturnExpr,
+    TypeExpr, UnaryExpr, VarBinding,
 };
 use kyokara_syntax::ast::traits::{HasName, HasTypeParams};
 
@@ -56,6 +56,7 @@ pub fn lower_body(
         module_scope,
         current_scope: None,
         in_contract: false,
+        impl_self_ty: None,
     };
 
     // Create root scope
@@ -154,6 +155,125 @@ pub fn lower_body(
     }
 }
 
+/// Lower an impl method body from CST to HIR.
+pub fn lower_impl_method_body(
+    fn_def: &ImplMethodDef,
+    module_scope: &ModuleScope,
+    file_id: FileId,
+    interner: &mut Interner,
+) -> BodyLowerResult {
+    let mut ctx = BodyLowerCtx {
+        exprs: Arena::new(),
+        pats: Arena::new(),
+        scopes: ScopeTree::default(),
+        scope_slot_counts: ArenaMap::default(),
+        pat_scopes: Vec::new(),
+        expr_scopes: ArenaMap::default(),
+        expr_source_map: ArenaMap::default(),
+        pat_source_map: ArenaMap::default(),
+        local_binding_meta: ArenaMap::default(),
+        diagnostics: Vec::new(),
+        file_id,
+        interner,
+        module_scope,
+        current_scope: None,
+        in_contract: false,
+        impl_self_ty: None,
+    };
+
+    ctx.impl_self_ty = fn_def
+        .syntax()
+        .ancestors()
+        .find_map(ImplDef::cast)
+        .and_then(|impl_def| impl_def.self_type())
+        .map(|self_ty| ctx.lower_type_ref(&self_ty));
+
+    let root_scope = ctx.scopes.new_root();
+    ctx.current_scope = Some(root_scope);
+    let param_count = fn_def
+        .param_list()
+        .map(|pl| pl.params().count())
+        .unwrap_or(0);
+    ctx.scope_slot_counts.insert(root_scope, param_count);
+
+    if let Some(param_list) = fn_def.param_list() {
+        for (i, param) in param_list.params().enumerate() {
+            if let Some(tok) = param.name_token() {
+                let name = Name::new(ctx.interner, tok.text());
+                ctx.scopes.define(root_scope, name, ScopeDef::Param(i));
+            }
+        }
+    }
+
+    if let Some(tpl) = HasTypeParams::type_param_list(fn_def) {
+        for tp in tpl.type_params() {
+            if let Some(tok) = tp.name_token() {
+                let name = Name::new(ctx.interner, tok.text());
+                ctx.scopes.define(root_scope, name, ScopeDef::Param(0));
+            }
+        }
+    }
+
+    ctx.in_contract = true;
+    let requires = fn_def
+        .requires_clauses()
+        .filter_map(|rc| rc.expr().map(|e| ctx.lower_expr(&e)))
+        .collect::<Vec<_>>();
+    let ensures = fn_def
+        .ensures_clauses()
+        .filter_map(|ec| ec.expr())
+        .map(|e| {
+            ctx.push_scope();
+            let result_name = Name::new(ctx.interner, "result");
+            let result_pat = ctx.alloc_pat(pat::Pat::Bind { name: result_name });
+            ctx.pat_source_map
+                .insert(result_pat, e.syntax().text_range());
+            ctx.register_local_binding(
+                result_name,
+                result_pat,
+                e.syntax().text_range(),
+                LocalBindingOrigin::ContractResult,
+                false,
+            );
+            let idx = ctx.lower_expr(&e);
+            ctx.pop_scope();
+            idx
+        })
+        .collect::<Vec<_>>();
+    let invariant = fn_def
+        .invariant_clauses()
+        .filter_map(|ic| ic.expr().map(|e| ctx.lower_expr(&e)))
+        .collect::<Vec<_>>();
+    ctx.in_contract = false;
+
+    let root = if let Some(body) = fn_def.body() {
+        let range = body.syntax().text_range();
+        let idx = ctx.lower_block(&body);
+        ctx.expr_source_map.insert(idx, range);
+        idx
+    } else {
+        ctx.alloc_expr(Expr::Missing)
+    };
+
+    BodyLowerResult {
+        body: Body {
+            exprs: ctx.exprs,
+            pats: ctx.pats,
+            root,
+            requires,
+            ensures,
+            invariant,
+            scopes: ctx.scopes,
+            pat_scopes: ctx.pat_scopes,
+            expr_scopes: ctx.expr_scopes,
+            expr_source_map: ctx.expr_source_map,
+            pat_source_map: ctx.pat_source_map,
+            local_binding_meta: ctx.local_binding_meta,
+        },
+        diagnostics: ctx.diagnostics,
+    }
+}
+
 /// Lower a property body from CST to HIR.
 ///
 /// Similar to `lower_body` but for `PropertyDef` nodes: uses
@@ -181,6 +301,7 @@ pub fn lower_property_body(
         module_scope,
         current_scope: None,
         in_contract: false,
+        impl_self_ty: None,
     };
 
     // Create root scope.
@@ -263,6 +384,7 @@ struct BodyLowerCtx<'a> {
     module_scope: &'a ModuleScope,
     current_scope: Option<ScopeIdx>,
     in_contract: bool,
+    impl_self_ty: Option<TypeRef>,
 }
 
 impl BodyLowerCtx<'_> {
@@ -1283,6 +1405,12 @@ impl BodyLowerCtx<'_> {
                     .type_arg_list()
                     .map(|tal| tal.type_args().map(|a| self.lower_type_ref(&a)).collect())
                     .unwrap_or_default();
+                if path.is_single()
+                    && path.segments[0].resolve(self.interner) == "Self"
+                    && let Some(self_ty) = &self.impl_self_ty
+                {
+                    return self_ty.clone();
+                }
                 TypeRef::Path { path, args }
             }
             TypeExpr::FnType(ft) => {

--- a/crates/hir-def/src/builtins.rs
+++ b/crates/hir-def/src/builtins.rs
@@ -5,7 +5,10 @@
 //! hir `check_file` pipeline call [`register_builtin_types`] after
 //! item tree collection but before type-checking.
 
-use crate::item_tree::{FnItem, FnParam, ItemTree, TypeDefKind, TypeItem, TypeItemIdx, VariantDef};
+use crate::item_tree::{
+    FnItem, FnParam, ItemTree, TraitItem, TraitMethodItem, TraitRefItem, TypeDefKind, TypeItem,
+    TypeItemIdx, TypeParamDef, VariantDef,
+};
 use crate::name::Name;
 use crate::path::Path;
 use crate::resolver::{
@@ -80,7 +83,14 @@ fn register_core_type_item(
     let idx = tree.types.alloc(TypeItem {
         name: type_name,
         is_pub: false,
-        type_params,
+        type_params: type_params
+            .into_iter()
+            .map(|name| TypeParamDef {
+                name,
+                bounds: Vec::new(),
+            })
+            .collect(),
+        derives: Vec::new(),
         kind,
     });
 
@@ -94,6 +104,13 @@ fn register_core_type_item(
     );
 
     (idx, type_name)
+}
+
+fn path_type(interner: &mut Interner, name: &str) -> TypeRef {
+    TypeRef::Path {
+        path: Path::single(Name::new(interner, name)),
+        args: Vec::new(),
+    }
 }
 
 /// Inject `Option<T>`, `Result<T, E>`, `List<T>`, `MutableList<T>`, `MutableMap<K,V>`,
@@ -122,6 +139,115 @@ pub fn register_builtin_types(
     register_map(tree, scope, interner);
     register_set(tree, scope, interner);
     register_parse_error(tree, scope, interner);
+}
+
+pub fn register_builtin_traits(
+    tree: &mut ItemTree,
+    scope: &mut ModuleScope,
+    interner: &mut Interner,
+) {
+    let string_ty = path_type(interner, "String");
+    let int_ty = path_type(interner, "Int");
+    let bool_ty = path_type(interner, "Bool");
+
+    let eq_name = Name::new(interner, "Eq");
+    let ord_name = Name::new(interner, "Ord");
+    let hash_name = Name::new(interner, "Hash");
+    let show_name = Name::new(interner, "Show");
+
+    let traits = [
+        TraitItem {
+            name: eq_name,
+            is_pub: false,
+            type_params: Vec::new(),
+            supertraits: Vec::new(),
+            methods: vec![TraitMethodItem {
+                name: Name::new(interner, "eq"),
+                type_params: Vec::new(),
+                params: vec![
+                    FnParam {
+                        name: Name::new(interner, "self"),
+                        ty: path_type(interner, "Self"),
+                    },
+                    FnParam {
+                        name: Name::new(interner, "other"),
+                        ty: path_type(interner, "Self"),
+                    },
+                ],
+                ret_type: Some(bool_ty.clone()),
+                with_effects: Vec::new(),
+            }],
+        },
+        TraitItem {
+            name: ord_name,
+            is_pub: false,
+            type_params: Vec::new(),
+            supertraits: vec![TraitRefItem {
+                path: Path::single(eq_name),
+                args: Vec::new(),
+            }],
+            methods: vec![TraitMethodItem {
+                name: Name::new(interner, "compare"),
+                type_params: Vec::new(),
+                params: vec![
+                    FnParam {
+                        name: Name::new(interner, "self"),
+                        ty: path_type(interner, "Self"),
+                    },
+                    FnParam {
+                        name: Name::new(interner, "other"),
+                        ty: path_type(interner, "Self"),
+                    },
+                ],
+                ret_type: Some(int_ty.clone()),
+                with_effects: Vec::new(),
+            }],
+        },
+        TraitItem {
+            name: hash_name,
+            is_pub: false,
+            type_params: Vec::new(),
+            supertraits: vec![TraitRefItem {
+                path: Path::single(eq_name),
+                args: Vec::new(),
+            }],
+            methods: vec![TraitMethodItem {
+                name: Name::new(interner, "hash"),
+                type_params: Vec::new(),
+                params: vec![FnParam {
+                    name: Name::new(interner, "self"),
+                    ty: path_type(interner, "Self"),
+                }],
+                ret_type: Some(int_ty.clone()),
+                with_effects: Vec::new(),
+            }],
+        },
+        TraitItem {
+            name: show_name,
+            is_pub: false,
+            type_params: Vec::new(),
+            supertraits: Vec::new(),
+            methods: vec![TraitMethodItem {
+                name: Name::new(interner, "show"),
+                type_params: Vec::new(),
+                params: vec![FnParam {
+                    name: Name::new(interner, "self"),
+                    ty: path_type(interner, "Self"),
+                }],
+                ret_type: Some(string_ty),
+                with_effects: Vec::new(),
+            }],
+        },
+    ];
+
+    for trait_item in traits {
+        let name = trait_item.name;
+        if scope.traits.contains_key(&name) {
+            continue;
+        }
+        let idx = tree.traits.alloc(trait_item);
+        scope.traits.insert(name, idx);
+    }
 }
 
 /// `type Option<T> = Some(T) | None`
@@ -1275,7 +1401,13 @@ fn mk_intrinsic(
         FnItem {
             name,
             is_pub: false,
-            type_params,
+            type_params: type_params
+                .into_iter()
+                .map(|name| TypeParamDef {
+                    name,
+                    bounds: Vec::new(),
+                })
+                .collect(),
             params: fn_params,
             ret_type: Some(ret),
             with_effects: Vec::new(),

--- a/crates/hir-def/src/item_tree.rs
+++ b/crates/hir-def/src/item_tree.rs
@@ -16,6 +16,10 @@ use crate::type_ref::TypeRef;
 pub type FnItemIdx = Idx<FnItem>;
 /// Index into the type arena.
 pub type TypeItemIdx = Idx<TypeItem>;
+/// Index into the trait arena.
+pub type TraitItemIdx = Idx<TraitItem>;
+/// Index into the impl arena.
+pub type ImplItemIdx = Idx<ImplItem>;
 /// Index into the capability arena.
 pub type EffectItemIdx = Idx<EffectItem>;
 /// Index into the property arena.
@@ -30,6 +34,8 @@ pub struct ItemTree {
     pub imports: Vec<Import>,
     pub functions: Arena<FnItem>,
     pub types: Arena<TypeItem>,
+    pub traits: Arena<TraitItem>,
+    pub impls: Arena<ImplItem>,
     pub effects: Arena<EffectItem>,
     pub properties: Arena<PropertyItem>,
     pub lets: Arena<LetItem>,
@@ -48,7 +54,7 @@ pub struct Import {
 pub struct FnItem {
     pub name: Name,
     pub is_pub: bool,
-    pub type_params: Vec<Name>,
+    pub type_params: Vec<TypeParamDef>,
     pub params: Vec<FnParam>,
     pub ret_type: Option<TypeRef>,
     pub with_effects: Vec<TypeRef>,
@@ -72,8 +78,23 @@ pub struct FnParam {
 pub struct TypeItem {
     pub name: Name,
     pub is_pub: bool,
-    pub type_params: Vec<Name>,
+    pub type_params: Vec<TypeParamDef>,
+    pub derives: Vec<TraitRefItem>,
     pub kind: TypeDefKind,
+}
+
+/// A structured type parameter with explicit bounds.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TypeParamDef {
+    pub name: Name,
+    pub bounds: Vec<TraitRefItem>,
+}
+
+/// A trait reference in item signatures.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TraitRefItem {
+    pub path: Path,
+    pub args: Vec<TypeRef>,
 }
 
 /// The kind of type definition.
@@ -94,12 +115,41 @@ pub struct VariantDef {
     pub fields: Vec<TypeRef>,
 }
 
+/// A trait declaration.
+#[derive(Debug, Clone)]
+pub struct TraitItem {
+    pub name: Name,
+    pub is_pub: bool,
+    pub type_params: Vec<TypeParamDef>,
+    pub supertraits: Vec<TraitRefItem>,
+    pub methods: Vec<TraitMethodItem>,
+}
+
+/// A method signature declared inside a trait.
+#[derive(Debug, Clone)]
+pub struct TraitMethodItem {
+    pub name: Name,
+    pub type_params: Vec<TypeParamDef>,
+    pub params: Vec<FnParam>,
+    pub ret_type: Option<TypeRef>,
+    pub with_effects: Vec<TypeRef>,
+}
+
+/// An impl block.
+#[derive(Debug, Clone)]
+pub struct ImplItem {
+    pub type_params: Vec<TypeParamDef>,
+    pub trait_ref: TraitRefItem,
+    pub self_ty: TypeRef,
+    pub methods: Vec<FnItemIdx>,
+}
+
 /// A capability definition.
 #[derive(Debug, Clone)]
 pub struct EffectItem {
     pub name: Name,
     pub is_pub: bool,
-    pub type_params: Vec<Name>,
+    pub type_params: Vec<TypeParamDef>,
     pub functions: Vec<FnItemIdx>,
 }
 

--- a/crates/hir-def/src/item_tree/lower.rs
+++ b/crates/hir-def/src/item_tree/lower.rs
@@ -118,6 +118,8 @@ impl ItemTreeCtx<'_> {
                 self.lower_fn_def(&f, false);
             }
             Item::TypeDef(t) => self.lower_type_def(&t),
+            Item::TraitDef(t) => self.lower_trait_def(&t),
+            Item::ImplDef(i) => self.lower_impl_def(&i),
             Item::EffectDef(c) => self.lower_cap_def(&c),
             Item::PropertyDef(p) => self.lower_property_def(&p),
             Item::LetBinding(l) => self.lower_let_binding(&l),
@@ -287,10 +289,15 @@ impl ItemTreeCtx<'_> {
         };
 
         let is_pub = t.is_pub();
+        let derives = t
+            .derive_clause()
+            .map(|dc| dc.trait_refs().map(|tr| self.lower_trait_ref(&tr)).collect())
+            .unwrap_or_default();
         let idx = self.tree.types.alloc(TypeItem {
             name,
             is_pub,
             type_params,
+            derives,
             kind: kind.clone(),
         });
 
@@ -340,6 +347,183 @@ impl ItemTreeCtx<'_> {
                     );
                 }
             }
+        }
+    }
+
+    fn lower_trait_def(&mut self, t: &TraitDef) {
+        let name = self.name_of(t);
+        let is_pub = t.is_pub();
+        let type_params = self.collect_type_params(t);
+        let supertraits = t
+            .supertrait_list()
+            .map(|st| st.trait_refs().map(|tr| self.lower_trait_ref(&tr)).collect())
+            .unwrap_or_default();
+        let methods = t
+            .method_sigs()
+            .map(|m| self.lower_trait_method_sig(&m))
+            .collect();
+
+        let idx = self.tree.traits.alloc(TraitItem {
+            name,
+            is_pub,
+            type_params,
+            supertraits,
+            methods,
+        });
+
+        if let std::collections::hash_map::Entry::Vacant(e) = self.module_scope.traits.entry(name) {
+            e.insert(idx);
+        } else {
+            let span = self.node_span(t.syntax());
+            self.diagnostics.push(
+                Diagnostic::error(
+                    format!("duplicate trait `{}`", name.resolve(self.interner)),
+                    span,
+                )
+                .with_kind(DiagnosticKind::DuplicateDefinition),
+            );
+        }
+    }
+
+    fn lower_trait_method_sig(&mut self, m: &TraitMethodSig) -> TraitMethodItem {
+        let name = self.name_of(m);
+        let type_params = self.collect_type_params(m);
+        let params = m
+            .param_list()
+            .map(|pl| {
+                pl.params()
+                    .map(|p| {
+                        let pname = p
+                            .name_token()
+                            .map(|tok| Name::new(self.interner, tok.text()))
+                            .unwrap_or_else(|| Name::new(self.interner, "_"));
+                        let ty = p
+                            .type_expr()
+                            .map(|te| self.lower_type_ref(&te))
+                            .unwrap_or_else(|| self.self_type_ref());
+                        FnParam { name: pname, ty }
+                    })
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default();
+        let ret_type = m
+            .return_type()
+            .and_then(|rt| rt.type_expr())
+            .map(|t| self.lower_type_ref(&t));
+
+        TraitMethodItem {
+            name,
+            type_params,
+            params,
+            ret_type,
+            with_effects: Vec::new(),
+        }
+    }
+
+    fn lower_impl_def(&mut self, i: &ImplDef) {
+        let type_params = self.collect_type_params(i);
+        let trait_ref = i
+            .trait_ref()
+            .map(|tr| self.lower_trait_ref(&tr))
+            .unwrap_or(TraitRefItem {
+                path: Path { segments: vec![] },
+                args: vec![],
+            });
+        let self_ty = i.self_type().map(|ty| self.lower_type_ref(&ty)).unwrap_or(TypeRef::Error);
+        let methods = i
+            .methods()
+            .map(|m| self.lower_impl_method_def(&m, &self_ty))
+            .collect::<Vec<_>>();
+
+        self.tree.impls.alloc(ImplItem {
+            type_params,
+            trait_ref,
+            self_ty,
+            methods,
+        });
+    }
+
+    fn lower_impl_method_def(&mut self, m: &ImplMethodDef, impl_self_ty: &TypeRef) -> FnItemIdx {
+        let name = self.name_of(m);
+        let type_params = self.collect_type_params(m);
+        let params = m
+            .param_list()
+            .map(|pl| {
+                pl.params()
+                    .map(|p| {
+                        let pname = p
+                            .name_token()
+                            .map(|tok| Name::new(self.interner, tok.text()))
+                            .unwrap_or_else(|| Name::new(self.interner, "_"));
+                        let ty = p.type_expr().map_or_else(
+                            || impl_self_ty.clone(),
+                            |te| {
+                                let ty = self.lower_type_ref(&te);
+                                self.substitute_self_type_ref(ty, impl_self_ty)
+                            },
+                        );
+                        FnParam { name: pname, ty }
+                    })
+                    .collect::<Vec<_>>()
+            })
+            .unwrap_or_default();
+        let ret_type = m
+            .return_type()
+            .and_then(|rt| rt.type_expr())
+            .map(|t| {
+                let ty = self.lower_type_ref(&t);
+                self.substitute_self_type_ref(ty, impl_self_ty)
+            });
+        self.tree.functions.alloc(FnItem {
+            name,
+            is_pub: false,
+            type_params,
+            params,
+            ret_type,
+            with_effects: Vec::new(),
+            has_body: m.body().is_some(),
+            source_range: Some(m.syntax().text_range()),
+            receiver_type: None,
+        })
+    }
+
+    fn substitute_self_type_ref(&mut self, ty: TypeRef, impl_self_ty: &TypeRef) -> TypeRef {
+        match ty {
+            TypeRef::Path { path, args } => {
+                if path.is_single() && path.segments[0].resolve(self.interner) == "Self" {
+                    return impl_self_ty.clone();
+                }
+                TypeRef::Path {
+                    path,
+                    args: args
+                        .into_iter()
+                        .map(|arg| self.substitute_self_type_ref(arg, impl_self_ty))
+                        .collect(),
+                }
+            }
+            TypeRef::Fn { params, ret } => TypeRef::Fn {
+                params: params
+                    .into_iter()
+                    .map(|param| self.substitute_self_type_ref(param, impl_self_ty))
+                    .collect(),
+                ret: Box::new(self.substitute_self_type_ref(*ret, impl_self_ty)),
+            },
+            TypeRef::Record { fields } => TypeRef::Record {
+                fields: fields
+                    .into_iter()
+                    .map(|(name, ty)| (name, self.substitute_self_type_ref(ty, impl_self_ty)))
+                    .collect(),
+            },
+            TypeRef::Refined {
+                name,
+                base,
+                predicate,
+            } => TypeRef::Refined {
+                name,
+                base: Box::new(self.substitute_self_type_ref(*base, impl_self_ty)),
+                predicate,
+            },
+            TypeRef::Error => TypeRef::Error,
         }
     }
 
@@ -783,7 +967,7 @@ impl ItemTreeCtx<'_> {
             .unwrap_or_else(|| Name::new(self.interner, "_"))
     }
 
-    fn collect_type_params(&mut self, node: &impl HasTypeParams) -> Vec<Name> {
+    fn collect_type_params(&mut self, node: &impl HasTypeParams) -> Vec<TypeParamDef> {
         node.type_param_list()
             .map(|tpl| {
                 let mut seen = std::collections::HashSet::new();
@@ -801,11 +985,36 @@ impl ItemTreeCtx<'_> {
                                 .with_kind(DiagnosticKind::DuplicateDefinition),
                             );
                         }
-                        Some(Name::new(self.interner, text))
+                        Some(TypeParamDef {
+                            name: Name::new(self.interner, text),
+                            bounds: tp
+                                .bound_list()
+                                .map(|bl| bl.trait_refs().map(|tr| self.lower_trait_ref(&tr)).collect())
+                                .unwrap_or_default(),
+                        })
                     })
                     .collect()
             })
             .unwrap_or_default()
+    }
+
+    fn lower_trait_ref(&mut self, trait_ref: &kyokara_syntax::ast::nodes::TraitRef) -> TraitRefItem {
+        let path = trait_ref
+            .path()
+            .map(|p| self.lower_path(&p))
+            .unwrap_or_else(|| Path { segments: vec![] });
+        let args = trait_ref
+            .type_arg_list()
+            .map(|tal| tal.type_args().map(|a| self.lower_type_ref(&a)).collect())
+            .unwrap_or_default();
+        TraitRefItem { path, args }
+    }
+
+    fn self_type_ref(&mut self) -> TypeRef {
+        TypeRef::Path {
+            path: Path::single(Name::new(self.interner, "Self")),
+            args: Vec::new(),
+        }
     }
 
     fn register_fn(&mut self, name: Name, idx: FnItemIdx, syntax: &kyokara_syntax::SyntaxNode) {

--- a/crates/hir-def/src/resolver.rs
+++ b/crates/hir-def/src/resolver.rs
@@ -7,7 +7,7 @@ use kyokara_stdx::{FxHashMap, FxHashSet};
 
 use kyokara_intern::Interner;
 
-use crate::item_tree::{EffectItemIdx, FnItemIdx, TypeItemIdx};
+use crate::item_tree::{EffectItemIdx, FnItemIdx, TraitItemIdx, TypeItemIdx};
 use crate::name::Name;
 use crate::scope::{ScopeDef, ScopeIdx, ScopeTree};
 
@@ -188,6 +188,8 @@ pub struct ModuleScope {
     pub types: FxHashMap<Name, TypeItemIdx>,
     /// Capability definitions.
     pub effects: FxHashMap<Name, EffectItemIdx>,
+    /// Trait definitions.
+    pub traits: FxHashMap<Name, TraitItemIdx>,
     /// ADT constructors: `VariantName -> (type_idx, variant_idx)`.
     pub constructors: FxHashMap<Name, (TypeItemIdx, usize)>,
     /// Imported names: `local_name -> import_index`.
@@ -243,6 +245,8 @@ pub enum ResolvedName {
     Type(TypeItemIdx),
     /// A capability at module level.
     Effect(EffectItemIdx),
+    /// A trait at module level.
+    Trait(TraitItemIdx),
     /// An ADT constructor.
     Constructor {
         type_idx: TypeItemIdx,
@@ -287,6 +291,9 @@ impl<'a> Resolver<'a> {
         }
         if let Some(&idx) = self.module.effects.get(&name) {
             return Some(ResolvedName::Effect(idx));
+        }
+        if let Some(&idx) = self.module.traits.get(&name) {
+            return Some(ResolvedName::Trait(idx));
         }
 
         // 2b. Synthetic modules (io, math, fs) — only if explicitly imported.
@@ -338,6 +345,9 @@ impl<'a> Resolver<'a> {
         }
         if let Some(&idx) = self.module.effects.get(&name) {
             return Some(ResolvedName::Effect(idx));
+        }
+        if let Some(&idx) = self.module.traits.get(&name) {
+            return Some(ResolvedName::Trait(idx));
         }
 
         // 2b. Synthetic modules — only if explicitly imported.

--- a/crates/hir-def/tests/lower_tests.rs
+++ b/crates/hir-def/tests/lower_tests.rs
@@ -94,6 +94,57 @@ fn collect_module_and_imports() {
 }
 
 #[test]
+fn collect_trait_impl_and_derive_items() {
+    let root = parse_source(
+        "pub trait Show { fn show(self) -> String }\n\
+         type Point derive(Eq, Hash) = { x: Int, y: Int }\n\
+         impl Show for Point { fn show(self) -> String { \"p\" } }",
+    );
+    let sf = SourceFile::cast(root).unwrap();
+    let mut interner = Interner::new();
+    let result = collect_item_tree(&sf, file_id(), &mut interner);
+
+    assert_eq!(result.tree.traits.len(), 1);
+    assert_eq!(result.tree.impls.len(), 1);
+    let trait_item = &result.tree.traits[result.tree.traits.iter().next().unwrap().0];
+    assert_eq!(trait_item.name.resolve(&interner), "Show");
+    assert_eq!(trait_item.methods.len(), 1);
+
+    let type_item = &result.tree.types[result.tree.types.iter().next().unwrap().0];
+    assert_eq!(type_item.derives.len(), 2);
+
+    let impl_item = &result.tree.impls[result.tree.impls.iter().next().unwrap().0];
+    assert_eq!(impl_item.methods.len(), 1);
+    assert!(result.diagnostics.is_empty(), "unexpected diagnostics: {:?}", result.diagnostics);
+}
+
+#[test]
+fn collect_bounded_type_params_on_fn_and_impl() {
+    let root = parse_source(
+        "pub trait Show { fn show(self) -> String }\n\
+         fn less<T: Show>(x: T) -> Bool { true }\n\
+         impl<T: Show> Show for Box<T> { fn show(self) -> String { Show.show(self.value) } }",
+    );
+    let sf = SourceFile::cast(root).unwrap();
+    let mut interner = Interner::new();
+    let result = collect_item_tree(&sf, file_id(), &mut interner);
+
+    let less = result
+        .tree
+        .functions
+        .iter()
+        .find(|(_, f)| f.name.resolve(&interner) == "less")
+        .map(|(_, f)| f)
+        .expect("less fn");
+    assert_eq!(less.type_params.len(), 1);
+    assert_eq!(less.type_params[0].bounds.len(), 1);
+
+    let impl_item = &result.tree.impls[result.tree.impls.iter().next().unwrap().0];
+    assert_eq!(impl_item.type_params.len(), 1);
+    assert_eq!(impl_item.type_params[0].bounds.len(), 1);
+}
+
+#[test]
 fn duplicate_fn_diagnostic() {
     let root = parse_source("fn foo() { 1 }\nfn foo() { 2 }");
     let sf = SourceFile::cast(root).unwrap();

--- a/crates/hir-ty/src/diagnostics.rs
+++ b/crates/hir-ty/src/diagnostics.rs
@@ -82,6 +82,8 @@ pub enum TyDiagnosticData {
     ImmutableAssignment { name: String },
     /// Mutable local captured by nested function or lambda.
     CapturedMutableLocal { name: String },
+    /// Type does not implement a required trait.
+    MissingTraitImpl { trait_name: String, ty: Ty },
 }
 
 impl TyDiagnosticData {
@@ -124,6 +126,7 @@ impl TyDiagnosticData {
             TyDiagnosticData::InvalidAssignmentTarget => "E0033",
             TyDiagnosticData::ImmutableAssignment { .. } => "E0034",
             TyDiagnosticData::CapturedMutableLocal { .. } => "E0035",
+            TyDiagnosticData::MissingTraitImpl { .. } => "E0037",
         }
     }
 
@@ -288,6 +291,9 @@ impl TyDiagnosticData {
                 format!(
                     "mutable locals cannot be captured by nested functions or lambdas (`{name}`)"
                 )
+            }
+            TyDiagnosticData::MissingTraitImpl { trait_name, ty } => {
+                format!("type `{}` does not implement trait `{trait_name}`", dt(ty))
             }
         };
         Diagnostic::error(message, span)

--- a/crates/hir-ty/src/infer.rs
+++ b/crates/hir-ty/src/infer.rs
@@ -92,6 +92,8 @@ pub(crate) struct InferenceCtx<'a> {
     pub caller_effects: EffectSet,
     /// Type parameters in scope for the current function.
     pub type_params: Vec<(Name, Ty)>,
+    /// Declared trait bounds for each type parameter in scope.
+    pub type_param_bounds: Vec<(Name, Vec<Name>)>,
     /// Parameter types by index (for ScopeDef::Param(i) lookups).
     pub param_types: Vec<Ty>,
     /// Parameter names by index (for locals collection in holes).
@@ -117,6 +119,186 @@ impl<'a> InferenceCtx<'a> {
 
     fn traversal_seq_compat_enabled(&self) -> bool {
         self.traversal_seq_compat_depth > 0
+    }
+
+    pub(crate) fn ty_satisfies_trait_name(&mut self, ty: &Ty, trait_name: Name) -> bool {
+        let ty = self.table.resolve_deep(ty);
+        match ty {
+            Ty::Error | Ty::Never => true,
+            Ty::Var(var) => self
+                .type_params
+                .iter()
+                .find(|(_, param_ty)| matches!(self.table.resolve(param_ty), Ty::Var(v) if v == var))
+                .and_then(|(name, _)| self.type_param_bounds.iter().find(|(n, _)| n == name))
+                .is_some_and(|(_, bounds)| {
+                    bounds
+                        .iter()
+                        .copied()
+                        .any(|bound| self.trait_name_satisfies(bound, trait_name))
+                }),
+            Ty::Int => self.builtin_trait_name_satisfied("Int", trait_name),
+            Ty::String => self.builtin_trait_name_satisfied("String", trait_name),
+            Ty::Char => self.builtin_trait_name_satisfied("Char", trait_name),
+            Ty::Bool => self.builtin_trait_name_satisfied("Bool", trait_name),
+            Ty::Unit => self.builtin_trait_name_satisfied("Unit", trait_name),
+            Ty::Float => self.builtin_trait_name_satisfied("Float", trait_name),
+            Ty::Adt { def, args } => {
+                let type_name = self.item_tree.types[def].name.resolve(self.interner);
+                if self.module_scope.core_types.kind_for_idx(def).is_some() {
+                    self.builtin_trait_name_satisfied(type_name, trait_name)
+                } else {
+                    self.user_adt_satisfies_trait(def, &args, trait_name)
+                }
+            }
+            Ty::Record { fields } => match trait_name.resolve(self.interner) {
+                "Eq" | "Ord" | "Hash" | "Show" => fields
+                    .iter()
+                    .all(|(_, field_ty)| self.ty_satisfies_trait_name(field_ty, trait_name)),
+                _ => false,
+            },
+            Ty::Fn { .. } => false,
+        }
+    }
+
+    pub(crate) fn ty_satisfies_trait(&mut self, ty: &Ty, trait_text: &str) -> bool {
+        self.module_scope
+            .traits
+            .keys()
+            .find(|name| name.resolve(self.interner) == trait_text)
+            .copied()
+            .is_some_and(|trait_name| self.ty_satisfies_trait_name(ty, trait_name))
+    }
+
+    fn builtin_trait_name_satisfied(&self, type_name: &str, trait_name: Name) -> bool {
+        let trait_name = trait_name.resolve(self.interner);
+        match trait_name {
+            "Eq" => matches!(
+                type_name,
+                "Int"
+                    | "String"
+                    | "Char"
+                    | "Bool"
+                    | "Unit"
+                    | "Option"
+                    | "Result"
+                    | "List"
+                    | "MutableList"
+                    | "Deque"
+                    | "BitSet"
+                    | "MutableBitSet"
+                    | "Map"
+                    | "MutableMap"
+                    | "Set"
+                    | "MutableSet"
+                    | "ParseError"
+            ),
+            "Ord" => matches!(
+                type_name,
+                "Int"
+                    | "String"
+                    | "Char"
+                    | "Bool"
+                    | "Unit"
+                    | "Option"
+                    | "Result"
+                    | "List"
+                    | "MutableList"
+                    | "Deque"
+                    | "ParseError"
+            ),
+            "Hash" => matches!(
+                type_name,
+                "Int"
+                    | "String"
+                    | "Char"
+                    | "Bool"
+                    | "Unit"
+                    | "Option"
+                    | "Result"
+                    | "List"
+                    | "Deque"
+                    | "BitSet"
+                    | "Map"
+                    | "Set"
+                    | "ParseError"
+            ),
+            "Show" => !matches!(type_name, "<fn>"),
+            _ => false,
+        }
+    }
+
+    fn trait_name_satisfies(&self, bound_name: Name, target_name: Name) -> bool {
+        if bound_name == target_name {
+            return true;
+        }
+        let Some(&bound_idx) = self.module_scope.traits.get(&bound_name) else {
+            return false;
+        };
+        self.item_tree.traits[bound_idx]
+            .supertraits
+            .iter()
+            .filter_map(|trait_ref| trait_ref.path.last())
+            .any(|super_name| self.trait_name_satisfies(super_name, target_name))
+    }
+
+    fn user_adt_satisfies_trait(
+        &mut self,
+        def: TypeItemIdx,
+        args: &[Ty],
+        trait_name: Name,
+    ) -> bool {
+        let type_item = &self.item_tree.types[def];
+
+        if type_item.derives.iter().any(|derived| {
+            derived
+                .path
+                .last()
+                .is_some_and(|derived_name| self.trait_name_satisfies(derived_name, trait_name))
+        }) {
+            let mut env_type_params = self.type_params.clone();
+            for (param, arg) in type_item.type_params.iter().zip(args.iter()) {
+                env_type_params.push((param.name, arg.clone()));
+            }
+            let env = TyResolutionEnv {
+                item_tree: self.item_tree,
+                module_scope: self.module_scope,
+                interner: self.interner,
+                type_params: env_type_params,
+                resolving_aliases: vec![],
+            };
+
+            let field_type_refs: Vec<TypeRef> = match &type_item.kind {
+                TypeDefKind::Alias(TypeRef::Record { fields }) => {
+                    fields.iter().map(|(_, ty)| ty.clone()).collect()
+                }
+                TypeDefKind::Record { fields } => fields.iter().map(|(_, ty)| ty.clone()).collect(),
+                TypeDefKind::Adt { variants } => variants
+                    .iter()
+                    .flat_map(|variant| variant.fields.iter().cloned())
+                    .collect(),
+                TypeDefKind::Alias(_) => Vec::new(),
+            };
+
+            for field_ty_ref in field_type_refs {
+                let field_ty = env.resolve_type_ref(&field_ty_ref, &mut self.table);
+                if !self.ty_satisfies_trait_name(&field_ty, trait_name) {
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        self.item_tree.impls.iter().any(|(_, impl_item)| {
+            impl_item
+                .trait_ref
+                .path
+                .last()
+                .is_some_and(|impl_trait| impl_trait == trait_name)
+                && matches!(
+                    &impl_item.self_ty,
+                    TypeRef::Path { path, .. } if path.last().is_some_and(|n| n == type_item.name)
+                )
+        })
     }
 
     pub(crate) fn with_loop_scope<R>(&mut self, f: impl FnOnce(&mut Self) -> R) -> R {
@@ -148,13 +330,32 @@ impl<'a> InferenceCtx<'a> {
     /// Unify two types, emitting a type mismatch diagnostic on failure.
     /// Returns the unified type (or Error on failure).
     pub(crate) fn unify_or_err(&mut self, expected: &Ty, actual: &Ty) -> Ty {
+        let mut exact_table = self.table.clone();
+        if exact_table.unify(expected, actual)
+            || (self.traversal_seq_compat_enabled()
+                && self.unify_seq_traversal_compat_with_table(
+                    &mut exact_table,
+                    expected,
+                    actual,
+                ))
+        {
+            self.table = exact_table;
+            return self.table.resolve_deep(expected);
+        }
+
         let expected_norm = self.normalize_record_aliases_for_unify(expected);
         let actual_norm = self.normalize_record_aliases_for_unify(actual);
 
-        if self.table.unify(&expected_norm, &actual_norm)
+        let mut normalized_table = self.table.clone();
+        if normalized_table.unify(&expected_norm, &actual_norm)
             || (self.traversal_seq_compat_enabled()
-                && self.unify_seq_traversal_compat(&expected_norm, &actual_norm))
+                && self.unify_seq_traversal_compat_with_table(
+                    &mut normalized_table,
+                    &expected_norm,
+                    &actual_norm,
+                ))
         {
+            self.table = normalized_table;
             self.table.resolve_deep(&expected_norm)
         } else {
             let expected = self.table.resolve_deep(&expected_norm);
@@ -169,9 +370,14 @@ impl<'a> InferenceCtx<'a> {
         }
     }
 
-    fn unify_seq_traversal_compat(&mut self, expected: &Ty, actual: &Ty) -> bool {
-        let expected = self.table.resolve(expected);
-        let actual = self.table.resolve(actual);
+    fn unify_seq_traversal_compat_with_table(
+        &self,
+        table: &mut UnificationTable,
+        expected: &Ty,
+        actual: &Ty,
+    ) -> bool {
+        let expected = table.resolve(expected);
+        let actual = table.resolve(actual);
         let (
             Ty::Adt {
                 def: expected_def,
@@ -201,7 +407,7 @@ impl<'a> InferenceCtx<'a> {
             return false;
         }
 
-        self.table.unify(&expected_args[0], &actual_args[0])
+        table.unify(&expected_args[0], &actual_args[0])
     }
 
     /// Expand record aliases into structural records for unification-only paths.
@@ -256,12 +462,12 @@ impl<'a> InferenceCtx<'a> {
         };
 
         let mut type_params = self.type_params.clone();
-        for (i, &param_name) in type_item.type_params.iter().enumerate() {
+        for (i, param) in type_item.type_params.iter().enumerate() {
             let arg = args
                 .get(i)
                 .cloned()
                 .unwrap_or_else(|| self.table.fresh_var());
-            type_params.push((param_name, arg));
+            type_params.push((param.name, arg));
         }
 
         let env = TyResolutionEnv {
@@ -317,9 +523,18 @@ pub fn infer_body(
 
     // Build type parameter bindings (fresh vars for each).
     let mut type_params: Vec<(Name, Ty)> = Vec::new();
-    for &name in &fn_item.type_params {
+    let mut type_param_bounds: Vec<(Name, Vec<Name>)> = Vec::new();
+    for param in &fn_item.type_params {
         let var = table.fresh_var();
-        type_params.push((name, var));
+        type_params.push((param.name, var));
+        type_param_bounds.push((
+            param.name,
+            param
+                .bounds
+                .iter()
+                .filter_map(|bound| bound.path.last())
+                .collect(),
+        ));
     }
 
     let env = TyResolutionEnv {
@@ -394,6 +609,7 @@ pub fn infer_body(
         ret_ty,
         caller_effects,
         type_params,
+        type_param_bounds,
         param_types: param_tys.clone(),
         param_names: fn_item.params.iter().map(|p| p.name).collect(),
         local_types: ArenaMap::default(),

--- a/crates/hir-ty/src/infer/expr.rs
+++ b/crates/hir-ty/src/infer/expr.rs
@@ -239,6 +239,7 @@ impl<'a> InferenceCtx<'a> {
                 }
             }
             Some(ResolvedName::Effect(_)) => self.non_value_name_in_expr("capability", name),
+            Some(ResolvedName::Trait(_)) => Ty::Error,
             Some(ResolvedName::Import(_)) => self.non_value_name_in_expr("import", name),
 
             // Module names (io, math, fs) are not values — they're only valid
@@ -758,7 +759,7 @@ impl<'a> InferenceCtx<'a> {
                     let mut tp_map: Vec<(kyokara_hir_def::name::Name, Ty)> =
                         self.type_params.clone();
                     for (param_name, arg) in type_item.type_params.iter().zip(args.iter()) {
-                        tp_map.push((*param_name, arg.clone()));
+                        tp_map.push((param_name.name, arg.clone()));
                     }
                     let env = TyResolutionEnv {
                         item_tree: self.item_tree,
@@ -1107,9 +1108,9 @@ impl<'a> InferenceCtx<'a> {
                     // Build substitution env.
                     let mut tp = self.type_params.clone();
                     let mut args = Vec::new();
-                    for &tparam in &type_item.type_params {
+                    for tparam in &type_item.type_params {
                         let var = self.table.fresh_var();
-                        tp.push((tparam, var.clone()));
+                        tp.push((tparam.name, var.clone()));
                         args.push(var);
                     }
                     let env = TyResolutionEnv {
@@ -1535,6 +1536,81 @@ impl<'a> InferenceCtx<'a> {
             return Some(Ty::Error);
         }
 
+        // Trait-qualified call: Ord.compare(a, b), Show.show(x)
+        if let Some(&trait_idx) = self.module_scope.traits.get(&name) {
+            let trait_item = &self.item_tree.traits[trait_idx];
+            if let Some(method) = trait_item.methods.iter().find(|method| method.name == field) {
+                let Some(first_arg) = args.first() else {
+                    self.push_diag(TyDiagnosticData::ArgCountMismatch {
+                        expected: method.params.len(),
+                        actual: 0,
+                    });
+                    return Some(Ty::Error);
+                };
+
+                let first_expr = match first_arg {
+                    CallArg::Positional(expr) | CallArg::Named { value: expr, .. } => *expr,
+                };
+                let recv_ty = self.infer_expr(first_expr, &Expectation::None);
+                let recv_ty = self.table.resolve_deep(&recv_ty);
+                if !self.ty_satisfies_trait_name(&recv_ty, name) {
+                    self.push_diag(TyDiagnosticData::MissingTraitImpl {
+                        trait_name: name.resolve(self.interner).to_owned(),
+                        ty: recv_ty,
+                    });
+                    for arg in &args[1..] {
+                        match arg {
+                            CallArg::Positional(expr) | CallArg::Named { value: expr, .. } => {
+                                self.infer_expr(*expr, &Expectation::None);
+                            }
+                        }
+                    }
+                    return Some(Ty::Error);
+                }
+
+                let env = Self::make_env(
+                    self.item_tree,
+                    self.module_scope,
+                    self.interner,
+                    &self.type_params,
+                );
+                let param_tys = method
+                    .params
+                    .iter()
+                    .map(|param| self.resolve_trait_method_type(&param.ty, &recv_ty, &env))
+                    .collect::<Vec<_>>();
+                let param_names = method.params.iter().map(|param| param.name).collect::<Vec<_>>();
+                let has_arg_errors =
+                    self.infer_call_args_with_binding(args, &param_tys, Some(&param_names));
+                if has_arg_errors {
+                    return Some(Ty::Error);
+                }
+                let ret = method
+                    .ret_type
+                    .as_ref()
+                    .map(|ret| self.resolve_trait_method_type(ret, &recv_ty, &env))
+                    .unwrap_or(Ty::Unit);
+                return Some(ret);
+            }
+
+            self.push_diag(TyDiagnosticData::NoSuchMethod {
+                method: format!(
+                    "{}.{}",
+                    name.resolve(self.interner),
+                    field.resolve(self.interner)
+                ),
+                ty: Ty::Error,
+            });
+            for arg in args {
+                match arg {
+                    CallArg::Positional(expr) | CallArg::Named { value: expr, .. } => {
+                        self.infer_expr(*expr, &Expectation::None);
+                    }
+                }
+            }
+            return Some(Ty::Error);
+        }
+
         // Type-owned static call: bare `Type.method()` if registered.
         if let Some(&type_idx) = self.module_scope.types.get(&name) {
             let owner_key = self.static_owner_key_for_type_idx(type_idx);
@@ -1561,6 +1637,25 @@ impl<'a> InferenceCtx<'a> {
         }
 
         None
+    }
+
+    fn resolve_trait_method_type(
+        &mut self,
+        ty_ref: &kyokara_hir_def::type_ref::TypeRef,
+        recv_ty: &Ty,
+        env: &TyResolutionEnv<'_>,
+    ) -> Ty {
+        match ty_ref {
+            kyokara_hir_def::type_ref::TypeRef::Path { path, args } if path.is_single() && args.is_empty() => {
+                let seg = path.segments[0];
+                if seg.resolve(self.interner) == "Self" {
+                    recv_ty.clone()
+                } else {
+                    env.resolve_type_ref(ty_ref, &mut self.table)
+                }
+            }
+            _ => env.resolve_type_ref(ty_ref, &mut self.table),
+        }
     }
 
     /// Infer a call to a resolved FnItemIdx (no receiver). Used for module-qualified
@@ -1878,7 +1973,9 @@ impl<'a> InferenceCtx<'a> {
                 )
             {
                 let key_ty = self.table.resolve_deep(&args[0]);
-                if !key_ty.is_hashable_collection_key() {
+                if !(self.ty_satisfies_trait(&key_ty, "Hash")
+                    && self.ty_satisfies_trait(&key_ty, "Eq"))
+                {
                     self.push_diag(TyDiagnosticData::InvalidMapKey { ty: key_ty });
                 }
             }
@@ -1898,7 +1995,9 @@ impl<'a> InferenceCtx<'a> {
                 )
             {
                 let elem_ty = self.table.resolve_deep(&args[0]);
-                if !elem_ty.is_hashable_collection_key() {
+                if !(self.ty_satisfies_trait(&elem_ty, "Hash")
+                    && self.ty_satisfies_trait(&elem_ty, "Eq"))
+                {
                     self.push_diag(TyDiagnosticData::InvalidSetElement { ty: elem_ty });
                 }
             }
@@ -1911,7 +2010,9 @@ impl<'a> InferenceCtx<'a> {
                 && method_str == "seq_frequencies"
             {
                 let elem_ty = self.table.resolve_deep(&args[0]);
-                if !elem_ty.is_hashable_collection_key() {
+                if !(self.ty_satisfies_trait(&elem_ty, "Hash")
+                    && self.ty_satisfies_trait(&elem_ty, "Eq"))
+                {
                     self.push_diag(TyDiagnosticData::InvalidMapKey { ty: elem_ty });
                 }
             }
@@ -1923,7 +2024,7 @@ impl<'a> InferenceCtx<'a> {
                 && matches!(method_str, "list_sort" | "list_binary_search")
             {
                 let elem_ty = self.table.resolve_deep(&args[0]);
-                if !elem_ty.is_sortable() {
+                if !self.ty_satisfies_trait(&elem_ty, "Ord") {
                     self.push_diag(TyDiagnosticData::UnsortableElement { ty: elem_ty });
                 }
             }
@@ -1953,7 +2054,9 @@ impl<'a> InferenceCtx<'a> {
                         .unwrap_or_else(|| self.table.fresh_var());
                     self.infer_expr(index, &Expectation::Has(key_ty.clone()));
                     let resolved_key = self.table.resolve_deep(&key_ty);
-                    if !resolved_key.is_hashable_collection_key() {
+                    if !(self.ty_satisfies_trait(&resolved_key, "Hash")
+                        && self.ty_satisfies_trait(&resolved_key, "Eq"))
+                    {
                         self.push_diag(TyDiagnosticData::InvalidMapKey { ty: resolved_key });
                     }
                     args.get(1).cloned().unwrap_or(Ty::Error)
@@ -1965,7 +2068,9 @@ impl<'a> InferenceCtx<'a> {
                         .unwrap_or_else(|| self.table.fresh_var());
                     self.infer_expr(index, &Expectation::Has(key_ty.clone()));
                     let resolved_key = self.table.resolve_deep(&key_ty);
-                    if !resolved_key.is_hashable_collection_key() {
+                    if !(self.ty_satisfies_trait(&resolved_key, "Hash")
+                        && self.ty_satisfies_trait(&resolved_key, "Eq"))
+                    {
                         self.push_diag(TyDiagnosticData::InvalidMapKey { ty: resolved_key });
                     }
                     args.get(1).cloned().unwrap_or(Ty::Error)

--- a/crates/hir-ty/src/infer/pat.rs
+++ b/crates/hir-ty/src/infer/pat.rs
@@ -196,7 +196,7 @@ impl<'a> InferenceCtx<'a> {
                             let mut tp_map: Vec<(kyokara_hir_def::name::Name, Ty)> =
                                 self.type_params.clone();
                             for (param_name, arg) in type_item.type_params.iter().zip(args.iter()) {
-                                tp_map.push((*param_name, arg.clone()));
+                                tp_map.push((param_name.name, arg.clone()));
                             }
                             let env = TyResolutionEnv {
                                 item_tree: self.item_tree,

--- a/crates/hir-ty/src/lib.rs
+++ b/crates/hir-ty/src/lib.rs
@@ -20,7 +20,7 @@ pub mod unify;
 
 use kyokara_diagnostics::Diagnostic;
 use kyokara_hir_def::body::Body;
-use kyokara_hir_def::body::lower::{lower_body, lower_property_body};
+use kyokara_hir_def::body::lower::{lower_body, lower_impl_method_body, lower_property_body};
 use kyokara_hir_def::item_tree::{FnItemIdx, ItemTree};
 use kyokara_hir_def::resolver::ModuleScope;
 use kyokara_hir_def::type_ref::TypeRef;
@@ -29,7 +29,7 @@ use kyokara_span::{FileId, Span, TextRange};
 use kyokara_stdx::FxHashMap;
 use kyokara_syntax::SyntaxNode;
 use kyokara_syntax::ast::AstNode;
-use kyokara_syntax::ast::nodes::{FnDef, PropertyDef};
+use kyokara_syntax::ast::nodes::{FnDef, ImplMethodDef, PropertyDef};
 use kyokara_syntax::ast::traits::HasName;
 
 use kyokara_hir_def::name::Name;
@@ -40,12 +40,18 @@ use crate::infer::InferenceResult;
 struct BodyLookupIndex {
     fn_by_range: FxHashMap<TextRange, FnDef>,
     fn_by_name: FxHashMap<String, FnDef>,
+    impl_by_range: FxHashMap<TextRange, ImplMethodDef>,
     prop_by_range: FxHashMap<TextRange, PropertyDef>,
 }
 
-fn build_body_lookup_index(fn_defs: &[FnDef], prop_defs: &[PropertyDef]) -> BodyLookupIndex {
+fn build_body_lookup_index(
+    fn_defs: &[FnDef],
+    impl_defs: &[ImplMethodDef],
+    prop_defs: &[PropertyDef],
+) -> BodyLookupIndex {
     let mut fn_by_range = FxHashMap::default();
     let mut fn_by_name = FxHashMap::default();
+    let mut impl_by_range = FxHashMap::default();
     let mut prop_by_range = FxHashMap::default();
 
     for fd in fn_defs {
@@ -58,6 +64,11 @@ fn build_body_lookup_index(fn_defs: &[FnDef], prop_defs: &[PropertyDef]) -> Body
         }
     }
 
+    for fd in impl_defs {
+        let range = fd.syntax().text_range();
+        impl_by_range.insert(range, fd.clone());
+    }
+
     for pd in prop_defs {
         let range = pd.syntax().text_range();
         prop_by_range.insert(range, pd.clone());
@@ -66,6 +77,7 @@ fn build_body_lookup_index(fn_defs: &[FnDef], prop_defs: &[PropertyDef]) -> Body
     BodyLookupIndex {
         fn_by_range,
         fn_by_name,
+        impl_by_range,
         prop_by_range,
     }
 }
@@ -87,6 +99,13 @@ fn lookup_property_def(
     source_range: Option<TextRange>,
 ) -> Option<&PropertyDef> {
     source_range.and_then(|range| index.prop_by_range.get(&range))
+}
+
+fn lookup_impl_method_def(
+    index: &BodyLookupIndex,
+    source_range: Option<TextRange>,
+) -> Option<&ImplMethodDef> {
+    source_range.and_then(|range| index.impl_by_range.get(&range))
 }
 
 /// Result of type-checking an entire module.
@@ -126,8 +145,10 @@ pub fn check_module(
     let mut fn_calls = Vec::new();
 
     let fn_defs: Vec<FnDef> = root.descendants().filter_map(FnDef::cast).collect();
+    let impl_method_defs: Vec<ImplMethodDef> =
+        root.descendants().filter_map(ImplMethodDef::cast).collect();
     let prop_defs: Vec<PropertyDef> = root.descendants().filter_map(PropertyDef::cast).collect();
-    let body_lookup = build_body_lookup_index(&fn_defs, &prop_defs);
+    let body_lookup = build_body_lookup_index(&fn_defs, &impl_method_defs, &prop_defs);
 
     for (fn_idx, fn_item) in item_tree.functions.iter() {
         if !fn_item.has_body {
@@ -151,6 +172,8 @@ pub fn check_module(
             lower_body(fd, module_scope, file_id, interner)
         } else if let Some(pd) = lookup_property_def(&body_lookup, fn_item.source_range) {
             lower_property_body(pd, module_scope, file_id, interner)
+        } else if let Some(imd) = lookup_impl_method_def(&body_lookup, fn_item.source_range) {
+            lower_impl_method_body(imd, module_scope, file_id, interner)
         } else {
             continue;
         };
@@ -309,7 +332,7 @@ mod tests {
         let fn_defs: Vec<FnDef> = root.descendants().filter_map(FnDef::cast).collect();
         let prop_defs: Vec<PropertyDef> =
             root.descendants().filter_map(PropertyDef::cast).collect();
-        let index = build_body_lookup_index(&fn_defs, &prop_defs);
+        let index = build_body_lookup_index(&fn_defs, &[], &prop_defs);
 
         let beta = &fn_defs[1];
         let beta_range = beta.syntax().text_range();
@@ -332,7 +355,7 @@ mod tests {
         let fn_defs: Vec<FnDef> = root.descendants().filter_map(FnDef::cast).collect();
         let prop_defs: Vec<PropertyDef> =
             root.descendants().filter_map(PropertyDef::cast).collect();
-        let index = build_body_lookup_index(&fn_defs, &prop_defs);
+        let index = build_body_lookup_index(&fn_defs, &[], &prop_defs);
 
         let by_name =
             lookup_fn_def(&index, None, "helper").expect("name fallback should resolve helper");

--- a/crates/hir-ty/src/resolve.rs
+++ b/crates/hir-ty/src/resolve.rs
@@ -131,7 +131,7 @@ impl<'a> TyResolutionEnv<'a> {
     /// the given explicit arguments or fresh inference variables.
     fn with_type_args(
         &self,
-        param_names: &[Name],
+        param_names: &[kyokara_hir_def::item_tree::TypeParamDef],
         args: &[TypeRef],
         table: &mut UnificationTable,
     ) -> TyResolutionEnv<'a> {
@@ -142,7 +142,7 @@ impl<'a> TyResolutionEnv<'a> {
             } else {
                 table.fresh_var()
             };
-            type_params.push((*name, ty));
+            type_params.push((name.name, ty));
         }
         TyResolutionEnv {
             item_tree: self.item_tree,
@@ -171,9 +171,9 @@ pub(crate) fn instantiate_fn_sig(
         type_params: env.type_params.clone(),
         resolving_aliases: vec![],
     };
-    for &name in &fn_item.type_params {
+    for param in &fn_item.type_params {
         let var = table.fresh_var();
-        inner_env.type_params.push((name, var));
+        inner_env.type_params.push((param.name, var));
     }
 
     let param_tys: Vec<Ty> = fn_item
@@ -209,9 +209,9 @@ pub(crate) fn instantiate_constructor(
         resolving_aliases: vec![],
     };
     let mut args = Vec::new();
-    for &name in &type_item.type_params {
+    for param in &type_item.type_params {
         let var = table.fresh_var();
-        inner_env.type_params.push((name, var.clone()));
+        inner_env.type_params.push((param.name, var.clone()));
         args.push(var);
     }
 
@@ -255,6 +255,7 @@ mod tests {
             name,
             is_pub: false,
             type_params: vec![],
+            derives: vec![],
             kind: TypeDefKind::Adt {
                 variants: vec![VariantDef {
                     name: variant_name,
@@ -267,6 +268,8 @@ mod tests {
             imports: vec![],
             functions: Arena::new(),
             types,
+            traits: Arena::new(),
+            impls: Arena::new(),
             effects: Arena::new(),
             properties: Arena::new(),
             lets: Arena::new(),

--- a/crates/hir-ty/src/unify.rs
+++ b/crates/hir-ty/src/unify.rs
@@ -6,6 +6,7 @@
 use crate::ty::{Ty, TyVarId};
 
 /// Union-find based unification table.
+#[derive(Clone)]
 pub struct UnificationTable {
     /// Each slot is either `None` (unbound variable) or `Some(ty)` (bound).
     vars: Vec<Option<Ty>>,

--- a/crates/hir-ty/tests/infer_tests.rs
+++ b/crates/hir-ty/tests/infer_tests.rs
@@ -5,7 +5,8 @@ use std::borrow::Cow;
 
 use kyokara_hir_def::builtins::{
     activate_synthetic_imports, register_builtin_intrinsics, register_builtin_methods,
-    register_builtin_types, register_static_methods, register_synthetic_modules,
+    register_builtin_traits, register_builtin_types, register_static_methods,
+    register_synthetic_modules,
 };
 use kyokara_hir_def::item_tree::lower::collect_item_tree;
 use kyokara_hir_ty::ty::Ty;
@@ -44,6 +45,11 @@ fn check(src: &str) -> (TypeCheckResult, Interner) {
     let mut interner = Interner::new();
     let mut item_result = collect_item_tree(&sf, file_id(), &mut interner);
     register_builtin_types(
+        &mut item_result.tree,
+        &mut item_result.module_scope,
+        &mut interner,
+    );
+    register_builtin_traits(
         &mut item_result.tree,
         &mut item_result.module_scope,
         &mut interner,
@@ -215,6 +221,34 @@ fn infer_binary_equality_rejects_non_comparable_types() {
     check_err(
         "fn foo() -> Bool { collections.List.new() == collections.List.new() }",
         "equality operator requires",
+    );
+}
+
+#[test]
+fn infer_builtin_trait_qualified_call() {
+    check_ok("fn foo() -> Int { Ord.compare(1, 2) }");
+}
+
+#[test]
+fn infer_generic_trait_bound_body() {
+    check_ok("fn less<T: Ord>(a: T, b: T) -> Bool { Ord.compare(a, b) < 0 }");
+}
+
+#[test]
+fn infer_user_impl_trait_call() {
+    check_ok(
+        "trait Show { fn show(self) -> String }\n\
+         type Point = { x: Int }\n\
+         impl Show for Point { fn show(self) -> String { \"p\" } }\n\
+         fn foo(p: Point) -> String { Show.show(p) }",
+    );
+}
+
+#[test]
+fn infer_derived_trait_call() {
+    check_ok(
+        "type Point derive(Eq) = { x: Int, y: Int }\n\
+         fn foo(a: Point, b: Point) -> Bool { Eq.eq(a, b) }",
     );
 }
 
@@ -1638,6 +1672,13 @@ fn infer_seq_frequencies_happy_paths() {
             let counts = (0..<4).frequencies()
             counts.get(0).unwrap_or(0) + counts.len()
         }"#,
+        r#"type P derive(Eq, Hash) = { x: Int }
+
+        fn main() -> Int {
+            let p: P = P { x: 1 }
+            let counts = collections.List.new().push(p).push(p).frequencies()
+            counts.len()
+        }"#,
     ];
 
     for src in cases {
@@ -1651,16 +1692,31 @@ fn infer_seq_frequencies_happy_paths() {
 }
 
 #[test]
-fn err_seq_frequencies_non_hashable_element_reports_e0024() {
-    let cases = [
-        r#"fn main() -> Int {
-            let counts = collections.List.new().push(collections.List.new().push(1)).frequencies()
-            counts.len()
-        }"#,
-        r#"type P = { x: Int }
+fn infer_list_sort_accepts_derived_ord_elements() {
+    check_ok(
+        r#"type P derive(Ord) = { x: Int }
 
         fn main() -> Int {
-            let counts = collections.List.new().push(P { x: 1 }).frequencies()
+            let a: P = P { x: 2 }
+            let b: P = P { x: 1 }
+            let xs = collections.List.new().push(a).push(b).sort()
+            xs.len()
+        }"#,
+    );
+}
+
+#[test]
+fn err_seq_frequencies_non_hashable_element_reports_e0024() {
+    let cases = [
+        r#"import collections
+
+        fn main() -> Int {
+            let inner = collections.MutableList.from_list(collections.List.new().push(1))
+            let counts = collections.List.new().push(inner).frequencies()
+            counts.len()
+        }"#,
+        r#"fn main() -> Int {
+            let counts = collections.List.new().push(fn(x: Int) => x).frequencies()
             counts.len()
         }"#,
     ];
@@ -1676,6 +1732,29 @@ fn err_seq_frequencies_non_hashable_element_reports_e0024() {
             result.diagnostics
         );
     }
+}
+
+#[test]
+fn err_seq_frequencies_named_record_without_derive_reports_e0024() {
+    let (result, _) = check(
+        r#"import collections
+
+        type P = { x: Int }
+
+        fn main() -> Int {
+            let counts = collections.List.new().push(P { x: 1 }).frequencies()
+            counts.len()
+        }"#,
+    );
+
+    assert!(
+        result
+            .diagnostics
+            .iter()
+            .any(|d| d.message.contains("map key")),
+        "expected E0024 map key diagnostic, got: {:?}",
+        result.diagnostics
+    );
 }
 
 #[test]

--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -10,6 +10,7 @@ pub use kyokara_hir_def::body::Body;
 pub use kyokara_hir_def::builtins::activate_synthetic_imports;
 pub use kyokara_hir_def::builtins::register_builtin_intrinsics;
 pub use kyokara_hir_def::builtins::register_builtin_methods;
+pub use kyokara_hir_def::builtins::register_builtin_traits;
 pub use kyokara_hir_def::builtins::register_builtin_types;
 pub use kyokara_hir_def::builtins::register_static_methods;
 pub use kyokara_hir_def::builtins::register_synthetic_modules;
@@ -143,6 +144,11 @@ pub fn check_file(source: &str) -> CheckResult {
         &mut item_result.module_scope,
         &mut interner,
     );
+    register_builtin_traits(
+        &mut item_result.tree,
+        &mut item_result.module_scope,
+        &mut interner,
+    );
     register_builtin_intrinsics(
         &mut item_result.tree,
         &mut item_result.module_scope,
@@ -241,6 +247,11 @@ pub fn check_project(entry_file: &std::path::Path) -> ProjectCheckResult {
         let mut item_result = collect_item_tree(&sf, file_id, &mut interner);
 
         register_builtin_types(
+            &mut item_result.tree,
+            &mut item_result.module_scope,
+            &mut interner,
+        );
+        register_builtin_traits(
             &mut item_result.tree,
             &mut item_result.module_scope,
             &mut interner,

--- a/crates/lsp/src/hover.rs
+++ b/crates/lsp/src/hover.rs
@@ -118,7 +118,7 @@ fn render_type_signature(item: &TypeItem, interner: &Interner, _tree: &ItemTree)
         let ps: Vec<&str> = item
             .type_params
             .iter()
-            .map(|p| p.resolve(interner))
+            .map(|p| p.name.resolve(interner))
             .collect();
         format!("<{}>", ps.join(", "))
     };

--- a/crates/parser/src/grammar/items.rs
+++ b/crates/parser/src/grammar/items.rs
@@ -10,7 +10,8 @@ use crate::token_set::TokenSet;
 
 /// Tokens that can start an item — used for error recovery.
 pub(super) const ITEM_RECOVERY: TokenSet = TokenSet::new(&[
-    ModuleKw, ImportKw, TypeKw, FnKw, CapKw, EffectKw, PropertyKw, LetKw, VarKw, PubKw,
+    ModuleKw, ImportKw, TypeKw, TraitKw, ImplKw, FnKw, CapKw, EffectKw, PropertyKw, LetKw, VarKw,
+    PubKw,
 ]);
 const CLAUSE_EXPR_RECOVERY: TokenSet = TokenSet::new(&[
     LBrace,
@@ -26,7 +27,7 @@ const CLAUSE_EXPR_RECOVERY: TokenSet = TokenSet::new(&[
 ]);
 
 pub(super) fn item(p: &mut Parser<'_>) -> Option<CompletedMarker> {
-    // `pub` can precede fn, type, or effect.
+    // `pub` can precede fn, type, trait, or effect.
     let is_pub = p.at(PubKw);
     let start = if is_pub {
         p.current_after_pub()
@@ -36,6 +37,14 @@ pub(super) fn item(p: &mut Parser<'_>) -> Option<CompletedMarker> {
 
     let cm = match start {
         TypeKw => type_def(p, is_pub),
+        TraitKw => trait_def(p, is_pub),
+        ImplKw => {
+            if is_pub {
+                p.error_recover("expected item", ITEM_RECOVERY);
+                return None;
+            }
+            impl_def(p)
+        }
         FnKw => fn_def(p, is_pub, false),
         CapKw => {
             p.error("`cap` is no longer supported; use `effect`");
@@ -106,7 +115,7 @@ fn import_alias(p: &mut Parser<'_>) {
 
 // ── Type Definition ─────────────────────────────────────────────────
 
-/// `pub? type Ident TypeParamList? '=' TypeBody`
+/// `pub? type Ident TypeParamList? DeriveClause? '=' TypeBody`
 fn type_def(p: &mut Parser<'_>, is_pub: bool) -> CompletedMarker {
     let m = p.open();
     if is_pub {
@@ -117,9 +126,29 @@ fn type_def(p: &mut Parser<'_>, is_pub: bool) -> CompletedMarker {
     if p.at(Lt) {
         type_param_list(p);
     }
+    if p.at(DeriveKw) {
+        derive_clause(p);
+    }
     p.expect(Eq);
     type_body(p);
     m.complete(p, TypeDef)
+}
+
+fn derive_clause(p: &mut Parser<'_>) {
+    let m = p.open();
+    p.bump(); // derive
+    p.expect(LParen);
+    if !p.at(RParen) {
+        trait_ref(p);
+        while p.eat(Comma) {
+            if p.at(RParen) {
+                break;
+            }
+            trait_ref(p);
+        }
+    }
+    p.expect(RParen);
+    m.complete(p, DeriveClause);
 }
 
 /// `VariantList / TypeExpr`
@@ -226,6 +255,107 @@ pub(super) fn fn_def(p: &mut Parser<'_>, is_pub: bool, allow_bodyless: bool) -> 
         p.error("expected function body");
     }
     m.complete(p, FnDef)
+}
+
+// ── Trait & Impl Definitions ───────────────────────────────────────
+
+/// `pub? trait Ident TypeParamList? (':' TraitRef ('+' TraitRef)*)? '{' TraitMethodSig* '}'`
+fn trait_def(p: &mut Parser<'_>, is_pub: bool) -> CompletedMarker {
+    let m = p.open();
+    if is_pub {
+        p.bump(); // pub
+    }
+    p.bump(); // trait
+    p.expect_identifier(IdentifierRole::TypeName);
+    if p.at(Lt) {
+        type_param_list(p);
+    }
+    if p.at(Colon) {
+        supertrait_list(p);
+    }
+    p.expect(LBrace);
+    while !p.at(RBrace) && !p.at_eof() {
+        if p.at(FnKw) {
+            trait_method_sig(p);
+        } else {
+            p.error_recover("expected trait method signature", TokenSet::new(&[FnKw, RBrace]));
+        }
+    }
+    p.expect(RBrace);
+    m.complete(p, TraitDef)
+}
+
+fn supertrait_list(p: &mut Parser<'_>) {
+    let m = p.open();
+    p.bump(); // :
+    trait_ref(p);
+    while p.eat(Plus) {
+        trait_ref(p);
+    }
+    m.complete(p, SupertraitList);
+}
+
+fn trait_method_sig(p: &mut Parser<'_>) {
+    let m = p.open();
+    p.bump(); // fn
+    p.expect_identifier(IdentifierRole::MethodName);
+    if p.at(Lt) {
+        type_param_list(p);
+    }
+    param_list(p);
+    if p.at(Arrow) {
+        return_type(p);
+    }
+    fn_contract(p);
+    if p.at(LBrace) {
+        let err = p.open();
+        p.error("trait method declarations cannot have a body");
+        super::expressions::block_expr(p);
+        err.complete(p, ErrorNode);
+    }
+    m.complete(p, TraitMethodSig);
+}
+
+/// `impl TypeParamList? TraitRef for TypeExpr '{' ImplMethodDef* '}'`
+fn impl_def(p: &mut Parser<'_>) -> CompletedMarker {
+    let m = p.open();
+    p.bump(); // impl
+    if p.at(Lt) {
+        type_param_list(p);
+    }
+    trait_ref(p);
+    p.expect(ForKw);
+    super::types::type_expr(p);
+    p.expect(LBrace);
+    while !p.at(RBrace) && !p.at_eof() {
+        if p.at(FnKw) {
+            impl_method_def(p);
+        } else {
+            p.error_recover("expected impl method definition", TokenSet::new(&[FnKw, RBrace]));
+        }
+    }
+    p.expect(RBrace);
+    m.complete(p, ImplDef)
+}
+
+fn impl_method_def(p: &mut Parser<'_>) {
+    let m = p.open();
+    p.bump(); // fn
+    p.expect_identifier(IdentifierRole::MethodName);
+    if p.at(Lt) {
+        type_param_list(p);
+    }
+    param_list(p);
+    if p.at(Arrow) {
+        return_type(p);
+    }
+    fn_contract(p);
+    if p.at(LBrace) {
+        super::expressions::block_expr(p);
+    } else {
+        p.error("expected function body");
+    }
+    m.complete(p, ImplMethodDef);
 }
 
 fn param_list(p: &mut Parser<'_>) {
@@ -560,5 +690,27 @@ pub(super) fn type_param_list(p: &mut Parser<'_>) {
 fn type_param(p: &mut Parser<'_>) {
     let m = p.open();
     p.expect_identifier(IdentifierRole::TypeParameterName);
+    if p.at(Colon) {
+        type_param_bound_list(p);
+    }
     m.complete(p, TypeParam);
+}
+
+fn type_param_bound_list(p: &mut Parser<'_>) {
+    let m = p.open();
+    p.bump(); // :
+    trait_ref(p);
+    while p.eat(Plus) {
+        trait_ref(p);
+    }
+    m.complete(p, TypeParamBoundList);
+}
+
+fn trait_ref(p: &mut Parser<'_>) {
+    let m = p.open();
+    super::parse_path(p);
+    if p.at(Lt) {
+        super::types::type_arg_list(p);
+    }
+    m.complete(p, TraitRef);
 }

--- a/crates/parser/src/syntax_kind.rs
+++ b/crates/parser/src/syntax_kind.rs
@@ -50,6 +50,12 @@ pub enum SyntaxKind {
     AsKw,
     /// `type`
     TypeKw,
+    /// `trait`
+    TraitKw,
+    /// `impl`
+    ImplKw,
+    /// `derive`
+    DeriveKw,
     /// `fn`
     FnKw,
     /// `let`
@@ -200,6 +206,10 @@ pub enum SyntaxKind {
     // Items
     /// `type Foo = …`
     TypeDef,
+    /// `trait Show { ... }`
+    TraitDef,
+    /// `impl Show for Point { ... }`
+    ImplDef,
     /// `fn foo(…) -> … { … }`
     FnDef,
     /// `effect Foo`
@@ -210,6 +220,16 @@ pub enum SyntaxKind {
     LetBinding,
     /// `var x = …`
     VarBinding,
+    /// `derive(Eq, Hash)`
+    DeriveClause,
+    /// `Ord`, `Hash<K>`
+    TraitRef,
+    /// `: Eq + Ord`
+    SupertraitList,
+    /// `fn compare(self, other: Self) -> Int`
+    TraitMethodSig,
+    /// `fn show(self) -> String { ... }`
+    ImplMethodDef,
 
     // Type-def sub-nodes
     /// `{ field: Type, … }`
@@ -248,6 +268,8 @@ pub enum SyntaxKind {
     TypeParamList,
     /// `T`
     TypeParam,
+    /// `: Eq + Hash`
+    TypeParamBoundList,
     /// `<Int, String>`
     TypeArgList,
 
@@ -373,6 +395,9 @@ impl SyntaxKind {
                 | Self::ImportKw
                 | Self::AsKw
                 | Self::TypeKw
+                | Self::TraitKw
+                | Self::ImplKw
+                | Self::DeriveKw
                 | Self::FnKw
                 | Self::LetKw
                 | Self::VarKw
@@ -409,6 +434,9 @@ impl SyntaxKind {
             Self::ImportKw => Some("import"),
             Self::AsKw => Some("as"),
             Self::TypeKw => Some("type"),
+            Self::TraitKw => Some("trait"),
+            Self::ImplKw => Some("impl"),
+            Self::DeriveKw => Some("derive"),
             Self::FnKw => Some("fn"),
             Self::LetKw => Some("let"),
             Self::VarKw => Some("var"),
@@ -510,6 +538,9 @@ impl SyntaxKind {
             "import" => Some(Self::ImportKw),
             "as" => Some(Self::AsKw),
             "type" => Some(Self::TypeKw),
+            "trait" => Some(Self::TraitKw),
+            "impl" => Some(Self::ImplKw),
+            "derive" => Some(Self::DeriveKw),
             "fn" => Some(Self::FnKw),
             "let" => Some(Self::LetKw),
             "var" => Some(Self::VarKw),
@@ -551,6 +582,9 @@ mod tests {
             SyntaxKind::ImportKw,
             SyntaxKind::AsKw,
             SyntaxKind::TypeKw,
+            SyntaxKind::TraitKw,
+            SyntaxKind::ImplKw,
+            SyntaxKind::DeriveKw,
             SyntaxKind::FnKw,
             SyntaxKind::LetKw,
             SyntaxKind::VarKw,

--- a/crates/parser/tests/parser_tests.rs
+++ b/crates/parser/tests/parser_tests.rs
@@ -211,6 +211,60 @@ fn type_with_generics() {
 }
 
 #[test]
+fn type_with_derive_clause() {
+    // type Point derive(Eq, Hash) = { x: Int, y: Int }
+    let (events, errors) = parse_tokens(&[
+        TypeKw, Ident, DeriveKw, LParen, Ident, Comma, Ident, RParen, Eq, LBrace, Ident, Colon,
+        Ident, Comma, Ident, Colon, Ident, RBrace,
+    ]);
+    assert!(has_no_errors(&errors));
+    assert!(has_node(&events, TypeDef));
+    assert!(has_node(&events, DeriveClause));
+    assert_eq!(count_start_nodes(&events, TraitRef), 2);
+}
+
+#[test]
+fn trait_def_with_supertraits() {
+    // pub trait Ord: Eq + Show { fn compare(self, other: Self) -> Int }
+    let (events, errors) = parse_tokens(&[
+        PubKw, TraitKw, Ident, Colon, Ident, Plus, Ident, LBrace, FnKw, Ident, LParen, Ident,
+        Comma, Ident, Colon, Ident, RParen, Arrow, Ident, RBrace,
+    ]);
+    assert!(has_no_errors(&errors), "unexpected errors: {errors:?}");
+    assert!(has_node(&events, TraitDef));
+    assert!(has_node(&events, SupertraitList));
+    assert!(has_node(&events, TraitMethodSig));
+    assert_eq!(count_start_nodes(&events, TraitRef), 2);
+}
+
+#[test]
+fn impl_def_is_parsed() {
+    // impl Show for Point { fn show(self) -> String { "" } }
+    let (events, errors) = parse_tokens(&[
+        ImplKw, Ident, ForKw, Ident, LBrace, FnKw, Ident, LParen, Ident, RParen, Arrow, Ident,
+        LBrace, StringLiteral, RBrace, RBrace,
+    ]);
+    assert!(has_no_errors(&errors), "unexpected errors: {errors:?}");
+    assert!(has_node(&events, ImplDef));
+    assert!(has_node(&events, TraitRef));
+    assert!(has_node(&events, ImplMethodDef));
+}
+
+#[test]
+fn bounded_type_params_are_parsed() {
+    // fn less<T: Ord + Show>(a: T) -> Bool { true }
+    let (events, errors) = parse_tokens(&[
+        FnKw, Ident, Lt, Ident, Colon, Ident, Plus, Ident, Gt, LParen, Ident, Colon, Ident,
+        RParen, Arrow, Ident, LBrace, TrueKw, RBrace,
+    ]);
+    assert!(has_no_errors(&errors), "unexpected errors: {errors:?}");
+    assert!(has_node(&events, FnDef));
+    assert!(has_node(&events, TypeParamList));
+    assert!(has_node(&events, TypeParamBoundList));
+    assert_eq!(count_start_nodes(&events, TraitRef), 2);
+}
+
+#[test]
 fn nested_type_args_accept_gtgt_token() {
     // fn f(xs: List<List<Int>>) -> Int { 0 }
     let (events, errors) = parse_tokens(&[

--- a/crates/pbt/src/runner.rs
+++ b/crates/pbt/src/runner.rs
@@ -6,7 +6,8 @@ use kyokara_eval::intrinsics::Args;
 use kyokara_hir::ModulePath;
 use kyokara_hir::{
     activate_synthetic_imports, check_module, check_project, collect_item_tree,
-    register_builtin_intrinsics, register_builtin_methods, register_builtin_types,
+    register_builtin_intrinsics, register_builtin_methods, register_builtin_traits,
+    register_builtin_types,
     register_static_methods, register_synthetic_modules,
 };
 use kyokara_hir_def::item_tree::FnItemIdx;
@@ -94,6 +95,11 @@ pub fn run_tests(source: &str, config: &TestConfig) -> Result<TestReport, String
 
     // 4. Register builtins.
     register_builtin_types(
+        &mut item_result.tree,
+        &mut item_result.module_scope,
+        &mut interner,
+    );
+    register_builtin_traits(
         &mut item_result.tree,
         &mut item_result.module_scope,
         &mut interner,

--- a/crates/syntax/src/ast/nodes.rs
+++ b/crates/syntax/src/ast/nodes.rs
@@ -61,6 +61,8 @@ impl SourceFile {
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum Item {
     TypeDef(TypeDef),
+    TraitDef(TraitDef),
+    ImplDef(ImplDef),
     FnDef(FnDef),
     EffectDef(EffectDef),
     PropertyDef(PropertyDef),
@@ -71,6 +73,8 @@ impl Item {
     pub fn cast(node: SyntaxNode) -> Option<Self> {
         match node.kind() {
             SyntaxKind::TypeDef => TypeDef::cast(node).map(Item::TypeDef),
+            SyntaxKind::TraitDef => TraitDef::cast(node).map(Item::TraitDef),
+            SyntaxKind::ImplDef => ImplDef::cast(node).map(Item::ImplDef),
             SyntaxKind::FnDef => FnDef::cast(node).map(Item::FnDef),
             SyntaxKind::EffectDef => EffectDef::cast(node).map(Item::EffectDef),
             SyntaxKind::PropertyDef => PropertyDef::cast(node).map(Item::PropertyDef),
@@ -154,6 +158,10 @@ impl HasTypeParams for TypeDef {}
 impl HasVisibility for TypeDef {}
 
 impl TypeDef {
+    pub fn derive_clause(&self) -> Option<DeriveClause> {
+        support::child(&self.syntax)
+    }
+
     /// The type body — either a variant list, record field list, or a type expression.
     pub fn variant_list(&self) -> Option<VariantList> {
         support::child(&self.syntax)
@@ -167,6 +175,40 @@ impl TypeDef {
     /// If the body is a record field list.
     pub fn record_field_list(&self) -> Option<RecordFieldList> {
         support::child(&self.syntax)
+    }
+}
+
+define_ast_node!(TraitDef, TraitDef);
+
+impl HasName for TraitDef {}
+impl HasTypeParams for TraitDef {}
+impl HasVisibility for TraitDef {}
+
+impl TraitDef {
+    pub fn supertrait_list(&self) -> Option<SupertraitList> {
+        support::child(&self.syntax)
+    }
+
+    pub fn method_sigs(&self) -> impl Iterator<Item = TraitMethodSig> + '_ {
+        support::children(&self.syntax)
+    }
+}
+
+define_ast_node!(ImplDef, ImplDef);
+
+impl HasTypeParams for ImplDef {}
+
+impl ImplDef {
+    pub fn trait_ref(&self) -> Option<TraitRef> {
+        support::child(&self.syntax)
+    }
+
+    pub fn self_type(&self) -> Option<TypeExpr> {
+        self.syntax.children().find_map(TypeExpr::cast)
+    }
+
+    pub fn methods(&self) -> impl Iterator<Item = ImplMethodDef> + '_ {
+        support::children(&self.syntax)
     }
 }
 
@@ -447,6 +489,88 @@ impl InvariantClause {
 
 // ── Generics ───────────────────────────────────────────────────────
 
+define_ast_node!(DeriveClause, DeriveClause);
+
+impl DeriveClause {
+    pub fn trait_refs(&self) -> impl Iterator<Item = TraitRef> + '_ {
+        support::children(&self.syntax)
+    }
+}
+
+define_ast_node!(TraitRef, TraitRef);
+
+impl TraitRef {
+    pub fn path(&self) -> Option<Path> {
+        support::child(&self.syntax)
+    }
+
+    pub fn type_arg_list(&self) -> Option<TypeArgList> {
+        support::child(&self.syntax)
+    }
+}
+
+define_ast_node!(SupertraitList, SupertraitList);
+
+impl SupertraitList {
+    pub fn trait_refs(&self) -> impl Iterator<Item = TraitRef> + '_ {
+        support::children(&self.syntax)
+    }
+}
+
+define_ast_node!(TraitMethodSig, TraitMethodSig);
+
+impl HasName for TraitMethodSig {}
+impl HasTypeParams for TraitMethodSig {}
+
+impl TraitMethodSig {
+    pub fn param_list(&self) -> Option<ParamList> {
+        support::child(&self.syntax)
+    }
+
+    pub fn return_type(&self) -> Option<ReturnType> {
+        support::child(&self.syntax)
+    }
+}
+
+define_ast_node!(ImplMethodDef, ImplMethodDef);
+
+impl HasName for ImplMethodDef {}
+impl HasTypeParams for ImplMethodDef {}
+
+impl ImplMethodDef {
+    pub fn param_list(&self) -> Option<ParamList> {
+        support::child(&self.syntax)
+    }
+
+    pub fn return_type(&self) -> Option<ReturnType> {
+        support::child(&self.syntax)
+    }
+
+    pub fn body(&self) -> Option<BlockExpr> {
+        support::child(&self.syntax)
+    }
+
+    pub fn with_clause(&self) -> Option<WithClause> {
+        support::child(&self.syntax)
+    }
+
+    pub fn contract_section(&self) -> Option<ContractSection> {
+        support::child(&self.syntax)
+    }
+
+    pub fn requires_clauses(&self) -> impl Iterator<Item = RequiresClause> + '_ {
+        ChildNodeIter::from_parent(self.contract_section().map(|c| c.syntax))
+    }
+
+    pub fn ensures_clauses(&self) -> impl Iterator<Item = EnsuresClause> + '_ {
+        ChildNodeIter::from_parent(self.contract_section().map(|c| c.syntax))
+    }
+
+    pub fn invariant_clauses(&self) -> impl Iterator<Item = InvariantClause> + '_ {
+        ChildNodeIter::from_parent(self.contract_section().map(|c| c.syntax))
+    }
+}
+
 define_ast_node!(TypeParamList, TypeParamList);
 
 impl TypeParamList {
@@ -458,6 +582,20 @@ impl TypeParamList {
 define_ast_node!(TypeParam, TypeParam);
 
 impl HasName for TypeParam {}
+
+impl TypeParam {
+    pub fn bound_list(&self) -> Option<TypeParamBoundList> {
+        support::child(&self.syntax)
+    }
+}
+
+define_ast_node!(TypeParamBoundList, TypeParamBoundList);
+
+impl TypeParamBoundList {
+    pub fn trait_refs(&self) -> impl Iterator<Item = TraitRef> + '_ {
+        support::children(&self.syntax)
+    }
+}
 
 define_ast_node!(TypeArgList, TypeArgList);
 

--- a/crates/syntax/tests/integration_tests.rs
+++ b/crates/syntax/tests/integration_tests.rs
@@ -2,7 +2,8 @@
 #![allow(clippy::unwrap_used)]
 
 use kyokara_syntax::ast::AstNode;
-use kyokara_syntax::ast::nodes::{ElseBranch, FnDef, ForStmt, IfExpr, SourceFile};
+use kyokara_syntax::ast::nodes::{ElseBranch, FnDef, ForStmt, IfExpr, ImplDef, SourceFile, TraitDef, TypeDef};
+use kyokara_syntax::ast::traits::{HasName, HasTypeParams};
 use kyokara_syntax::{SyntaxKind, parse};
 
 /// Helper: parse source, check no errors, return CST debug string.
@@ -95,6 +96,55 @@ fn parse_effect_with_body_is_rejected() {
         result.errors
     );
     assert_eq!(green_text(&result.green), src);
+}
+
+#[test]
+fn parse_trait_impl_and_derive_roundtrip_and_ast_access() {
+    let src = "pub trait Show { fn show(self) -> String }\n\ntype Point derive(Eq, Hash) = { x: Int, y: Int }\n\nimpl Show for Point { fn show(self) -> String { \"p\" } }";
+    let green = parse_ok(src);
+    assert_eq!(green_text(&green), src);
+
+    let root = kyokara_syntax::SyntaxNode::new_root(green);
+    let sf = SourceFile::cast(root).expect("source file");
+
+    let trait_def = sf
+        .syntax()
+        .descendants()
+        .find_map(TraitDef::cast)
+        .expect("trait def");
+    assert_eq!(trait_def.name_token().unwrap().text(), "Show");
+    assert!(trait_def.supertrait_list().is_none());
+    assert_eq!(trait_def.method_sigs().count(), 1);
+
+    let type_def = sf
+        .syntax()
+        .descendants()
+        .find_map(TypeDef::cast)
+        .expect("type def");
+    let derive = type_def.derive_clause().expect("derive clause");
+    assert_eq!(derive.trait_refs().count(), 2);
+
+    let impl_def = sf
+        .syntax()
+        .descendants()
+        .find_map(ImplDef::cast)
+        .expect("impl def");
+    assert_eq!(impl_def.trait_ref().unwrap().path().unwrap().segments().next().unwrap().text(), "Show");
+    assert_eq!(impl_def.methods().count(), 1);
+}
+
+#[test]
+fn parse_bounded_type_params_roundtrip() {
+    let src = "fn less<T: Ord + Show>(a: T, b: T) -> Bool { true }";
+    let green = parse_ok(src);
+    assert_eq!(green_text(&green), src);
+
+    let root = kyokara_syntax::SyntaxNode::new_root(green);
+    let fn_def = root.descendants().find_map(FnDef::cast).expect("fn");
+    let params = fn_def.type_param_list().expect("type params");
+    let tp = params.type_params().next().expect("type param");
+    let bounds = tp.bound_list().expect("bound list");
+    assert_eq!(bounds.trait_refs().count(), 2);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- add the RFC 0011 source surface for `trait`, `impl`, `derive(...)`, bounded type params, and qualified trait calls
- replace the old collection/sort allowlists with trait conformance checks and witness-carrying map/set runtimes
- keep dot calls inherent-only and leave KIR/WASM parity deferred to #400

## Testing
- cargo test --workspace
- cargo clippy --workspace --tests -- -D warnings