### PR TITLE
Tighten constrained overloading coverage

### DIFF
--- a/crates/api/tests/api_tests.rs
+++ b/crates/api/tests/api_tests.rs
@@ -1597,6 +1597,21 @@ fn main() -> Int { foo() + foo(2) }"#;
 }
 
 #[test]
+fn check_user_defined_function_overload_family_wrong_arity_reports_one_of() {
+    let src = r#"fn foo() -> Int { 1 }
+fn foo(x: Int) -> Int { x + 1 }
+fn foo(x: Int, y: Int, z: Int) -> Int { x + y + z }
+fn main() -> Int { foo(1, 2) }"#;
+    let output = check(src, "test.ky");
+    assert!(
+        output.diagnostics.iter().any(|d| d.code == "E0007"
+            && d.message.contains("expected 0, 1, or 3 argument(s), found 2")),
+        "expected constrained-family arity diagnostic, got: {:?}",
+        output.diagnostics
+    );
+}
+
+#[test]
 fn check_user_defined_method_overload_family_by_arity_is_allowed() {
     let src = r#"type Box = { value: Int }
 fn Box.size(self) -> Int { self.value }
@@ -1614,6 +1629,25 @@ fn main() -> Int {
 }
 
 #[test]
+fn check_user_defined_method_overload_family_wrong_arity_reports_one_of() {
+    let src = r#"type Box = { value: Int }
+fn Box.size(self) -> Int { self.value }
+fn Box.size(self, extra: Int) -> Int { self.value + extra }
+fn Box.size(self, extra: Int, extra2: Int) -> Int { self.value + extra + extra2 }
+fn main() -> Int {
+    let b = Box { value: 2 }
+    b.size(1, 2, 3)
+}"#;
+    let output = check(src, "test.ky");
+    assert!(
+        output.diagnostics.iter().any(|d| d.code == "E0007"
+            && d.message.contains("expected 0, 1, or 2 argument(s), found 3")),
+        "expected constrained-family arity diagnostic, got: {:?}",
+        output.diagnostics
+    );
+}
+
+#[test]
 fn check_user_defined_function_type_based_overload_is_rejected() {
     let src = r#"fn foo(x: Int) -> Int { x }
 fn foo(x: String) -> String { x }
@@ -1625,6 +1659,54 @@ fn main() -> Int { 0 }"#;
             .iter()
             .any(|d| d.code == "E0102" && d.message.contains("call shapes overlap")),
         "expected overload-family overlap diagnostic, got: {:?}",
+        output.diagnostics
+    );
+}
+
+#[test]
+fn check_user_defined_function_return_type_only_overload_is_rejected() {
+    let src = r#"fn foo(x: Int) -> Int { x }
+fn foo(x: Int) -> String { "x" }
+fn main() -> Int { 0 }"#;
+    let output = check(src, "test.ky");
+    assert!(
+        output
+            .diagnostics
+            .iter()
+            .any(|d| d.code == "E0102" && d.message.contains("call shapes overlap")),
+        "expected return-type-only overlap diagnostic, got: {:?}",
+        output.diagnostics
+    );
+}
+
+#[test]
+fn check_user_defined_function_param_name_only_overload_is_rejected() {
+    let src = r#"fn foo(x: Int, y: Int) -> Int { x + y }
+fn foo(left: Int, right: Int) -> Int { left + right }
+fn main() -> Int { 0 }"#;
+    let output = check(src, "test.ky");
+    assert!(
+        output
+            .diagnostics
+            .iter()
+            .any(|d| d.code == "E0102" && d.message.contains("call shapes overlap")),
+        "expected param-name-only overlap diagnostic, got: {:?}",
+        output.diagnostics
+    );
+}
+
+#[test]
+fn check_user_defined_function_generic_overlap_is_rejected() {
+    let src = r#"fn foo<T>(x: T) -> T { x }
+fn foo(x: Int) -> Int { x }
+fn main() -> Int { 0 }"#;
+    let output = check(src, "test.ky");
+    assert!(
+        output
+            .diagnostics
+            .iter()
+            .any(|d| d.code == "E0102" && d.message.contains("call shapes overlap")),
+        "expected generic overlap diagnostic, got: {:?}",
         output.diagnostics
     );
 }
@@ -1647,6 +1729,23 @@ fn main() -> Int { 0 }"#;
 }
 
 #[test]
+fn check_user_defined_method_param_name_only_overload_is_rejected() {
+    let src = r#"type Box = { value: Int }
+fn Box.size(self, x: Int, y: Int) -> Int { x + y }
+fn Box.size(self, left: Int, right: Int) -> Int { left + right }
+fn main() -> Int { 0 }"#;
+    let output = check(src, "test.ky");
+    assert!(
+        output
+            .diagnostics
+            .iter()
+            .any(|d| d.code == "E0102" && d.message.contains("call shapes overlap")),
+        "expected method param-name-only overlap diagnostic, got: {:?}",
+        output.diagnostics
+    );
+}
+
+#[test]
 fn check_overloaded_function_family_cannot_be_used_as_value() {
     let src = r#"fn foo() -> Int { 1 }
 fn foo(x: Int) -> Int { x }
@@ -1660,6 +1759,47 @@ fn main() -> Int {
             d.code == "E0039" && d.message.contains("overloaded function family `foo`")
         }),
         "expected overloaded-family-as-value diagnostic, got: {:?}",
+        output.diagnostics
+    );
+}
+
+#[test]
+fn check_project_imported_and_local_arity_distinct_family_is_allowed() {
+    let output = check_project_from_files(&[
+        ("main.ky", "import util\nfn foo() -> Int { 1 }\nfn main() -> Int { foo() + foo(2) }\n"),
+        ("util.ky", "pub fn foo(x: Int) -> Int { x + 1 }\n"),
+    ]);
+    assert!(
+        output.diagnostics.is_empty(),
+        "expected no diagnostics, got: {:?}",
+        output.diagnostics
+    );
+}
+
+#[test]
+fn check_project_import_overlap_same_shape_is_rejected() {
+    let output = check_project_from_files(&[
+        ("main.ky", "import util\nfn foo(x: Int) -> Int { x }\nfn main() -> Int { 0 }\n"),
+        ("util.ky", "pub fn foo(x: Int) -> Int { x + 1 }\n"),
+    ]);
+    assert!(
+        output.diagnostics.iter().any(|d| d.code == "E0101"
+            && d.message.contains("overload family for `foo` overlaps")),
+        "expected conflicting imported overlap diagnostic, got: {:?}",
+        output.diagnostics
+    );
+}
+
+#[test]
+fn check_project_imported_overloaded_function_family_cannot_be_used_as_value() {
+    let output = check_project_from_files(&[
+        ("main.ky", "import util\nfn main() -> Int {\n  let f = foo\n  0\n}\n"),
+        ("util.ky", "pub fn foo() -> Int { 1 }\npub fn foo(x: Int) -> Int { x }\n"),
+    ]);
+    assert!(
+        output.diagnostics.iter().any(|d| d.code == "E0039"
+            && d.message.contains("overloaded function family `foo`")),
+        "expected imported overloaded-family-as-value diagnostic, got: {:?}",
         output.diagnostics
     );
 }

--- a/crates/eval/tests/eval_tests.rs
+++ b/crates/eval/tests/eval_tests.rs
@@ -7877,6 +7877,20 @@ fn main() -> Int { foo() + foo(2) }"#,
 }
 
 #[test]
+fn eval_user_defined_function_overload_family_wrong_arity_is_compile_error() {
+    let err = run_err(
+        r#"fn foo() -> Int { 1 }
+fn foo(x: Int) -> Int { x + 1 }
+fn foo(x: Int, y: Int, z: Int) -> Int { x + y + z }
+fn main() -> Int { foo(1, 2) }"#,
+    );
+    assert!(
+        err.contains("expected 0, 1, or 3 argument(s), found 2"),
+        "expected constrained-family wrong-arity error, got: {err}"
+    );
+}
+
+#[test]
 fn eval_user_defined_method_overload_family_by_arity_dispatches() {
     let val = run_ok(
         r#"type Box = { value: Int }
@@ -7888,6 +7902,24 @@ fn main() -> Int {
 }"#,
     );
     assert_eq!(val, Value::Int(7));
+}
+
+#[test]
+fn eval_user_defined_method_overload_family_wrong_arity_is_compile_error() {
+    let err = run_err(
+        r#"type Box = { value: Int }
+fn Box.size(self) -> Int { self.value }
+fn Box.size(self, extra: Int) -> Int { self.value + extra }
+fn Box.size(self, extra: Int, extra2: Int) -> Int { self.value + extra + extra2 }
+fn main() -> Int {
+    let b = Box { value: 2 }
+    b.size(1, 2, 3)
+}"#,
+    );
+    assert!(
+        err.contains("expected 0, 1, or 2 argument(s), found 3"),
+        "expected constrained-family wrong-arity error, got: {err}"
+    );
 }
 
 #[test]
@@ -7903,6 +7935,42 @@ fn main() -> Int {
     assert!(
         err.contains("E0039") || err.contains("overloaded function family `foo`"),
         "expected overloaded-family-as-value error, got: {err}"
+    );
+}
+
+#[test]
+fn run_project_imported_and_local_overload_family_dispatches() {
+    let val = run_project_with_files_manifest_ok(
+        &[
+            ("main.ky", "import util\nfn foo() -> Int { 1 }\nfn main() -> Int { foo() + foo(2) }"),
+            ("util.ky", "pub fn foo(x: Int) -> Int { x + 1 }"),
+        ],
+        None,
+    );
+    assert_eq!(val, Value::Int(4));
+}
+
+#[test]
+fn run_project_import_overlap_same_shape_is_compile_error() {
+    let err = run_project_with_files_err(&[
+        ("main.ky", "import util\nfn foo(x: Int) -> Int { x }\nfn main() -> Int { 0 }"),
+        ("util.ky", "pub fn foo(x: Int) -> Int { x + 1 }"),
+    ]);
+    assert!(
+        err.contains("E0102") || err.contains("overlaps an existing definition"),
+        "expected conflicting imported overlap diagnostic, got: {err}"
+    );
+}
+
+#[test]
+fn run_project_imported_overloaded_function_family_as_value_is_compile_error() {
+    let err = run_project_with_files_err(&[
+        ("main.ky", "import util\nfn main() -> Int {\n  let f = foo\n  0\n}"),
+        ("util.ky", "pub fn foo() -> Int { 1 }\npub fn foo(x: Int) -> Int { x }"),
+    ]);
+    assert!(
+        err.contains("E0039") || err.contains("overloaded function family `foo`"),
+        "expected imported overloaded-family-as-value error, got: {err}"
     );
 }
 

--- a/crates/hir-def/src/call_family.rs
+++ b/crates/hir-def/src/call_family.rs
@@ -335,6 +335,35 @@ mod tests {
     }
 
     #[test]
+    fn family_reports_deduped_sorted_arity_choices_when_multiple_candidates_share_arity() {
+        let mut interner = Interner::default();
+        let zero = Vec::<FnParam>::new();
+        let one_a = vec![param(&mut interner, "x")];
+        let one_b = vec![param(&mut interner, "y")];
+        let three = vec![
+            param(&mut interner, "x"),
+            param(&mut interner, "y"),
+            param(&mut interner, "z"),
+        ];
+        let families = [0usize, 1usize, 2usize, 3usize];
+        let args = [pos(0), pos(1)];
+        let selection = select_call_family_candidate(&args, &families, |candidate| match candidate {
+            0 => zero.as_slice(),
+            1 => one_a.as_slice(),
+            2 => one_b.as_slice(),
+            3 => three.as_slice(),
+            _ => unreachable!(),
+        });
+        assert_eq!(
+            selection,
+            CallFamilySelection::ArgCountMismatch {
+                expected: vec![0, 1, 3],
+                actual: 2,
+            }
+        );
+    }
+
+    #[test]
     fn family_marks_ambiguous_same_shape_candidates() {
         let mut interner = Interner::default();
         let one = vec![param(&mut interner, "x")];
@@ -357,6 +386,14 @@ mod tests {
         let mut interner = Interner::default();
         let lhs = vec![param(&mut interner, "x")];
         let rhs = vec![param(&mut interner, "x")];
+        assert!(call_shapes_overlap(&lhs, &rhs));
+    }
+
+    #[test]
+    fn overlap_rejects_same_arity_families_distinguished_only_by_param_names() {
+        let mut interner = Interner::default();
+        let lhs = vec![param(&mut interner, "x"), param(&mut interner, "y")];
+        let rhs = vec![param(&mut interner, "left"), param(&mut interner, "right")];
         assert!(call_shapes_overlap(&lhs, &rhs));
     }
 

--- a/crates/hir-def/tests/lower_tests.rs
+++ b/crates/hir-def/tests/lower_tests.rs
@@ -174,6 +174,22 @@ fn arity_distinct_functions_do_not_diagnose_overlap() {
 }
 
 #[test]
+fn same_arity_functions_with_different_param_names_still_diagnose_overlap() {
+    let root = parse_source("fn foo(x: Int) -> Int { x }\nfn foo(y: Int) -> Int { y }");
+    let sf = SourceFile::cast(root).unwrap();
+    let mut interner = Interner::new();
+    let result = collect_item_tree(&sf, file_id(), &mut interner);
+
+    assert!(
+        result.diagnostics.iter().any(|d| d
+            .message
+            .contains("invalid overload family for function `foo`: call shapes overlap")),
+        "expected overlap diagnostic, got: {:?}",
+        result.diagnostics
+    );
+}
+
+#[test]
 fn duplicate_type_diagnostic() {
     let root = parse_source("type Foo = Int\ntype Foo = Bool");
     let sf = SourceFile::cast(root).unwrap();

--- a/crates/hir-ty/src/lib.rs
+++ b/crates/hir-ty/src/lib.rs
@@ -32,8 +32,6 @@ use kyokara_stdx::FxHashMap;
 use kyokara_syntax::SyntaxNode;
 use kyokara_syntax::ast::AstNode;
 use kyokara_syntax::ast::nodes::{FnDef, ImplMethodDef, LetBinding, PropertyDef};
-use kyokara_syntax::ast::traits::HasName;
-
 use kyokara_hir_def::name::Name;
 
 use crate::diagnostics::TyDiagnosticData;
@@ -42,7 +40,6 @@ use crate::ty::Ty;
 
 struct BodyLookupIndex {
     fn_by_range: FxHashMap<TextRange, FnDef>,
-    fn_by_name: FxHashMap<String, FnDef>,
     impl_by_range: FxHashMap<TextRange, ImplMethodDef>,
     prop_by_range: FxHashMap<TextRange, PropertyDef>,
     let_by_range: FxHashMap<TextRange, LetBinding>,
@@ -55,7 +52,6 @@ fn build_body_lookup_index(
     let_defs: &[LetBinding],
 ) -> BodyLookupIndex {
     let mut fn_by_range = FxHashMap::default();
-    let mut fn_by_name = FxHashMap::default();
     let mut impl_by_range = FxHashMap::default();
     let mut prop_by_range = FxHashMap::default();
     let mut let_by_range = FxHashMap::default();
@@ -63,11 +59,6 @@ fn build_body_lookup_index(
     for fd in fn_defs {
         let range = fd.syntax().text_range();
         fn_by_range.insert(range, fd.clone());
-        if let Some(name) = fd.name_token() {
-            fn_by_name
-                .entry(name.text().to_owned())
-                .or_insert_with(|| fd.clone());
-        }
     }
 
     for fd in impl_defs {
@@ -87,23 +78,14 @@ fn build_body_lookup_index(
 
     BodyLookupIndex {
         fn_by_range,
-        fn_by_name,
         impl_by_range,
         prop_by_range,
         let_by_range,
     }
 }
 
-fn lookup_fn_def<'a>(
-    index: &'a BodyLookupIndex,
-    source_range: Option<TextRange>,
-    fn_name: &str,
-) -> Option<&'a FnDef> {
-    if let Some(range) = source_range {
-        index.fn_by_range.get(&range)
-    } else {
-        index.fn_by_name.get(fn_name)
-    }
+fn lookup_fn_def(index: &BodyLookupIndex, source_range: Option<TextRange>) -> Option<&FnDef> {
+    source_range.and_then(|range| index.fn_by_range.get(&range))
 }
 
 fn lookup_property_def(
@@ -284,10 +266,9 @@ pub fn check_module(
             continue;
         }
 
-        // Match by source range when available (exact CST node identity),
-        // falling back to name-based matching for imported functions.
-        let fn_name_str = fn_item.name.resolve(interner);
-        let fn_def = lookup_fn_def(&body_lookup, fn_item.source_range, fn_name_str);
+        // Match only by source range. Imported clones intentionally have no
+        // body in this module; runtime wires their actual bodies separately.
+        let fn_def = lookup_fn_def(&body_lookup, fn_item.source_range);
 
         // Try FnDef first; if not found, try PropertyDef (synthetic FnItems
         // created for properties point at PropertyDef source ranges).
@@ -462,13 +443,13 @@ mod tests {
 
         let beta = &fn_defs[1];
         let beta_range = beta.syntax().text_range();
-        let by_range = lookup_fn_def(&index, Some(beta_range), "alpha")
+        let by_range = lookup_fn_def(&index, Some(beta_range))
             .expect("range lookup should prefer exact node");
         assert_eq!(by_range.syntax().text_range(), beta_range);
     }
 
     #[test]
-    fn body_lookup_uses_name_fallback_when_range_missing() {
+    fn body_lookup_returns_none_when_range_is_missing() {
         let parse = kyokara_syntax::parse(
             r#"
             fn main() -> Int { helper() }
@@ -483,8 +464,9 @@ mod tests {
             root.descendants().filter_map(PropertyDef::cast).collect();
         let index = build_body_lookup_index(&fn_defs, &[], &prop_defs, &[]);
 
-        let by_name =
-            lookup_fn_def(&index, None, "helper").expect("name fallback should resolve helper");
-        assert_eq!(by_name.name_token().expect("name token").text(), "helper");
+        assert!(
+            lookup_fn_def(&index, None).is_none(),
+            "missing source range should not guess a body by name"
+        );
     }
 }


### PR DESCRIPTION
## Summary
- add broad red/green coverage for allowed and rejected constrained overloading forms
- cover imported/local family composition, wrong-arity errors, and overlap rejection cases
- fix imported function body lookup so cloned imports never borrow a local body by name fallback

## Testing
- cargo test --workspace
- cargo clippy --workspace --tests -- -D warnings