### PR TITLE
Reuse cached analysis for LSP code actions

### DIFF
--- a/crates/lsp/src/code_action.rs
+++ b/crates/lsp/src/code_action.rs
@@ -2,7 +2,6 @@
 
 use std::sync::Arc;
 
-use kyokara_hir::CheckResult;
 use kyokara_span::FileId;
 use tower_lsp::lsp_types::{
     self, CodeAction, CodeActionKind, CodeActionOrCommand, NumberOrString, TextEdit, Url,
@@ -54,15 +53,19 @@ fn missing_match_cases_action(
     diag: &lsp_types::Diagnostic,
     uri: &Url,
 ) -> Option<CodeAction> {
-    // Reconstruct a CheckResult from the analysis data.
-    let check_result = reconstruct_check_result(analysis);
     let file_id = FileId(0);
+    let root = analysis.syntax_root();
 
     // Use the diagnostic range start as offset.
     let offset = lsp_range_start_to_offset(&diag.range, source)?;
 
-    let result =
-        kyokara_refactor::quickfix::add_missing_match_cases(&check_result, file_id, offset).ok()?;
+    let result = kyokara_refactor::quickfix::add_missing_match_cases_from_diagnostics(
+        &root,
+        &analysis.type_check.raw_diagnostics,
+        file_id,
+        offset,
+    )
+    .ok()?;
 
     let edits: Vec<TextEdit> = result
         .edits
@@ -94,13 +97,18 @@ fn missing_capability_action(
     diag: &lsp_types::Diagnostic,
     uri: &Url,
 ) -> Option<CodeAction> {
-    let check_result = reconstruct_check_result(analysis);
     let file_id = FileId(0);
+    let root = analysis.syntax_root();
 
     let offset = lsp_range_start_to_offset(&diag.range, source)?;
 
-    let result =
-        kyokara_refactor::quickfix::add_missing_capability(&check_result, file_id, offset).ok()?;
+    let result = kyokara_refactor::quickfix::add_missing_capability_from_diagnostics(
+        &root,
+        &analysis.type_check.raw_diagnostics,
+        file_id,
+        offset,
+    )
+    .ok()?;
 
     let edits: Vec<TextEdit> = result
         .edits
@@ -124,18 +132,6 @@ fn missing_capability_action(
         }),
         ..Default::default()
     })
-}
-
-/// Reconstruct a `CheckResult` from `FileAnalysis` for the refactor crate.
-///
-/// The green node is Arc-backed so cloning is cheap. The interner is
-/// reconstructed by re-running `check_file` — this is acceptable because
-/// code actions are infrequent and the file was just analyzed.
-fn reconstruct_check_result(analysis: &FileAnalysis) -> CheckResult {
-    // Re-run check to get a CheckResult with a valid interner.
-    // This is the simplest approach — the refactor crate needs &CheckResult
-    // with a live Interner, and we can't clone Rodeo.
-    kyokara_hir::check_file(&analysis.source)
 }
 
 fn lsp_range_start_to_offset(range: &lsp_types::Range, source: &str) -> Option<u32> {

--- a/crates/refactor/src/quickfix.rs
+++ b/crates/refactor/src/quickfix.rs
@@ -2,7 +2,7 @@
 
 use kyokara_hir::{CheckResult, ProjectCheckResult};
 use kyokara_hir_ty::diagnostics::TyDiagnosticData;
-use kyokara_span::{FileId, TextRange};
+use kyokara_span::{FileId, Span, TextRange};
 use kyokara_syntax::SyntaxNode;
 use kyokara_syntax::ast::AstNode;
 use kyokara_syntax::ast::nodes::{FnDef, MatchExpr};
@@ -19,12 +19,30 @@ pub fn add_missing_match_cases(
     offset: u32,
 ) -> Result<RefactorResult, RefactorError> {
     let root = SyntaxNode::new_root(result.green.clone());
-    for (data, span) in &result.type_check.raw_diagnostics {
+    add_missing_match_cases_from_diagnostics(
+        &root,
+        &result.type_check.raw_diagnostics,
+        file_id,
+        offset,
+    )
+}
+
+/// Add missing match cases from an existing syntax root and raw diagnostics.
+///
+/// This avoids reconstructing a full `CheckResult` when a caller already has
+/// cached syntax and diagnostics, such as the LSP server.
+pub fn add_missing_match_cases_from_diagnostics(
+    root: &SyntaxNode,
+    raw_diagnostics: &[(TyDiagnosticData, Span)],
+    file_id: FileId,
+    offset: u32,
+) -> Result<RefactorResult, RefactorError> {
+    for (data, span) in raw_diagnostics {
         if let TyDiagnosticData::MissingMatchArms { missing } = data {
             let start: u32 = span.range.start().into();
             let end: u32 = span.range.end().into();
             if offset >= start && offset <= end {
-                return build_match_cases_edit(file_id, &root, span.range, missing);
+                return build_match_cases_edit(file_id, root, span.range, missing);
             }
         }
     }
@@ -187,12 +205,30 @@ pub fn add_missing_capability(
     offset: u32,
 ) -> Result<RefactorResult, RefactorError> {
     let root = SyntaxNode::new_root(result.green.clone());
-    for (data, span) in &result.type_check.raw_diagnostics {
+    add_missing_capability_from_diagnostics(
+        &root,
+        &result.type_check.raw_diagnostics,
+        file_id,
+        offset,
+    )
+}
+
+/// Add missing capability from an existing syntax root and raw diagnostics.
+///
+/// This avoids reconstructing a full `CheckResult` when a caller already has
+/// cached syntax and diagnostics, such as the LSP server.
+pub fn add_missing_capability_from_diagnostics(
+    root: &SyntaxNode,
+    raw_diagnostics: &[(TyDiagnosticData, Span)],
+    file_id: FileId,
+    offset: u32,
+) -> Result<RefactorResult, RefactorError> {
+    for (data, span) in raw_diagnostics {
         if let TyDiagnosticData::EffectViolation { missing } = data {
             let start: u32 = span.range.start().into();
             let end: u32 = span.range.end().into();
             if offset >= start && offset <= end {
-                return build_capability_edit(file_id, &root, span.range, missing);
+                return build_capability_edit(file_id, root, span.range, missing);
             }
         }
     }

--- a/crates/refactor/tests/refactor_tests.rs
+++ b/crates/refactor/tests/refactor_tests.rs
@@ -271,6 +271,47 @@ fn pick(c: Color) -> Int {
 }
 
 #[test]
+fn add_missing_match_cases_from_diagnostics() {
+    let src = r#"type Color = Red | Green | Blue
+fn pick(c: Color) -> Int {
+    match (c) {
+        Red => 1
+    }
+}"#;
+    let result = kyokara_hir::check_file(src);
+    let root = kyokara_syntax::SyntaxNode::new_root(result.green.clone());
+
+    let (_, span) = result
+        .type_check
+        .raw_diagnostics
+        .iter()
+        .find(|(d, _)| matches!(d, kyokara_hir::TyDiagnosticData::MissingMatchArms { .. }))
+        .expect("expected MissingMatchArms diagnostic");
+
+    let offset: u32 = span.range.start().into();
+    let refactor = kyokara_refactor::quickfix::add_missing_match_cases_from_diagnostics(
+        &root,
+        &result.type_check.raw_diagnostics,
+        file_id(),
+        offset,
+    )
+    .unwrap();
+
+    assert!(!refactor.edits.is_empty(), "expected edits");
+    let edit = &refactor.edits[0];
+    assert!(
+        edit.new_text.contains("Green"),
+        "should contain Green: {}",
+        edit.new_text
+    );
+    assert!(
+        edit.new_text.contains("Blue"),
+        "should contain Blue: {}",
+        edit.new_text
+    );
+}
+
+#[test]
 fn add_missing_match_cases_empty_nested_match_uses_context_indent() {
     let src = r#"type Color = Red | Green | Blue
 fn pick(c: Color) -> Int {
@@ -378,6 +419,40 @@ fn pure_caller() -> Unit { effectful() }"#;
         target_file: None,
     };
     let refactor = kyokara_refactor::refactor(&result, file_id(), action).unwrap();
+
+    assert!(!refactor.edits.is_empty(), "expected edits");
+    let edit = &refactor.edits[0];
+    assert!(
+        edit.new_text.contains("Console"),
+        "should contain Console: {}",
+        edit.new_text
+    );
+}
+
+#[test]
+fn add_missing_capability_from_diagnostics() {
+    let src = r#"effect Console
+fn emit(s: String) -> Unit { }
+fn effectful() -> Unit with Console { emit("hi") }
+fn pure_caller() -> Unit { effectful() }"#;
+    let result = kyokara_hir::check_file(src);
+    let root = kyokara_syntax::SyntaxNode::new_root(result.green.clone());
+
+    let (_, span) = result
+        .type_check
+        .raw_diagnostics
+        .iter()
+        .find(|(d, _)| matches!(d, kyokara_hir::TyDiagnosticData::EffectViolation { .. }))
+        .expect("expected EffectViolation diagnostic");
+
+    let offset: u32 = span.range.start().into();
+    let refactor = kyokara_refactor::quickfix::add_missing_capability_from_diagnostics(
+        &root,
+        &result.type_check.raw_diagnostics,
+        file_id(),
+        offset,
+    )
+    .unwrap();
 
     assert!(!refactor.edits.is_empty(), "expected edits");
     let edit = &refactor.edits[0];


### PR DESCRIPTION
## Summary
- add narrow refactor quickfix helpers over cached syntax and raw diagnostics
- switch LSP code actions to use `FileAnalysis` directly instead of re-running `check_file()`
- cover the new helper entry points in refactor tests

## Testing
- cargo test --workspace
- cargo clippy --workspace --tests -- -D warnings