### PR TITLE
Remove fixed WASM follow-chain cap

### DIFF
--- a/crates/codegen/src/wasm/func.rs
+++ b/crates/codegen/src/wasm/func.rs
@@ -7,7 +7,7 @@ use kyokara_kir::block::{BlockId, Terminator};
 use kyokara_kir::function::KirFunction;
 use kyokara_kir::inst::{CallTarget, Constant, Inst};
 use kyokara_kir::value::ValueId;
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxHashMap, FxHashSet};
 use wasm_encoder::{BlockType, Function, Instruction, MemArg, ValType};
 
 use crate::error::CodegenError;
@@ -342,8 +342,11 @@ impl<'a> FuncCodegen<'a> {
     fn follow_chain(&self, start: BlockId) -> Vec<BlockId> {
         let mut chain = Vec::new();
         let mut current = start;
-        for _ in 0..50 {
-            // guard against pathological input
+        let mut visited = FxHashSet::default();
+        loop {
+            if !visited.insert(current) {
+                break;
+            }
             let block = &self.kir_func.blocks[current];
             match &block.terminator {
                 Some(Terminator::Jump(target)) => {

--- a/crates/codegen/tests/codegen_tests.rs
+++ b/crates/codegen/tests/codegen_tests.rs
@@ -552,6 +552,21 @@ fn test_deeply_nested_if_else() {
 }
 
 #[test]
+fn test_very_deeply_nested_if_else_exceeds_old_follow_chain_cap() {
+    let mut expr = String::from("0");
+    for i in (0..80).rev() {
+        expr = format!("if (x == {i}) {{ {i} }} else {{ {expr} }}");
+    }
+    let source = format!(
+        "fn main() -> Int {{\n\
+           let x = 79\n\
+           {expr}\n\
+         }}"
+    );
+    assert_eq!(run_main_i64(&source), 79);
+}
+
+#[test]
 fn test_if_else_both_return() {
     assert_eq!(
         run_main_i64(


### PR DESCRIPTION
## Summary
- replace the fixed 50-hop control-flow chain cap with cycle-aware iterative traversal
- preserve termination on malformed cyclic graphs via a visited-set guard
- add an end-to-end codegen regression for very deep nested `if` merge discovery

## Testing
- cargo test -p kyokara-codegen test_very_deeply_nested_if_else_exceeds_old_follow_chain_cap -- --nocapture
- cargo test --workspace
- cargo clippy --workspace --tests -- -D warnings

Closes #428