### PR TITLE
Improve formatter layout for multiline call arguments

### DIFF
--- a/crates/fmt/src/format.rs
+++ b/crates/fmt/src/format.rs
@@ -168,6 +168,23 @@ fn lambda_body_prefers_multiline(kind: SyntaxKind) -> bool {
     )
 }
 
+/// Some call arguments are much clearer when the entire arg list breaks
+/// into block layout instead of using the generic hanging-arg shape.
+fn arg_prefers_block_layout(node: &SyntaxNode) -> bool {
+    match node.kind() {
+        SyntaxKind::LambdaExpr => node
+            .children()
+            .find(|c| is_expr(c.kind()))
+            .is_some_and(|body| lambda_body_prefers_multiline(body.kind())),
+        SyntaxKind::IfExpr | SyntaxKind::MatchExpr | SyntaxKind::BlockExpr => true,
+        SyntaxKind::NamedArg | SyntaxKind::ParenExpr => node
+            .children()
+            .find(|c| is_expr(c.kind()))
+            .is_some_and(|expr| arg_prefers_block_layout(&expr)),
+        _ => false,
+    }
+}
+
 // ── Source file ─────────────────────────────────────────────────────
 
 fn format_source_file(node: &SyntaxNode) -> Doc {
@@ -1034,14 +1051,32 @@ fn format_arg_list(node: &SyntaxNode) -> Doc {
     // Collect all args: positional (Expr children) and named (NamedArg children).
     // They appear interleaved in the CST, so process all children in order.
     let mut arg_docs = Vec::new();
+    let mut prefer_block_layout = false;
     for child in node.children() {
         if is_expr(child.kind()) || child.kind() == SyntaxKind::NamedArg {
+            prefer_block_layout |= arg_prefers_block_layout(&child);
             arg_docs.push(format_node(&child));
         }
     }
 
     if arg_docs.is_empty() {
         return Doc::text("()");
+    }
+
+    if prefer_block_layout {
+        return Doc::concat(vec![
+            Doc::text("("),
+            Doc::indent(
+                INDENT,
+                Doc::concat(vec![
+                    Doc::HardLine,
+                    Doc::join(arg_docs, Doc::concat(vec![Doc::text(","), Doc::HardLine])),
+                    Doc::text(","),
+                ]),
+            ),
+            Doc::HardLine,
+            Doc::text(")"),
+        ]);
     }
 
     Doc::group(Doc::concat(vec![
@@ -1307,8 +1342,8 @@ fn format_record_expr(node: &SyntaxNode) -> Doc {
     let mut parts = Vec::new();
     if let Some(path) = find_child_node(node, SyntaxKind::Path) {
         parts.push(format_node(&path));
+        parts.push(Doc::text(" "));
     }
-    parts.push(Doc::text(" "));
     if let Some(field_list) = find_child_node(node, SyntaxKind::RecordExprFieldList) {
         parts.push(format_node(&field_list));
     }

--- a/crates/fmt/tests/fmt_tests.rs
+++ b/crates/fmt/tests/fmt_tests.rs
@@ -440,6 +440,14 @@ fn fmt_record_expr() {
     );
 }
 
+#[test]
+fn fmt_anonymous_record_expr_has_no_leading_space() {
+    assert_fmt(
+        "fn main() -> { x: Int, y: Int } { { x: 1, y: 2 } }",
+        "fn main() -> { x: Int, y: Int } {\n  { x: 1, y: 2 }\n}\n",
+    );
+}
+
 // ── Patterns ────────────────────────────────────────────────────────
 
 #[test]
@@ -611,7 +619,47 @@ fn fmt_lambda_with_if_body_uses_stable_multiline_layout() {
 fn fmt_fold_lambda_in_call_uses_stable_multiline_layout() {
     assert_fmt(
         "fn main() -> Int { (0..<3).fold(0, fn(acc: Int, n: Int) => if (n > 1) { acc + n } else { acc }) }",
-        "fn main() -> Int {\n  (0 ..< 3).fold(0, fn(acc: Int, n: Int) =>\n      if (n > 1) {\n        acc + n\n      } else {\n        acc\n      })\n}\n",
+        "fn main() -> Int {\n  (0 ..< 3).fold(\n    0,\n    fn(acc: Int, n: Int) =>\n      if (n > 1) {\n        acc + n\n      } else {\n        acc\n      },\n  )\n}\n",
+    );
+}
+
+#[test]
+fn fmt_direct_call_multiline_lambda_argument_uses_block_arg_layout() {
+    assert_fmt_parse_ok(
+        "fn main() -> Int { apply(1, fn(acc: Int, n: Int) => if (n > 1) { acc + n } else { acc }) }",
+        "fn main() -> Int {\n  apply(\n    1,\n    fn(acc: Int, n: Int) =>\n      if (n > 1) {\n        acc + n\n      } else {\n        acc\n      },\n  )\n}\n",
+    );
+}
+
+#[test]
+fn fmt_unfold_lambda_with_block_body_uses_block_arg_layout() {
+    assert_fmt_parse_ok(
+        "fn main() -> Int { 0.unfold(fn(state: Int) => { let next = state + 1\nSome({ value: state, state: next }) }).count() }",
+        "fn main() -> Int {\n  0.unfold(\n    fn(state: Int) =>\n      {\n        let next = state + 1\n        Some({ value: state, state: next })\n      },\n  ).count()\n}\n",
+    );
+}
+
+#[test]
+fn fmt_named_arg_multiline_lambda_uses_block_arg_layout() {
+    assert_fmt_parse_ok(
+        "fn main() -> Int { apply(seed: 0, step: fn(state: Int) => if (state > 0) { state - 1 } else { state }).count() }",
+        "fn main() -> Int {\n  apply(\n    seed: 0,\n    step: fn(state: Int) =>\n      if (state > 0) {\n        state - 1\n      } else {\n        state\n      },\n  ).count()\n}\n",
+    );
+}
+
+#[test]
+fn fmt_if_expression_argument_uses_block_arg_layout() {
+    assert_fmt_parse_ok(
+        "fn main() -> Int { choose(if (ready) { 1 } else { 2 }, 3) }",
+        "fn main() -> Int {\n  choose(\n    if (ready) {\n      1\n    } else {\n      2\n    },\n    3,\n  )\n}\n",
+    );
+}
+
+#[test]
+fn fmt_simple_lambda_argument_stays_compact() {
+    assert_fmt(
+        "fn main() -> Int { (0..<3).fold(0, fn(acc: Int, n: Int) => acc + n) }",
+        "fn main() -> Int {\n  (0 ..< 3).fold(0, fn(acc: Int, n: Int) => acc + n)\n}\n",
     );
 }
 


### PR DESCRIPTION
Closes #404

## Summary
- switch call argument lists to block layout when any argument is a multiline-preferred lambda or block-shaped expression
- keep simple lambda arguments on the compact inline layout
- fix anonymous record literals so they do not gain a stray space before `{`

## Testing
- cargo test -p kyokara-fmt --test fmt_tests -- --nocapture
- cargo test -p kyokara-fmt
- cargo clippy --workspace --tests -- -D warnings
- cargo test --workspace