### PR TITLE
Add overload dispatch perf case

### DIFF
--- a/docs/performance-harness.md
+++ b/docs/performance-harness.md
@@ -72,6 +72,7 @@ Representative v1 cases:
 - `mutable_bool_dense_relation_run` keeps the same dense precedence workload on the legacy `MutableList<Bool>` representation, so the packed-bit win is measurable on a like-for-like algorithm.
 - `mutable_map_set_churn_run` intentionally stresses repeated `MutableMap` / `MutableSet` insert, contains, and remove churn, so mutable hash-collection regressions are visible without waiting for AoC-style search workloads to fail.
 - `mutable_map_sparse_int_probe_run` intentionally stresses long-running sparse `MutableMap<Int, Int>` lookup/insert/remove churn with explicit capacity hints, so primitive-key hot-path regressions are visible without relying on full AoC solver runs.
+- `overload_family_dispatch_run` intentionally stresses constrained call-family dispatch across user-defined functions, user-defined methods, and builtin named-argument families, so overload-selection regressions are visible outside full application benchmarks.
 - `cow_collection_chain_run` intentionally stresses immutable same-name rebinding on `List`, `Map`, `Set`, and `Deque` so COW-path regressions are visible.
 
 ## Baselines

--- a/tools/perf/baselines/macos__aarch64__apple_m3__rustc_1_93_1__01f6ddf75_2026_02_11___release_lto_fat.json
+++ b/tools/perf/baselines/macos__aarch64__apple_m3__rustc_1_93_1__01f6ddf75_2026_02_11___release_lto_fat.json
@@ -93,6 +93,30 @@
       "median_ms": 33.160375
     },
     {
+      "id": "mutable_map_sparse_int_probe_run",
+      "mode": "run",
+      "samples_ms": [
+        199.111792,
+        166.331583,
+        163.365458,
+        161.120458,
+        177.170125
+      ],
+      "median_ms": 166.331583
+    },
+    {
+      "id": "overload_family_dispatch_run",
+      "mode": "run",
+      "samples_ms": [
+        278.377333,
+        265.54475,
+        292.932583,
+        280.492792,
+        293.1425
+      ],
+      "median_ms": 280.492792
+    },
+    {
       "id": "parse_dense_module_check",
       "mode": "check",
       "samples_ms": [

--- a/tools/perf/cases/overload_family_dispatch_run/bench.json
+++ b/tools/perf/cases/overload_family_dispatch_run/bench.json
@@ -1,0 +1,11 @@
+{
+  "id": "overload_family_dispatch_run",
+  "mode": "run",
+  "entry": "main.ky",
+  "project": false,
+  "expected_stdout": "2719901\n",
+  "warmup_runs": 1,
+  "measured_runs": 5,
+  "max_regression_pct": 20.0,
+  "max_regression_ms": 15.0
+}

--- a/tools/perf/cases/overload_family_dispatch_run/main.ky
+++ b/tools/perf/cases/overload_family_dispatch_run/main.ky
@@ -1,0 +1,73 @@
+import io
+
+type Counter = { total: Int }
+
+fn score() -> Int {
+  3
+}
+
+fn score(x: Int) -> Int {
+  x + 5
+}
+
+fn score(x: Int, y: Int, z: Int) -> Int {
+  (x * 2) + (y * 3) + (z * 5)
+}
+
+fn Counter.bump(self) -> Counter {
+  Counter { total: self.total + 1 }
+}
+
+fn Counter.bump(self, delta: Int) -> Counter {
+  Counter { total: self.total + delta }
+}
+
+fn exercise_function_family(rounds: Int) -> Int {
+  var acc = 0
+  var i = 0
+  while (i < rounds) {
+    acc = acc + score()
+    acc = acc + score(i % 17)
+    acc = acc + score(i % 5, i % 7, i % 11)
+    i = i + 1
+  }
+  acc
+}
+
+fn exercise_method_family(rounds: Int) -> Int {
+  var c = Counter { total: 0 }
+  var i = 0
+  while (i < rounds) {
+    c = c.bump()
+    c = c.bump((i % 13) + 1)
+    i = i + 1
+  }
+  c.total
+}
+
+fn exercise_builtin_family(rounds: Int) -> Int {
+  let word = "kyokara-overloading"
+  var hits = 0
+  var i = 0
+  while (i < rounds) {
+    if (word.starts_with("kyo")) {
+      hits = hits + 1
+    }
+    if (word.starts_with("over", start: 8)) {
+      hits = hits + 2
+    }
+    if (word.starts_with("load", start: 12)) {
+      hits = hits + 3
+    }
+    i = i + 1
+  }
+  hits
+}
+
+fn main() -> Unit {
+  let rounds = 40000
+  let total = exercise_function_family(rounds)
+    + exercise_method_family(rounds)
+    + exercise_builtin_family(rounds)
+  io.println(total.to_string())
+}

--- a/xtask/src/perf.rs
+++ b/xtask/src/perf.rs
@@ -999,6 +999,7 @@ mod tests {
                 "mutable_bool_dense_relation_run",
                 "mutable_map_set_churn_run",
                 "mutable_map_sparse_int_probe_run",
+                "overload_family_dispatch_run",
                 "parse_dense_module_check",
                 "wordfreq_map_set_run",
             ]
@@ -1107,6 +1108,35 @@ mod tests {
                 && source.contains(".insert(")
                 && source.contains(".remove("),
             "sparse probe case must hit the sparse int-key hot path operations"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn overload_family_dispatch_case_exercises_constrained_call_families() -> Result<()> {
+        let root = workspace_root()?;
+        let source = fs::read_to_string(
+            root.join("tools")
+                .join("perf")
+                .join("cases")
+                .join("overload_family_dispatch_run")
+                .join("main.ky"),
+        )?;
+        assert!(
+            source.contains("fn score() -> Int")
+                && source.contains("fn score(x: Int) -> Int")
+                && source.contains("fn score(x: Int, y: Int, z: Int) -> Int"),
+            "overload case must define a user function family with arity-distinct members"
+        );
+        assert!(
+            source.contains("fn Counter.bump(self) -> Counter")
+                && source.contains("fn Counter.bump(self, delta: Int) -> Counter"),
+            "overload case must define a user method family with arity-distinct members"
+        );
+        assert!(
+            source.contains(".starts_with(\"kyo\")")
+                && source.contains(".starts_with(\"over\", start: 8)"),
+            "overload case must exercise the builtin named-arg call family path"
         );
         Ok(())
     }


### PR DESCRIPTION
## Summary
- add an overload-family dispatch benchmark case to the perf corpus
- extend xtask perf corpus tests and docs for the new case
- refresh the local committed perf baseline for the new case and the existing sparse int probe case

## Testing
- cargo test -p xtask -- --nocapture
- cargo clippy -p xtask --tests -- -D warnings
- cargo run -q -p kyokara-cli --release -- run tools/perf/cases/overload_family_dispatch_run/main.ky
- cargo run -p xtask -- perf record --case mutable_map_sparse_int_probe_run
- cargo run -p xtask -- perf record --case overload_family_dispatch_run
- cargo run -p xtask -- perf check --case mutable_map_sparse_int_probe_run
- cargo run -p xtask -- perf check --case overload_family_dispatch_run