### PR TITLE
Reject deferred WASM string and char constants

### DIFF
--- a/crates/codegen/src/wasm/func.rs
+++ b/crates/codegen/src/wasm/func.rs
@@ -635,7 +635,7 @@ impl<'a> FuncCodegen<'a> {
             }
 
             Inst::Const(c) => {
-                self.emit_const(func, c);
+                self.emit_const(func, c)?;
                 func.instruction(&Instruction::LocalSet(local_idx));
             }
 
@@ -708,7 +708,7 @@ impl<'a> FuncCodegen<'a> {
 
     // ── Constants ─────────────────────────────────────────────────
 
-    fn emit_const(&self, func: &mut Function, c: &Constant) {
+    fn emit_const(&self, func: &mut Function, c: &Constant) -> Result<(), CodegenError> {
         match c {
             Constant::Int(v) => {
                 func.instruction(&Instruction::I64Const(*v));
@@ -722,11 +722,18 @@ impl<'a> FuncCodegen<'a> {
             Constant::Unit => {
                 func.instruction(&Instruction::I32Const(0));
             }
-            Constant::String(_) | Constant::Char(_) => {
-                // Deferred: emit unreachable for now.
-                func.instruction(&Instruction::Unreachable);
+            Constant::String(_) => {
+                return Err(CodegenError::UnsupportedInstruction(
+                    "String constant (deferred)".into(),
+                ));
+            }
+            Constant::Char(_) => {
+                return Err(CodegenError::UnsupportedInstruction(
+                    "Char constant (deferred)".into(),
+                ));
             }
         }
+        Ok(())
     }
 
     fn emit_trap_if_true(&self, func: &mut Function) {

--- a/crates/codegen/tests/codegen_tests.rs
+++ b/crates/codegen/tests/codegen_tests.rs
@@ -2,6 +2,15 @@
 #![allow(clippy::unwrap_used)]
 
 use kyokara_hir::check_file;
+use kyokara_hir::ItemTree;
+use kyokara_hir_def::name::Name;
+use kyokara_hir_ty::effects::EffectSet;
+use kyokara_hir_ty::ty::Ty;
+use kyokara_intern::Interner;
+use kyokara_kir::KirModule;
+use kyokara_kir::build::KirBuilder;
+use kyokara_kir::function::KirContracts;
+use kyokara_kir::inst::Constant;
 use kyokara_kir::lower::lower_module;
 
 fn instantiate_main(source: &str) -> (wasmtime::Store<()>, wasmtime::Instance) {
@@ -29,6 +38,38 @@ fn instantiate_main(source: &str) -> (wasmtime::Store<()>, wasmtime::Instance) {
     let instance =
         wasmtime::Instance::new(&mut store, &wasm_module, &[]).expect("instantiation failed");
     (store, instance)
+}
+
+fn compile_kir_error(module: &KirModule, item_tree: &ItemTree, interner: &Interner) -> String {
+    kyokara_codegen::compile(module, item_tree, interner)
+        .expect_err("codegen should fail")
+        .to_string()
+}
+
+fn compile_invalid_const_kir_error(constant: Constant) -> String {
+    let mut interner = Interner::new();
+    let main_name = Name::new(&mut interner, "main");
+
+    let mut builder = KirBuilder::new();
+    let entry = builder.new_block(None);
+    builder.switch_to(entry);
+    let value = builder.push_const(constant, Ty::Unit);
+    builder.set_return(value);
+
+    let func = builder.build(
+        main_name,
+        Vec::new(),
+        Ty::Unit,
+        EffectSet::default(),
+        entry,
+        KirContracts::default(),
+    );
+
+    let mut module = KirModule::new();
+    let fn_id = module.functions.alloc(func);
+    module.entry = Some(fn_id);
+
+    compile_kir_error(&module, &ItemTree::default(), &interner)
 }
 
 /// Compile source to WASM, run `main()` via wasmtime, return the i64 result.
@@ -101,6 +142,24 @@ fn test_constants() {
         ("fn main() -> Bool { true }", 1),
         ("fn main() -> Bool { false }", 0),
     ]);
+}
+
+#[test]
+fn test_string_constant_is_compile_time_unsupported_instruction() {
+    let err = compile_invalid_const_kir_error(Constant::String("hi".into()));
+    assert!(
+        err.contains("unsupported instruction: String constant (deferred)"),
+        "unexpected codegen error: {err}"
+    );
+}
+
+#[test]
+fn test_char_constant_is_compile_time_unsupported_instruction() {
+    let err = compile_invalid_const_kir_error(Constant::Char('x'));
+    assert!(
+        err.contains("unsupported instruction: Char constant (deferred)"),
+        "unexpected codegen error: {err}"
+    );
 }
 
 // ── Arithmetic ────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- return a compile-time `UnsupportedInstruction` for deferred string and char constants in WASM codegen
- stop encoding those deferred cases as runtime `unreachable`
- add KIR-level regression tests that exercise the raw deferred constant path

## Testing
- cargo test --workspace
- cargo clippy --workspace --tests -- -D warnings