### PR TITLE
Run rustfmt over workspace

### DIFF
--- a/crates/api/tests/api_tests.rs
+++ b/crates/api/tests/api_tests.rs
@@ -129,7 +129,8 @@ fn check_char_code_surface_typechecks() {
 #[test]
 fn check_char_decimal_digit_surface_typechecks() {
     let output = check(
-        &with_option_variants(r#"fn main() -> Int {
+        &with_option_variants(
+            r#"fn main() -> Int {
     let a = if ('7'.is_decimal_digit()) { 1 } else { 0 }
     let b = match ('7'.to_decimal_digit()) {
         Some(n) => n
@@ -140,7 +141,8 @@ fn check_char_decimal_digit_surface_typechecks() {
         None => 0
     }
     a + b + c
-}"#),
+}"#,
+        ),
         "test.ky",
     );
     assert!(
@@ -1934,7 +1936,10 @@ fn check_project_with_options_from_files(
 #[test]
 fn check_project_imported_function_can_read_its_top_level_let() {
     let output = check_project_from_files(&[
-        ("main.ky", "from util import util\nfn main() -> Int { util() }\n"),
+        (
+            "main.ky",
+            "from util import util\nfn main() -> Int { util() }\n",
+        ),
         ("util.ky", "let off = 1\npub fn util() -> Int { off }\n"),
     ]);
     assert!(
@@ -1948,7 +1953,10 @@ fn check_project_imported_function_can_read_its_top_level_let() {
 fn check_project_with_options_emits_typed_ast_for_multiple_files() {
     let output = check_project_with_options_from_files(
         &[
-            ("main.ky", "from math import add\nfn main() -> Int { add(1, 2) }\n"),
+            (
+                "main.ky",
+                "from math import add\nfn main() -> Int { add(1, 2) }\n",
+            ),
             ("math.ky", "pub fn add(x: Int, y: Int) -> Int { x + y }\n"),
         ],
         &CheckOptions {
@@ -2322,7 +2330,10 @@ fn project_symbol_id_uniqueness() {
 #[test]
 fn project_symbol_graph_duplicate_fn_defs_use_unique_ids() {
     let output = check_project_from_files(&[
-        ("main.ky", "from math import add\nfn main() -> Int { add(1, 2) }\n"),
+        (
+            "main.ky",
+            "from math import add\nfn main() -> Int { add(1, 2) }\n",
+        ),
         (
             "math.ky",
             "pub fn add(x: Int, y: Int) -> Int { x + y }\npub fn add(x: Int, y: Int) -> Int { x - y }\n",
@@ -2345,7 +2356,10 @@ fn project_symbol_graph_duplicate_fn_defs_use_unique_ids() {
 #[test]
 fn project_call_edges_use_qualified_ids() {
     let output = check_project_from_files(&[
-        ("main.ky", "from math import add\nfn caller() -> Int { add(1, 2) }"),
+        (
+            "main.ky",
+            "from math import add\nfn caller() -> Int { add(1, 2) }",
+        ),
         ("math.ky", "pub fn add(x: Int, y: Int) -> Int { x + y }"),
     ]);
     let caller = output
@@ -2737,7 +2751,10 @@ fn transaction_verification_failure_has_structured_spans() {
 #[test]
 fn refactor_project_verified_json_structure() {
     let (_dir, main_path) = write_project(&[
-        ("main.ky", "from math import add\nfn caller() -> Int { add(1, 2) }"),
+        (
+            "main.ky",
+            "from math import add\nfn caller() -> Int { add(1, 2) }",
+        ),
         ("math.ky", "pub fn add(x: Int, y: Int) -> Int { x + y }"),
     ]);
     let action = kyokara_refactor::RefactorAction::RenameSymbol {
@@ -2883,7 +2900,10 @@ fn api_refactor_project_io_error_surfaces_in_dto() {
     // A valid project refactor should succeed — regression test that
     // filesystem operations work and don't silently fail.
     let (_dir, main_path) = write_project(&[
-        ("main.ky", "from math import add\nfn caller() -> Int { add(1, 2) }"),
+        (
+            "main.ky",
+            "from math import add\nfn caller() -> Int { add(1, 2) }",
+        ),
         ("math.ky", "pub fn add(x: Int, y: Int) -> Int { x + y }"),
     ]);
     let action = kyokara_refactor::RefactorAction::RenameSymbol {
@@ -3000,7 +3020,10 @@ fn check_project_aliased_synthetic_collections_import_activates_alias() {
 #[test]
 fn check_project_reports_ambiguous_import_last_segment() {
     let output = check_project_from_files(&[
-        ("main.ky", "import math\nfn main() -> Int { math.value() }\n"),
+        (
+            "main.ky",
+            "import math\nfn main() -> Int { math.value() }\n",
+        ),
         ("a/math.ky", "pub fn value() -> Int { 1 }\n"),
         ("b/math.ky", "pub fn value() -> Int { 2 }\n"),
     ]);
@@ -3020,7 +3043,10 @@ fn check_project_reports_ambiguous_import_last_segment() {
 fn check_project_qualified_import_resolves_duplicate_leaf_modules() {
     // `import a.math` should resolve exactly `a/math.ky` even when `b/math.ky` exists.
     let output = check_project_from_files(&[
-        ("main.ky", "import a.math\nfn main() -> Int { math.value() }\n"),
+        (
+            "main.ky",
+            "import a.math\nfn main() -> Int { math.value() }\n",
+        ),
         ("a/math.ky", "pub fn value() -> Int { 1 }\n"),
         ("b/math.ky", "pub fn value() -> Int { 2 }\n"),
     ]);
@@ -3040,7 +3066,10 @@ fn check_project_qualified_import_resolves_duplicate_leaf_modules() {
 fn check_project_qualified_import_missing_path_does_not_match_by_leaf() {
     // `import c.math` should not fall back to any `*.math` leaf modules.
     let output = check_project_from_files(&[
-        ("main.ky", "import c.math\nfn main() -> Int { math.value() }\n"),
+        (
+            "main.ky",
+            "import c.math\nfn main() -> Int { math.value() }\n",
+        ),
         ("a/math.ky", "pub fn value() -> Int { 1 }\n"),
         ("b/math.ky", "pub fn value() -> Int { 2 }\n"),
     ]);
@@ -3086,7 +3115,8 @@ fn check_project_lowering_diagnostic_has_real_file_path() {
 #[test]
 fn constructor_pattern_binding_is_in_scope() {
     // `Some(x) => x` should not produce "unresolved name x".
-    let src = &with_option_variants("fn main() -> Int { match (Some(1)) { Some(x) => x, None => 0 } }");
+    let src =
+        &with_option_variants("fn main() -> Int { match (Some(1)) { Some(x) => x, None => 0 } }");
     let output = check(src, "test.ky");
     let unresolved: Vec<_> = output
         .diagnostics
@@ -3680,7 +3710,10 @@ fn let_constructor_pattern_bindings_in_scope() {
 fn project_import_collision_produces_diagnostic() {
     // Two modules export `pub fn foo()` — importing both should produce a collision diagnostic.
     let output = check_project_from_files(&[
-        ("main.ky", "from a import foo\nfrom b import foo\nfn main() -> Int { foo() }"),
+        (
+            "main.ky",
+            "from a import foo\nfrom b import foo\nfn main() -> Int { foo() }",
+        ),
         ("a.ky", "pub fn foo() -> Int { 1 }"),
         ("b.ky", "pub fn foo() -> Int { 2 }"),
     ]);
@@ -3708,7 +3741,10 @@ fn project_import_collision_produces_diagnostic() {
 #[test]
 fn project_import_collision_does_not_misattribute_call_edge_to_specific_module() {
     let output = check_project_from_files(&[
-        ("main.ky", "from a import foo\nfrom b import foo\nfn main() -> Int { foo() }"),
+        (
+            "main.ky",
+            "from a import foo\nfrom b import foo\nfn main() -> Int { foo() }",
+        ),
         ("a.ky", "pub fn foo() -> Int { 1 }"),
         ("b.ky", "pub fn foo() -> Int { 2 }"),
     ]);
@@ -4792,7 +4828,10 @@ fn project_metamorphic_local_alpha_rename_preserves_edges_in_entry_and_imported_
 #[test]
 fn project_metamorphic_nested_block_shadow_preserves_outer_import_attribution() {
     let original = [
-        ("main.ky", "from math import add\nfn main() -> Int { add(1, 2) }\n"),
+        (
+            "main.ky",
+            "from math import add\nfn main() -> Int { add(1, 2) }\n",
+        ),
         ("math.ky", "pub fn add(x: Int, y: Int) -> Int { x + y }\n"),
     ];
     let transformed = [
@@ -5094,7 +5133,8 @@ fn check_seq_any_all_find_canonical_surface_has_no_diagnostics() {
 #[test]
 fn check_seq_scan_unfold_int_pow_canonical_surface_has_no_diagnostics() {
     assert_check_no_diagnostics(
-        &with_option_variants(r#"fn main() -> Int {
+        &with_option_variants(
+            r#"fn main() -> Int {
             let a = (1..<4).scan(0, fn(acc: Int, n: Int) => acc + n).to_list()
             let b = (0).unfold(fn(state: Int) =>
                 if (state < 3) {
@@ -5104,7 +5144,8 @@ fn check_seq_scan_unfold_int_pow_canonical_surface_has_no_diagnostics() {
                 }
             ).to_list()
             a.len() + b.len() + 2.pow(10)
-        }"#),
+        }"#,
+        ),
         "seq scan/unfold + int.pow canonical surface",
     );
 }
@@ -5112,7 +5153,8 @@ fn check_seq_scan_unfold_int_pow_canonical_surface_has_no_diagnostics() {
 #[test]
 fn check_seq_unfold_accepts_named_record_alias_payload() {
     assert_check_no_diagnostics(
-        &with_option_variants(r#"type PickStep = { value: Int, state: Int }
+        &with_option_variants(
+            r#"type PickStep = { value: Int, state: Int }
 
         fn main() -> Int {
             (0).unfold(fn(state: Int) =>
@@ -5122,7 +5164,8 @@ fn check_seq_unfold_accepts_named_record_alias_payload() {
                     None
                 }
             ).count()
-        }"#),
+        }"#,
+        ),
         "seq unfold accepts named record payload alias",
     );
 }
@@ -5335,7 +5378,8 @@ fn main() -> String { h.md5("abc") }"#,
 #[test]
 fn check_option_result_combinator_parity_canonical_surface_has_no_diagnostics() {
     assert_check_no_diagnostics(
-        &with_core_variants(r#"fn main() -> Int {
+        &with_core_variants(
+            r#"fn main() -> Int {
             let o0 = collections.List.new().head().unwrap_or(1)
             let o1 = collections.List.new().push(41).head().map_or(0, fn(n: Int) => n + 1)
             let o2 = collections.List.new().push(41).head().map(fn(n: Int) => n + 1).unwrap_or(0)
@@ -5347,7 +5391,8 @@ fn check_option_result_combinator_parity_canonical_surface_has_no_diagnostics() 
                 Err(e) => e
             }
             o0 + o1 + o2 + o3 + r1 + r2 + r3
-        }"#),
+        }"#,
+        ),
         "option/result combinator parity canonical surface",
     );
 }
@@ -6029,7 +6074,8 @@ fn check_mutable_set_derived_hash_eq_element_has_no_set_diagnostic() {
 #[test]
 fn check_collections_mutable_priority_queue_constructor_surface_has_no_diagnostics_rfc_0012() {
     assert_check_no_diagnostics(
-        &with_option_variants(r#"import collections
+        &with_option_variants(
+            r#"import collections
 
 fn main() -> Int {
     let pq: MutablePriorityQueue<Int, String> = collections.MutablePriorityQueue.new_min()
@@ -6039,7 +6085,8 @@ fn main() -> Int {
         Some(item) => item.priority + pq.len()
         None => 0
     }
-}"#),
+}"#,
+        ),
         "collections.MutablePriorityQueue constructor canonical surface",
     );
 }
@@ -6048,7 +6095,8 @@ fn main() -> Int {
 fn check_collections_mutable_priority_queue_alias_constructor_surface_has_no_diagnostics_rfc_0012()
 {
     assert_check_no_diagnostics(
-        &with_option_variants(r#"import collections as c
+        &with_option_variants(
+            r#"import collections as c
 
 fn main() -> Int {
     let pq: MutablePriorityQueue<Int, String> = c.MutablePriorityQueue.new_max()
@@ -6058,7 +6106,8 @@ fn main() -> Int {
         Some(item) => item.priority
         None => 0
     }
-}"#),
+}"#,
+        ),
         "collections.MutablePriorityQueue alias constructor canonical surface",
     );
 }
@@ -6240,7 +6289,8 @@ fn main() -> Unit {
 #[test]
 fn check_opaque_traversal_surface_has_no_diagnostics_rfc_0003() {
     assert_check_no_diagnostics(
-        &with_option_variants(r#"type Seed = { x: Int }
+        &with_option_variants(
+            r#"type Seed = { x: Int }
 
 fn main() -> Int {
     let a = (0..<5).count()
@@ -6259,7 +6309,8 @@ fn main() -> Int {
         }
     ).count()
     a + b + c
-}"#),
+}"#,
+        ),
         "opaque traversal canonical surface",
     );
 }
@@ -6334,7 +6385,8 @@ fn main() -> Int {
 #[test]
 fn check_deque_and_list_index_update_canonical_surface_has_no_diagnostics() {
     assert_check_no_diagnostics(
-        &with_option_variants(r#"import collections
+        &with_option_variants(
+            r#"import collections
 
 fn main() -> Int {
             let q0 = collections.Deque.new().push_back(1).push_back(2).push_front(0)
@@ -6346,7 +6398,8 @@ fn main() -> Int {
             let xs = collections.List.new().push(10).push(20).set(1, 99)
             let ys = xs.update(0, fn(n: Int) => n + 1)
             ys.get(0).unwrap_or(0) + ys.get(1).unwrap_or(0) + q1.len()
-        }"#),
+        }"#,
+        ),
         "deque + list set/update canonical surface",
     );
 }
@@ -6354,7 +6407,8 @@ fn main() -> Int {
 #[test]
 fn check_deque_pop_back_canonical_surface_has_no_diagnostics() {
     assert_check_no_diagnostics(
-        &with_option_variants(r#"import collections
+        &with_option_variants(
+            r#"import collections
 
 fn main() -> Int {
     let q0 = collections.Deque.new().push_back(1).push_back(2).push_front(0)
@@ -6365,7 +6419,8 @@ fn main() -> Int {
         }
         None => -1
     }
-}"#),
+}"#,
+        ),
         "deque pop_back canonical surface",
     );
 }

--- a/crates/cli/tests/pattern_soundness_fixtures.rs
+++ b/crates/cli/tests/pattern_soundness_fixtures.rs
@@ -141,7 +141,12 @@ fn pattern_exhaustiveness_matrix() {
             prelude: "type ABC = A | B | C\ntype Wrap3 = Wrap(ABC) | Empty",
             match_ty: "Wrap3",
             arms: "    Wrap3.Wrap(ABC.A) => 1\n    Wrap3.Empty => 0",
-            scrutinees: &["Wrap3.Wrap(ABC.A)", "Wrap3.Wrap(ABC.B)", "Wrap3.Wrap(ABC.C)", "Wrap3.Empty"],
+            scrutinees: &[
+                "Wrap3.Wrap(ABC.A)",
+                "Wrap3.Wrap(ABC.B)",
+                "Wrap3.Wrap(ABC.C)",
+                "Wrap3.Empty",
+            ],
             expected_runtime_exhaustive: false,
             mode: SoundnessMode::Strict,
             issue: Some(137),

--- a/crates/codegen/tests/codegen_tests.rs
+++ b/crates/codegen/tests/codegen_tests.rs
@@ -1,8 +1,8 @@
 //! End-to-end tests: source → parse → check → KIR → WASM → wasmtime → assert.
 #![allow(clippy::unwrap_used)]
 
-use kyokara_hir::check_file;
 use kyokara_hir::ItemTree;
+use kyokara_hir::check_file;
 use kyokara_hir_def::name::Name;
 use kyokara_hir_ty::effects::EffectSet;
 use kyokara_hir_ty::ty::Ty;

--- a/crates/eval/src/interpreter.rs
+++ b/crates/eval/src/interpreter.rs
@@ -1226,7 +1226,10 @@ impl Interpreter {
                     .methods
                     .get(&(receiver_key, field_name))
                     .and_then(|candidates| {
-                        self.try_select_plain_positional_method_candidate(candidates, actual_arg_count)
+                        self.try_select_plain_positional_method_candidate(
+                            candidates,
+                            actual_arg_count,
+                        )
                     })
             })
             .or_else(|| {
@@ -1234,7 +1237,10 @@ impl Interpreter {
                     .methods
                     .get(&(ReceiverKey::Any, field_name))
                     .and_then(|candidates| {
-                        self.try_select_plain_positional_method_candidate(candidates, actual_arg_count)
+                        self.try_select_plain_positional_method_candidate(
+                            candidates,
+                            actual_arg_count,
+                        )
                     })
             })
     }
@@ -1326,12 +1332,8 @@ impl Interpreter {
             trait_name.resolve(&self.interner),
             method_name.resolve(&self.interner)
         );
-        let bound_args = self.bind_call_values_to_params(
-            &callee_name,
-            args,
-            arg_values,
-            &method.params,
-        )?;
+        let bound_args =
+            self.bind_call_values_to_params(&callee_name, args, arg_values, &method.params)?;
         let Some(receiver) = bound_args.first() else {
             return Err(RuntimeError::ArityMismatch {
                 callee: callee_name,
@@ -2526,7 +2528,10 @@ impl Interpreter {
                     if let Some(candidates) = candidates {
                         if Self::args_are_all_positional(&args)
                             && let Some(fn_idx) = self
-                                .try_select_plain_positional_function_candidate(candidates, args.len())
+                                .try_select_plain_positional_function_candidate(
+                                    candidates,
+                                    args.len(),
+                                )
                         {
                             let mut out = Args::with_capacity(args.len());
                             for arg in &args {
@@ -2556,20 +2561,20 @@ impl Interpreter {
                                 } => {
                                     let source_order = self.args_in_source_order(&args);
                                     let mut arg_values = Vec::with_capacity(source_order.len());
-                                for idx in &source_order {
-                                    let value = eval_propagate!(self, env, body, *idx);
-                                    arg_values.push(value);
-                                }
-                                let arg_vals = self.bind_call_items_to_params(
-                                    &format!("function `{}`", name.resolve(&self.interner)),
-                                    &args,
-                                    arg_values,
-                                    &self.item_tree.functions[fn_idx].params,
-                                )?;
-                                let mut out = Args::with_capacity(arg_vals.len());
-                                for value in arg_vals {
-                                    out.push(value);
-                                }
+                                    for idx in &source_order {
+                                        let value = eval_propagate!(self, env, body, *idx);
+                                        arg_values.push(value);
+                                    }
+                                    let arg_vals = self.bind_call_items_to_params(
+                                        &format!("function `{}`", name.resolve(&self.interner)),
+                                        &args,
+                                        arg_values,
+                                        &self.item_tree.functions[fn_idx].params,
+                                    )?;
+                                    let mut out = Args::with_capacity(arg_vals.len());
+                                    for value in arg_vals {
+                                        out.push(value);
+                                    }
                                     return self.call_fn(fn_idx, out).map(ControlFlow::Value);
                                 }
                                 CallFamilySelection::InvalidShape { errors } => {
@@ -2633,8 +2638,10 @@ impl Interpreter {
                                     .map(ControlFlow::Value);
                             }
 
-                            if let Some(&(module_name, type_name)) =
-                                self.active_module_scope().imported_type_namespaces.get(&owner)
+                            if let Some(&(module_name, type_name)) = self
+                                .active_module_scope()
+                                .imported_type_namespaces
+                                .get(&owner)
                                 && let Some(&fn_idx) = self
                                     .module_scope
                                     .synthetic_module_static_methods
@@ -2658,23 +2665,29 @@ impl Interpreter {
                                     arg_values,
                                     params,
                                 )?;
-                                return self.call_fn_idx_value(fn_idx, arg_vals).map(ControlFlow::Value);
+                                return self
+                                    .call_fn_idx_value(fn_idx, arg_vals)
+                                    .map(ControlFlow::Value);
                             }
 
-                            if let Some(namespace) = self.active_module_scope().visible_namespace(owner)
+                            if let Some(namespace) =
+                                self.active_module_scope().visible_namespace(owner)
                                 && let Some(candidates) = namespace.functions.get(field_name)
                             {
                                 let selection = match candidates.as_slice() {
                                     [fn_idx] => CallFamilySelection::Selected {
                                         candidate: *fn_idx,
-                                        binding: kyokara_hir_def::call_family::bind_call_args_to_params(
-                                            &args,
-                                            &self.item_tree.functions[*fn_idx].params,
-                                        ),
+                                        binding:
+                                            kyokara_hir_def::call_family::bind_call_args_to_params(
+                                                &args,
+                                                &self.item_tree.functions[*fn_idx].params,
+                                            ),
                                     },
-                                    _ => select_call_family_candidate(&args, candidates, |fn_idx| {
-                                        &self.item_tree.functions[fn_idx].params
-                                    }),
+                                    _ => {
+                                        select_call_family_candidate(&args, candidates, |fn_idx| {
+                                            &self.item_tree.functions[fn_idx].params
+                                        })
+                                    }
                                 };
                                 match selection {
                                     CallFamilySelection::Selected { candidate, .. } => {
@@ -2725,10 +2738,14 @@ impl Interpreter {
                             }
                         }
 
-                        if let Some(type_idx) = self.active_module_scope().resolve_type_path(&base_path) {
+                        if let Some(type_idx) =
+                            self.active_module_scope().resolve_type_path(&base_path)
+                        {
                             let owner_key = self.static_owner_key_for_type_idx(type_idx);
-                            if let Some(&fn_idx) =
-                                self.module_scope.static_methods.get(&(owner_key, *field_name))
+                            if let Some(&fn_idx) = self
+                                .module_scope
+                                .static_methods
+                                .get(&(owner_key, *field_name))
                             {
                                 let source_order = self.args_in_source_order(&args);
                                 let mut arg_values = Vec::with_capacity(source_order.len());
@@ -2748,14 +2765,19 @@ impl Interpreter {
                                     arg_values,
                                     params,
                                 )?;
-                                return self.call_fn_idx_value(fn_idx, arg_vals).map(ControlFlow::Value);
+                                return self
+                                    .call_fn_idx_value(fn_idx, arg_vals)
+                                    .map(ControlFlow::Value);
                             }
                         }
 
                         if base_segments.len() == 2 {
                             let module_name = base_segments[0];
                             let type_name = base_segments[1];
-                            if self.active_module_scope().imported_modules.contains(&module_name)
+                            if self
+                                .active_module_scope()
+                                .imported_modules
+                                .contains(&module_name)
                                 && let Some(&fn_idx) = self
                                     .module_scope
                                     .synthetic_module_static_methods
@@ -2779,7 +2801,9 @@ impl Interpreter {
                                     arg_values,
                                     params,
                                 )?;
-                                return self.call_fn_idx_value(fn_idx, arg_vals).map(ControlFlow::Value);
+                                return self
+                                    .call_fn_idx_value(fn_idx, arg_vals)
+                                    .map(ControlFlow::Value);
                             }
                         }
                     }
@@ -2800,12 +2824,15 @@ impl Interpreter {
                         && module_path.is_single()
                     {
                         let module_name = module_path.segments[0];
-                        if let Some(namespace) = self.active_module_scope().visible_namespace(module_name)
+                        if let Some(namespace) =
+                            self.active_module_scope().visible_namespace(module_name)
                             && let Some(&type_idx) = namespace.types.get(type_name)
                         {
                             let owner_key = self.static_owner_key_for_type_idx(type_idx);
-                            if let Some(&fn_idx) =
-                                self.module_scope.static_methods.get(&(owner_key, field_name))
+                            if let Some(&fn_idx) = self
+                                .module_scope
+                                .static_methods
+                                .get(&(owner_key, field_name))
                             {
                                 let source_order = self.args_in_source_order(&args);
                                 let mut arg_values = Vec::with_capacity(source_order.len());
@@ -2826,11 +2853,16 @@ impl Interpreter {
                                     arg_values,
                                     params,
                                 )?;
-                                return self.call_fn_idx_value(fn_idx, arg_vals).map(ControlFlow::Value);
+                                return self
+                                    .call_fn_idx_value(fn_idx, arg_vals)
+                                    .map(ControlFlow::Value);
                             }
                         }
 
-                        if self.active_module_scope().imported_modules.contains(&module_name)
+                        if self
+                            .active_module_scope()
+                            .imported_modules
+                            .contains(&module_name)
                             && let Some(&fn_idx) = self
                                 .module_scope
                                 .synthetic_module_static_methods
@@ -2855,7 +2887,9 @@ impl Interpreter {
                                 arg_values,
                                 params,
                             )?;
-                            return self.call_fn_idx_value(fn_idx, arg_vals).map(ControlFlow::Value);
+                            return self
+                                .call_fn_idx_value(fn_idx, arg_vals)
+                                .map(ControlFlow::Value);
                         }
                     }
 
@@ -2878,8 +2912,10 @@ impl Interpreter {
                                 .map(ControlFlow::Value);
                         }
 
-                        if let Some(&(module_name, type_name)) =
-                            self.active_module_scope().imported_type_namespaces.get(&seg)
+                        if let Some(&(module_name, type_name)) = self
+                            .active_module_scope()
+                            .imported_type_namespaces
+                            .get(&seg)
                             && let Some(&fn_idx) = self
                                 .module_scope
                                 .synthetic_module_static_methods
@@ -2904,12 +2940,16 @@ impl Interpreter {
                                 arg_values,
                                 params,
                             )?;
-                            return self.call_fn_idx_value(fn_idx, arg_vals).map(ControlFlow::Value);
+                            return self
+                                .call_fn_idx_value(fn_idx, arg_vals)
+                                .map(ControlFlow::Value);
                         }
 
                         if let Some(&type_idx) = self.active_module_scope().types.get(&seg)
-                            && let Some(&variant_idx) =
-                                self.active_module_scope().type_variants.get(&(type_idx, field_name))
+                            && let Some(&variant_idx) = self
+                                .active_module_scope()
+                                .type_variants
+                                .get(&(type_idx, field_name))
                         {
                             let source_order = self.args_in_source_order(&args);
                             let mut out = Args::with_capacity(source_order.len());
@@ -2922,7 +2962,8 @@ impl Interpreter {
 
                         // Module-qualified call: io.println(s), math.min(a, b)
                         if self.active_module_scope().imported_modules.contains(&seg)
-                            && let Some(mod_fns) = self.active_module_scope().synthetic_modules.get(&seg)
+                            && let Some(mod_fns) =
+                                self.active_module_scope().synthetic_modules.get(&seg)
                             && let Some(&fn_idx) = mod_fns.get(&field_name)
                         {
                             let source_order = self.args_in_source_order(&args);
@@ -2944,7 +2985,9 @@ impl Interpreter {
                                 arg_values,
                                 params,
                             )?;
-                            return self.call_fn_idx_value(fn_idx, arg_vals).map(ControlFlow::Value);
+                            return self
+                                .call_fn_idx_value(fn_idx, arg_vals)
+                                .map(ControlFlow::Value);
                         }
 
                         if let Some(namespace) = self.active_module_scope().visible_namespace(seg)
@@ -3037,7 +3080,9 @@ impl Interpreter {
                                 arg_values,
                                 params,
                             )?;
-                            return self.call_fn_idx_value(fn_idx, arg_vals).map(ControlFlow::Value);
+                            return self
+                                .call_fn_idx_value(fn_idx, arg_vals)
+                                .map(ControlFlow::Value);
                         }
                     }
 
@@ -3061,7 +3106,9 @@ impl Interpreter {
                                         &self.item_tree.functions[candidate].params[1..],
                                     ),
                                 })
-                                .or_else(|| self.method_candidate_for_value(&base_val, field_name, &args))
+                                .or_else(|| {
+                                    self.method_candidate_for_value(&base_val, field_name, &args)
+                                })
                         } else {
                             self.method_candidate_for_value(&base_val, field_name, &args)
                         };
@@ -3103,8 +3150,10 @@ impl Interpreter {
                             return Ok(ControlFlow::Value(value));
                         }
                         let source_order = self.args_in_source_order(&args);
-                        let method_param_count =
-                            self.item_tree.functions[fn_idx].params.len().saturating_sub(1);
+                        let method_param_count = self.item_tree.functions[fn_idx]
+                            .params
+                            .len()
+                            .saturating_sub(1);
                         let callee_name = format!(
                             "method `{}`",
                             self.item_tree.functions[fn_idx]
@@ -3113,8 +3162,7 @@ impl Interpreter {
                         );
                         let mut arg_vals = Args::with_capacity(method_param_count + 1);
                         arg_vals.push(base_val);
-                        if Self::args_are_all_positional(&args)
-                            && method_param_count == args.len()
+                        if Self::args_are_all_positional(&args) && method_param_count == args.len()
                         {
                             for idx in &source_order {
                                 arg_vals.push(eval_propagate!(self, env, body, *idx));
@@ -3136,7 +3184,9 @@ impl Interpreter {
                                 arg_vals.push(value);
                             }
                         }
-                        return self.call_fn_idx_value(fn_idx, arg_vals).map(ControlFlow::Value);
+                        return self
+                            .call_fn_idx_value(fn_idx, arg_vals)
+                            .map(ControlFlow::Value);
                     }
 
                     // Not a method — fall through to field access + call.
@@ -3412,7 +3462,10 @@ impl Interpreter {
                     if let Some(candidates) = candidates {
                         if Self::args_are_all_positional(args)
                             && let Some(fn_idx) = self
-                                .try_select_plain_positional_function_candidate(candidates, args.len())
+                                .try_select_plain_positional_function_candidate(
+                                    candidates,
+                                    args.len(),
+                                )
                         {
                             let mut out = Args::with_capacity(args.len());
                             for arg in args {
@@ -3499,12 +3552,15 @@ impl Interpreter {
                         && module_path.is_single()
                     {
                         let module_name = module_path.segments[0];
-                        if let Some(namespace) = self.active_module_scope().visible_namespace(module_name)
+                        if let Some(namespace) =
+                            self.active_module_scope().visible_namespace(module_name)
                             && let Some(&type_idx) = namespace.types.get(type_name)
                         {
                             let owner_key = self.static_owner_key_for_type_idx(type_idx);
-                            if let Some(&fn_idx) =
-                                self.module_scope.static_methods.get(&(owner_key, field_name))
+                            if let Some(&fn_idx) = self
+                                .module_scope
+                                .static_methods
+                                .get(&(owner_key, field_name))
                             {
                                 let source_order = self.args_in_source_order(args);
                                 let mut arg_values = Vec::with_capacity(source_order.len());
@@ -3525,11 +3581,16 @@ impl Interpreter {
                                     arg_values,
                                     params,
                                 )?;
-                                return self.call_fn_idx_value(fn_idx, arg_vals).map(ControlFlow::Value);
+                                return self
+                                    .call_fn_idx_value(fn_idx, arg_vals)
+                                    .map(ControlFlow::Value);
                             }
                         }
 
-                        if self.active_module_scope().imported_modules.contains(&module_name)
+                        if self
+                            .active_module_scope()
+                            .imported_modules
+                            .contains(&module_name)
                             && let Some(&fn_idx) = self
                                 .module_scope
                                 .synthetic_module_static_methods
@@ -3554,7 +3615,9 @@ impl Interpreter {
                                 arg_values,
                                 params,
                             )?;
-                            return self.call_fn_idx_value(fn_idx, arg_vals).map(ControlFlow::Value);
+                            return self
+                                .call_fn_idx_value(fn_idx, arg_vals)
+                                .map(ControlFlow::Value);
                         }
                     }
 
@@ -3576,8 +3639,10 @@ impl Interpreter {
                                 .map(ControlFlow::Value);
                         }
 
-                        if let Some(&(module_name, type_name)) =
-                            self.active_module_scope().imported_type_namespaces.get(&seg)
+                        if let Some(&(module_name, type_name)) = self
+                            .active_module_scope()
+                            .imported_type_namespaces
+                            .get(&seg)
                             && let Some(&fn_idx) = self
                                 .module_scope
                                 .synthetic_module_static_methods
@@ -3602,12 +3667,16 @@ impl Interpreter {
                                 arg_values,
                                 params,
                             )?;
-                            return self.call_fn_idx_value(fn_idx, arg_vals).map(ControlFlow::Value);
+                            return self
+                                .call_fn_idx_value(fn_idx, arg_vals)
+                                .map(ControlFlow::Value);
                         }
 
                         if let Some(&type_idx) = self.active_module_scope().types.get(&seg)
-                            && let Some(&variant_idx) =
-                                self.active_module_scope().type_variants.get(&(type_idx, field_name))
+                            && let Some(&variant_idx) = self
+                                .active_module_scope()
+                                .type_variants
+                                .get(&(type_idx, field_name))
                         {
                             let source_order = self.args_in_source_order(args);
                             let mut out = Args::with_capacity(source_order.len());
@@ -3620,7 +3689,8 @@ impl Interpreter {
 
                         // Module-qualified call: io.println(s)
                         if self.active_module_scope().imported_modules.contains(&seg)
-                            && let Some(mod_fns) = self.active_module_scope().synthetic_modules.get(&seg)
+                            && let Some(mod_fns) =
+                                self.active_module_scope().synthetic_modules.get(&seg)
                             && let Some(&fn_idx) = mod_fns.get(&field_name)
                         {
                             let source_order = self.args_in_source_order(args);
@@ -3642,7 +3712,9 @@ impl Interpreter {
                                 arg_values,
                                 params,
                             )?;
-                            return self.call_fn_idx_value(fn_idx, arg_vals).map(ControlFlow::Value);
+                            return self
+                                .call_fn_idx_value(fn_idx, arg_vals)
+                                .map(ControlFlow::Value);
                         }
 
                         if let Some(namespace) = self.active_module_scope().visible_namespace(seg)
@@ -3735,7 +3807,9 @@ impl Interpreter {
                                 arg_values,
                                 params,
                             )?;
-                            return self.call_fn_idx_value(fn_idx, arg_vals).map(ControlFlow::Value);
+                            return self
+                                .call_fn_idx_value(fn_idx, arg_vals)
+                                .map(ControlFlow::Value);
                         }
                     }
 
@@ -3758,7 +3832,9 @@ impl Interpreter {
                                         &self.item_tree.functions[candidate].params[1..],
                                     ),
                                 })
-                                .or_else(|| self.method_candidate_for_value(&base_val, field_name, args))
+                                .or_else(|| {
+                                    self.method_candidate_for_value(&base_val, field_name, args)
+                                })
                         } else {
                             self.method_candidate_for_value(&base_val, field_name, args)
                         };
@@ -3804,8 +3880,10 @@ impl Interpreter {
                             return Ok(ControlFlow::Value(value));
                         }
                         let source_order = self.args_in_source_order(args);
-                        let method_param_count =
-                            self.item_tree.functions[fn_idx].params.len().saturating_sub(1);
+                        let method_param_count = self.item_tree.functions[fn_idx]
+                            .params
+                            .len()
+                            .saturating_sub(1);
                         let callee_name = format!(
                             "method `{}`",
                             self.item_tree.functions[fn_idx]
@@ -3814,9 +3892,7 @@ impl Interpreter {
                         );
                         let mut arg_vals = Args::with_capacity(method_param_count + 1);
                         arg_vals.push(base_val);
-                        if Self::args_are_all_positional(args)
-                            && method_param_count == args.len()
-                        {
+                        if Self::args_are_all_positional(args) && method_param_count == args.len() {
                             for idx in &source_order {
                                 arg_vals.push(eval_propagate_shared!(self, body, *idx));
                             }
@@ -3837,7 +3913,9 @@ impl Interpreter {
                                 arg_vals.push(value);
                             }
                         }
-                        return self.call_fn_idx_value(fn_idx, arg_vals).map(ControlFlow::Value);
+                        return self
+                            .call_fn_idx_value(fn_idx, arg_vals)
+                            .map(ControlFlow::Value);
                     }
 
                     // Not a method — fall through to field access + call.
@@ -4050,7 +4128,8 @@ impl Interpreter {
                 });
         }
         if path.segments.len() > 1
-            && let Some((type_idx, variant_idx)) = self.active_module_scope().resolve_constructor_path(path)
+            && let Some((type_idx, variant_idx)) =
+                self.active_module_scope().resolve_constructor_path(path)
         {
             return self.constructor_value(type_idx, variant_idx);
         }
@@ -4322,23 +4401,21 @@ impl Interpreter {
                 body_expr,
                 body,
                 env: captured_env,
-            } => {
-                self.with_call_frame(|this| {
-                    this.ensure_arity("lambda", params.len(), args.len())?;
-                    let mut env = captured_env.clone();
-                    env.push_scope();
-                    let prev_body = this.current_body.replace(body.clone());
-                    let result = (|| -> Result<Value, RuntimeError> {
-                        for (pat_idx, val) in params.iter().zip(args) {
-                            this.bind_pat(body, *pat_idx, &val, &mut env)?;
-                        }
-                        let result = this.eval_terminal_expr(&mut env, body, *body_expr)?;
-                        Ok(result.into_value())
-                    })();
-                    this.current_body = prev_body;
-                    result
-                })
-            }
+            } => self.with_call_frame(|this| {
+                this.ensure_arity("lambda", params.len(), args.len())?;
+                let mut env = captured_env.clone();
+                env.push_scope();
+                let prev_body = this.current_body.replace(body.clone());
+                let result = (|| -> Result<Value, RuntimeError> {
+                    for (pat_idx, val) in params.iter().zip(args) {
+                        this.bind_pat(body, *pat_idx, &val, &mut env)?;
+                    }
+                    let result = this.eval_terminal_expr(&mut env, body, *body_expr)?;
+                    Ok(result.into_value())
+                })();
+                this.current_body = prev_body;
+                result
+            }),
             FnValue::Constructor {
                 type_idx,
                 variant_idx,
@@ -4381,23 +4458,21 @@ impl Interpreter {
                     body_expr,
                     body,
                     env: captured_env,
-                } => {
-                    self.with_call_frame(|this| {
-                        this.ensure_arity("lambda", params.len(), args.len())?;
-                        let mut env = captured_env;
-                        env.push_scope();
-                        let prev_body = this.current_body.replace(body.clone());
-                        let result = (|| -> Result<Value, RuntimeError> {
-                            for (pat_idx, val) in params.iter().zip(args) {
-                                this.bind_pat(&body, *pat_idx, &val, &mut env)?;
-                            }
-                            let result = this.eval_terminal_expr(&mut env, &body, body_expr)?;
-                            Ok(result.into_value())
-                        })();
-                        this.current_body = prev_body;
-                        result
-                    })
-                }
+                } => self.with_call_frame(|this| {
+                    this.ensure_arity("lambda", params.len(), args.len())?;
+                    let mut env = captured_env;
+                    env.push_scope();
+                    let prev_body = this.current_body.replace(body.clone());
+                    let result = (|| -> Result<Value, RuntimeError> {
+                        for (pat_idx, val) in params.iter().zip(args) {
+                            this.bind_pat(&body, *pat_idx, &val, &mut env)?;
+                        }
+                        let result = this.eval_terminal_expr(&mut env, &body, body_expr)?;
+                        Ok(result.into_value())
+                    })();
+                    this.current_body = prev_body;
+                    result
+                }),
                 FnValue::Constructor {
                     type_idx,
                     variant_idx,
@@ -5336,12 +5411,10 @@ impl Interpreter {
                     Ok(())
                 }
             },
-            SeqPlan::Map { input, f } => {
-                self.seq_for_each_control(input, &mut |interp, item| {
-                    let mapped = interp.call_value_ref(f, smallvec::smallvec![item])?;
-                    emit(interp, mapped)
-                })
-            }
+            SeqPlan::Map { input, f } => self.seq_for_each_control(input, &mut |interp, item| {
+                let mapped = interp.call_value_ref(f, smallvec::smallvec![item])?;
+                emit(interp, mapped)
+            }),
             SeqPlan::FlatMap { input, f } => {
                 self.seq_for_each_control(input, &mut |interp, item| {
                     let produced = interp.call_value_ref(f, smallvec::smallvec![item])?;
@@ -6102,7 +6175,8 @@ impl Interpreter {
                 let plan = self.require_traversal_plan(&args[0], "seq_fold")?;
                 let mut acc = args[1].clone();
                 self.seq_for_each(&plan, &mut |interp, item| {
-                    acc = interp.call_value_ref(&args[2], smallvec::smallvec![acc.clone(), item])?;
+                    acc =
+                        interp.call_value_ref(&args[2], smallvec::smallvec![acc.clone(), item])?;
                     Ok(())
                 })?;
                 Ok(acc)
@@ -6257,7 +6331,8 @@ impl Interpreter {
                 let plan = self.require_traversal_plan(&args[0], "seq_find")?;
                 let mut found: Option<Value> = None;
                 self.seq_for_each_control(&plan, &mut |interp, item| {
-                    let keep = interp.call_value_ref(&args[1], smallvec::smallvec![item.clone()])?;
+                    let keep =
+                        interp.call_value_ref(&args[1], smallvec::smallvec![item.clone()])?;
                     match keep {
                         Value::Bool(true) => {
                             found = Some(item);
@@ -6556,7 +6631,10 @@ impl Interpreter {
         if let Expr::Path(path) = &body.exprs[base_idx]
             && path.is_single()
             && let Some(&type_idx) = self.active_module_scope().types.get(&path.segments[0])
-            && let Some(&variant_idx) = self.active_module_scope().type_variants.get(&(type_idx, field))
+            && let Some(&variant_idx) = self
+                .active_module_scope()
+                .type_variants
+                .get(&(type_idx, field))
         {
             return Some(self.constructor_value(type_idx, variant_idx));
         }
@@ -6571,7 +6649,10 @@ impl Interpreter {
             let module_name = module_path.segments[0];
             if let Some(namespace) = self.active_module_scope().visible_namespace(module_name)
                 && let Some(&type_idx) = namespace.types.get(type_name)
-                && let Some(&variant_idx) = self.active_module_scope().type_variants.get(&(type_idx, field))
+                && let Some(&variant_idx) = self
+                    .active_module_scope()
+                    .type_variants
+                    .get(&(type_idx, field))
             {
                 return Some(self.constructor_value(type_idx, variant_idx));
             }

--- a/crates/eval/src/lib.rs
+++ b/crates/eval/src/lib.rs
@@ -327,8 +327,10 @@ pub fn run_project_with_manifest(
         kyokara_hir_def::item_tree::FnItemIdx,
         FxHashMap<kyokara_hir_def::name::Name, Vec<kyokara_hir_def::item_tree::FnItemIdx>>,
     > = FxHashMap::default();
-    let mut module_scope_overrides: FxHashMap<kyokara_hir_def::item_tree::FnItemIdx, kyokara_hir_def::resolver::ModuleScope> =
-        FxHashMap::default();
+    let mut module_scope_overrides: FxHashMap<
+        kyokara_hir_def::item_tree::FnItemIdx,
+        kyokara_hir_def::resolver::ModuleScope,
+    > = FxHashMap::default();
     let mut let_scope_overrides: FxHashMap<
         kyokara_hir_def::item_tree::FnItemIdx,
         FxHashMap<kyokara_hir_def::name::Name, Value>,
@@ -389,7 +391,8 @@ pub fn run_project_with_manifest(
 
                 if let Some(namespace_names) = imported_namespace_names.get(mod_path) {
                     for namespace_name in namespace_names {
-                        let Some(namespace) = entry_info.scope.namespaces.get(namespace_name) else {
+                        let Some(namespace) = entry_info.scope.namespaces.get(namespace_name)
+                        else {
                             continue;
                         };
                         let Some(namespace_candidates) = namespace.functions.get(&src_fn_item.name)
@@ -434,7 +437,10 @@ pub fn run_project_with_manifest(
         }
 
         // Attach the same module-local map to every function from this module.
-        for fn_idx in module_fn_map.values().flat_map(|candidates| candidates.iter().copied()) {
+        for fn_idx in module_fn_map
+            .values()
+            .flat_map(|candidates| candidates.iter().copied())
+        {
             fn_scope_overrides.insert(fn_idx, module_fn_map.clone());
             module_scope_overrides.insert(fn_idx, mod_scope.clone());
         }
@@ -455,7 +461,10 @@ pub fn run_project_with_manifest(
             );
             let module_let_values = let_interp.materialize_top_level_let_values()?;
             project.interner = let_interp.into_interner();
-            for fn_idx in module_fn_map.values().flat_map(|candidates| candidates.iter().copied()) {
+            for fn_idx in module_fn_map
+                .values()
+                .flat_map(|candidates| candidates.iter().copied())
+            {
                 let_scope_overrides.insert(fn_idx, module_let_values.clone());
             }
         }

--- a/crates/eval/src/value.rs
+++ b/crates/eval/src/value.rs
@@ -1014,7 +1014,9 @@ impl SetValue {
         if let Ok(primitive) = MapKey::from_value(value) {
             return Ok(match &self.storage {
                 PersistentSetStorage::Primitive(entries) => entries.find_index(&primitive),
-                PersistentSetStorage::Generic(entries) => entries.find_index_with(hash, value, eq)?,
+                PersistentSetStorage::Generic(entries) => {
+                    entries.find_index_with(hash, value, eq)?
+                }
             });
         }
         match &self.storage {
@@ -2042,10 +2044,9 @@ impl BoolListValue {
     fn to_values(&self) -> Vec<Value> {
         let mut out = Vec::with_capacity(self.len);
         for idx in 0..self.len {
-            out.push(Value::Bool(
-                self.get(idx)
-                    .expect("bool list index should stay in bounds while materializing"),
-            ));
+            out.push(Value::Bool(self.get(idx).expect(
+                "bool list index should stay in bounds while materializing",
+            )));
         }
         out
     }
@@ -2227,7 +2228,9 @@ impl MutableListValue {
         let items = self.items.borrow();
         match &*items {
             MutableListStorage::Generic(items) => Rc::as_ptr(items),
-            MutableListStorage::Bool(_) => panic!("current_backing_ptr only applies to generic list storage"),
+            MutableListStorage::Bool(_) => {
+                panic!("current_backing_ptr only applies to generic list storage")
+            }
         }
     }
 
@@ -3327,7 +3330,10 @@ mod tests {
     #[test]
     fn primitive_persistent_map_remove_reinsert_appends_to_end() {
         let mut map = PrimitivePersistentMapValue::new();
-        assert!(map.is_empty(), "new primitive persistent map should start empty");
+        assert!(
+            map.is_empty(),
+            "new primitive persistent map should start empty"
+        );
 
         map.insert(MapKey::String("b".into()), Value::Int(1));
         map.insert(MapKey::String("a".into()), Value::Int(2));
@@ -3353,7 +3359,10 @@ mod tests {
     #[test]
     fn primitive_persistent_set_remove_reinsert_appends_to_end() {
         let mut set = PrimitivePersistentSetValue::new();
-        assert!(set.is_empty(), "new primitive persistent set should start empty");
+        assert!(
+            set.is_empty(),
+            "new primitive persistent set should start empty"
+        );
 
         set.insert(MapKey::String("b".into()));
         set.insert(MapKey::String("a".into()));

--- a/crates/eval/tests/eval_tests.rs
+++ b/crates/eval/tests/eval_tests.rs
@@ -216,7 +216,10 @@ fn eval_function_body_can_read_top_level_let() {
 fn eval_imported_module_function_can_read_its_top_level_let() {
     let val = run_project_with_files_manifest_ok(
         &[
-            ("main.ky", "from util import util\nfn main() -> Int { util() }"),
+            (
+                "main.ky",
+                "from util import util\nfn main() -> Int { util() }",
+            ),
             ("util.ky", "let off = 1\npub fn util() -> Int { off }"),
         ],
         None,

--- a/crates/hir-def/src/body/lower.rs
+++ b/crates/hir-def/src/body/lower.rs
@@ -1279,14 +1279,9 @@ impl BodyLowerCtx<'_> {
                     .resolve(self.interner)
                     .starts_with(|c: char| c.is_uppercase());
 
-                if is_constructor
-                    && self.module_scope.resolve_constructor_path(&path).is_some()
-                {
+                if is_constructor && self.module_scope.resolve_constructor_path(&path).is_some() {
                     // Nullary constructor pattern
-                    let pat_idx = self.alloc_pat(pat::Pat::Constructor {
-                        path,
-                        args: vec![],
-                    });
+                    let pat_idx = self.alloc_pat(pat::Pat::Constructor { path, args: vec![] });
                     self.pat_source_map
                         .insert(pat_idx, ip.syntax().text_range());
                     pat_idx

--- a/crates/hir-def/src/builtins.rs
+++ b/crates/hir-def/src/builtins.rs
@@ -1434,7 +1434,9 @@ pub fn activate_type_member_imports(tree: &ItemTree, scope: &mut ModuleScope) {
             scope
                 .imported_variants
                 .insert(visible_name, (type_idx, variant_idx));
-            scope.constructors.insert(visible_name, (type_idx, variant_idx));
+            scope
+                .constructors
+                .insert(visible_name, (type_idx, variant_idx));
         }
     }
 }

--- a/crates/hir-def/src/call_family.rs
+++ b/crates/hir-def/src/call_family.rs
@@ -27,9 +27,17 @@ impl CallArgBinding {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum CallFamilySelection<T> {
-    Selected { candidate: T, binding: CallArgBinding },
-    InvalidShape { errors: Vec<CallShapeError> },
-    ArgCountMismatch { expected: Vec<usize>, actual: usize },
+    Selected {
+        candidate: T,
+        binding: CallArgBinding,
+    },
+    InvalidShape {
+        errors: Vec<CallShapeError>,
+    },
+    ArgCountMismatch {
+        expected: Vec<usize>,
+        actual: usize,
+    },
     Ambiguous,
 }
 
@@ -62,7 +70,8 @@ pub fn bind_call_args_to_params(args: &[CallArg], params: &[FnParam]) -> CallArg
                     suppress_missing_args = true;
                     continue;
                 }
-                while next_pos < binding.param_to_arg.len() && binding.param_to_arg[next_pos].is_some()
+                while next_pos < binding.param_to_arg.len()
+                    && binding.param_to_arg[next_pos].is_some()
                 {
                     next_pos += 1;
                 }
@@ -251,7 +260,10 @@ mod tests {
     #[test]
     fn bind_rejects_positional_for_named_only_param() {
         let mut interner = Interner::default();
-        let params = vec![param(&mut interner, "prefix"), named_only_param(&mut interner, "start")];
+        let params = vec![
+            param(&mut interner, "prefix"),
+            named_only_param(&mut interner, "start"),
+        ];
         let binding = bind_call_args_to_params(&[pos(0), pos(1)], &params);
         assert_eq!(
             binding.errors,
@@ -264,11 +276,12 @@ mod tests {
     #[test]
     fn bind_accepts_named_only_param_when_named() {
         let mut interner = Interner::default();
-        let params = vec![param(&mut interner, "prefix"), named_only_param(&mut interner, "start")];
-        let binding = bind_call_args_to_params(
-            &[pos(0), named(&mut interner, "start", 1)],
-            &params,
-        );
+        let params = vec![
+            param(&mut interner, "prefix"),
+            named_only_param(&mut interner, "start"),
+        ];
+        let binding =
+            bind_call_args_to_params(&[pos(0), named(&mut interner, "start", 1)], &params);
         assert!(binding.errors.is_empty(), "{binding:?}");
         assert_eq!(binding.param_to_arg, vec![Some(0), Some(1)]);
     }
@@ -277,14 +290,18 @@ mod tests {
     fn family_selects_by_named_arg_presence() {
         let mut interner = Interner::default();
         let prefix_only = vec![param(&mut interner, "prefix")];
-        let with_offset = vec![param(&mut interner, "prefix"), named_only_param(&mut interner, "start")];
+        let with_offset = vec![
+            param(&mut interner, "prefix"),
+            named_only_param(&mut interner, "start"),
+        ];
         let families = [0usize, 1usize];
         let args = [pos(0), named(&mut interner, "start", 1)];
-        let selection = select_call_family_candidate(&args, &families, |candidate| match candidate {
-            0 => prefix_only.as_slice(),
-            1 => with_offset.as_slice(),
-            _ => unreachable!(),
-        });
+        let selection =
+            select_call_family_candidate(&args, &families, |candidate| match candidate {
+                0 => prefix_only.as_slice(),
+                1 => with_offset.as_slice(),
+                _ => unreachable!(),
+            });
         assert!(matches!(
             selection,
             CallFamilySelection::Selected { candidate: 1, .. }
@@ -295,14 +312,18 @@ mod tests {
     fn family_reports_shape_error_before_family_arity_error() {
         let mut interner = Interner::default();
         let prefix_only = vec![param(&mut interner, "prefix")];
-        let with_offset = vec![param(&mut interner, "prefix"), named_only_param(&mut interner, "start")];
+        let with_offset = vec![
+            param(&mut interner, "prefix"),
+            named_only_param(&mut interner, "start"),
+        ];
         let families = [0usize, 1usize];
         let args = [pos(0), pos(1)];
-        let selection = select_call_family_candidate(&args, &families, |candidate| match candidate {
-            0 => prefix_only.as_slice(),
-            1 => with_offset.as_slice(),
-            _ => unreachable!(),
-        });
+        let selection =
+            select_call_family_candidate(&args, &families, |candidate| match candidate {
+                0 => prefix_only.as_slice(),
+                1 => with_offset.as_slice(),
+                _ => unreachable!(),
+            });
         assert_eq!(
             selection,
             CallFamilySelection::InvalidShape {
@@ -320,11 +341,12 @@ mod tests {
         let one = vec![param(&mut interner, "predicate")];
         let families = [0usize, 1usize];
         let args = [pos(0), pos(1)];
-        let selection = select_call_family_candidate(&args, &families, |candidate| match candidate {
-            0 => zero.as_slice(),
-            1 => one.as_slice(),
-            _ => unreachable!(),
-        });
+        let selection =
+            select_call_family_candidate(&args, &families, |candidate| match candidate {
+                0 => zero.as_slice(),
+                1 => one.as_slice(),
+                _ => unreachable!(),
+            });
         assert_eq!(
             selection,
             CallFamilySelection::ArgCountMismatch {
@@ -347,13 +369,14 @@ mod tests {
         ];
         let families = [0usize, 1usize, 2usize, 3usize];
         let args = [pos(0), pos(1)];
-        let selection = select_call_family_candidate(&args, &families, |candidate| match candidate {
-            0 => zero.as_slice(),
-            1 => one_a.as_slice(),
-            2 => one_b.as_slice(),
-            3 => three.as_slice(),
-            _ => unreachable!(),
-        });
+        let selection =
+            select_call_family_candidate(&args, &families, |candidate| match candidate {
+                0 => zero.as_slice(),
+                1 => one_a.as_slice(),
+                2 => one_b.as_slice(),
+                3 => three.as_slice(),
+                _ => unreachable!(),
+            });
         assert_eq!(
             selection,
             CallFamilySelection::ArgCountMismatch {
@@ -408,8 +431,14 @@ mod tests {
     #[test]
     fn overlap_allows_distinct_named_suffix_shapes() {
         let mut interner = Interner::default();
-        let lhs = vec![param(&mut interner, "prefix"), named_only_param(&mut interner, "start")];
-        let rhs = vec![param(&mut interner, "prefix"), named_only_param(&mut interner, "offset")];
+        let lhs = vec![
+            param(&mut interner, "prefix"),
+            named_only_param(&mut interner, "start"),
+        ];
+        let rhs = vec![
+            param(&mut interner, "prefix"),
+            named_only_param(&mut interner, "offset"),
+        ];
         assert!(!call_shapes_overlap(&lhs, &rhs));
     }
 
@@ -417,7 +446,10 @@ mod tests {
     fn overlap_blocks_positional_and_named_only_same_arity_family() {
         let mut interner = Interner::default();
         let lhs = vec![param(&mut interner, "x"), param(&mut interner, "y")];
-        let rhs = vec![param(&mut interner, "x"), named_only_param(&mut interner, "y")];
+        let rhs = vec![
+            param(&mut interner, "x"),
+            named_only_param(&mut interner, "y"),
+        ];
         assert!(call_shapes_overlap(&lhs, &rhs));
     }
 }

--- a/crates/hir-def/src/item_tree.rs
+++ b/crates/hir-def/src/item_tree.rs
@@ -50,12 +50,8 @@ pub struct Import {
 
 #[derive(Debug, Clone)]
 pub enum ImportKind {
-    Namespace {
-        alias: Option<Name>,
-    },
-    Members {
-        members: Vec<ImportMemberItem>,
-    },
+    Namespace { alias: Option<Name> },
+    Members { members: Vec<ImportMemberItem> },
 }
 
 #[derive(Debug, Clone)]

--- a/crates/hir-def/src/item_tree/lower.rs
+++ b/crates/hir-def/src/item_tree/lower.rs
@@ -337,7 +337,9 @@ impl ItemTreeCtx<'_> {
         // Register constructors for ADTs
         if let TypeDefKind::Adt { ref variants } = kind {
             for (vi, variant) in variants.iter().enumerate() {
-                self.module_scope.type_variants.insert((idx, variant.name), vi);
+                self.module_scope
+                    .type_variants
+                    .insert((idx, variant.name), vi);
             }
         }
     }

--- a/crates/hir-def/tests/lower_tests.rs
+++ b/crates/hir-def/tests/lower_tests.rs
@@ -3,8 +3,8 @@
 
 use kyokara_hir_def::body::lower::lower_body;
 use kyokara_hir_def::expr::{BinaryOp, CallArg, Expr, Literal, Stmt, UnaryOp};
-use kyokara_hir_def::item_tree::{ImportKind, TypeDefKind};
 use kyokara_hir_def::item_tree::lower::collect_item_tree;
+use kyokara_hir_def::item_tree::{ImportKind, TypeDefKind};
 use kyokara_hir_def::pat::Pat;
 use kyokara_intern::Interner;
 use kyokara_span::FileId;
@@ -81,11 +81,18 @@ fn collect_adt_with_constructors() {
     let type_idx = result.tree.types.iter().next().unwrap().0;
     let just = kyokara_hir_def::name::Name::new(&mut interner, "Just");
     let nothing = kyokara_hir_def::name::Name::new(&mut interner, "Nothing");
-    assert!(result.module_scope.type_variants.contains_key(&(type_idx, just)));
-    assert!(result
-        .module_scope
-        .type_variants
-        .contains_key(&(type_idx, nothing)));
+    assert!(
+        result
+            .module_scope
+            .type_variants
+            .contains_key(&(type_idx, just))
+    );
+    assert!(
+        result
+            .module_scope
+            .type_variants
+            .contains_key(&(type_idx, nothing))
+    );
 }
 
 #[test]
@@ -131,7 +138,11 @@ fn collect_trait_impl_and_derive_items() {
 
     let impl_item = &result.tree.impls[result.tree.impls.iter().next().unwrap().0];
     assert_eq!(impl_item.methods.len(), 1);
-    assert!(result.diagnostics.is_empty(), "unexpected diagnostics: {:?}", result.diagnostics);
+    assert!(
+        result.diagnostics.is_empty(),
+        "unexpected diagnostics: {:?}",
+        result.diagnostics
+    );
 }
 
 #[test]

--- a/crates/hir-ty/src/infer/expr.rs
+++ b/crates/hir-ty/src/infer/expr.rs
@@ -638,8 +638,7 @@ impl<'a> InferenceCtx<'a> {
     }
 
     fn infer_call(&mut self, callee: ExprIdx, args: &[CallArg]) -> Ty {
-        if let Expr::Path(path) = &self.body.exprs[callee]
-        {
+        if let Expr::Path(path) = &self.body.exprs[callee] {
             if path.is_single() {
                 let name = path.segments[0];
                 if let Some(resolved) = self.body.resolve_name_at(self.module_scope, callee, name)
@@ -1696,8 +1695,7 @@ impl<'a> InferenceCtx<'a> {
                         });
                         for arg in args {
                             match arg {
-                                CallArg::Positional(expr)
-                                | CallArg::Named { value: expr, .. } => {
+                                CallArg::Positional(expr) | CallArg::Named { value: expr, .. } => {
                                     self.infer_expr(*expr, &Expectation::None);
                                 }
                             }
@@ -1706,8 +1704,7 @@ impl<'a> InferenceCtx<'a> {
                     }
                     for (arg, param_ty) in args.iter().zip(params.iter()) {
                         match arg {
-                            CallArg::Positional(expr)
-                            | CallArg::Named { value: expr, .. } => {
+                            CallArg::Positional(expr) | CallArg::Named { value: expr, .. } => {
                                 self.infer_expr(*expr, &Expectation::Has(param_ty.clone()));
                             }
                         }
@@ -1756,7 +1753,8 @@ impl<'a> InferenceCtx<'a> {
         {
             let name = path.segments[0];
 
-            if let Some(&(module_name, type_name)) = self.module_scope.imported_type_namespaces.get(&name)
+            if let Some(&(module_name, type_name)) =
+                self.module_scope.imported_type_namespaces.get(&name)
                 && let Some(&fn_idx) = self.module_scope.synthetic_module_static_methods.get(&(
                     module_name,
                     type_name,
@@ -1785,8 +1783,7 @@ impl<'a> InferenceCtx<'a> {
                         });
                         for arg in args {
                             match arg {
-                                CallArg::Positional(expr)
-                                | CallArg::Named { value: expr, .. } => {
+                                CallArg::Positional(expr) | CallArg::Named { value: expr, .. } => {
                                     self.infer_expr(*expr, &Expectation::None);
                                 }
                             }
@@ -1795,8 +1792,7 @@ impl<'a> InferenceCtx<'a> {
                     }
                     for (arg, param_ty) in args.iter().zip(params.iter()) {
                         match arg {
-                            CallArg::Positional(expr)
-                            | CallArg::Named { value: expr, .. } => {
+                            CallArg::Positional(expr) | CallArg::Named { value: expr, .. } => {
                                 self.infer_expr(*expr, &Expectation::Has(param_ty.clone()));
                             }
                         }
@@ -2023,11 +2019,13 @@ impl<'a> InferenceCtx<'a> {
                 return Some(self.infer_trait_qualified_call(owner, *field, args));
             }
 
-            if let Some(&(module_name, type_name)) = self.module_scope.imported_type_namespaces.get(&owner)
-                && let Some(&fn_idx) = self
-                    .module_scope
-                    .synthetic_module_static_methods
-                    .get(&(module_name, type_name, *field))
+            if let Some(&(module_name, type_name)) =
+                self.module_scope.imported_type_namespaces.get(&owner)
+                && let Some(&fn_idx) = self.module_scope.synthetic_module_static_methods.get(&(
+                    module_name,
+                    type_name,
+                    *field,
+                ))
             {
                 let ty = self.infer_qualified_fn_call(callee, fn_idx, args);
                 if type_name.resolve(self.interner) == "MutablePriorityQueue"
@@ -2071,10 +2069,11 @@ impl<'a> InferenceCtx<'a> {
             let module_name = base_segments[0];
             let type_name = base_segments[1];
             if self.module_scope.imported_modules.contains(&module_name)
-                && let Some(&fn_idx) = self
-                    .module_scope
-                    .synthetic_module_static_methods
-                    .get(&(module_name, type_name, *field))
+                && let Some(&fn_idx) = self.module_scope.synthetic_module_static_methods.get(&(
+                    module_name,
+                    type_name,
+                    *field,
+                ))
             {
                 let ty = self.infer_qualified_fn_call(callee, fn_idx, args);
                 if type_name.resolve(self.interner) == "MutablePriorityQueue"
@@ -2253,12 +2252,7 @@ impl<'a> InferenceCtx<'a> {
             .params
             .iter()
             .map(|param| {
-                self.resolve_trait_method_type(
-                    &param.ty,
-                    &recv_ty,
-                    &env,
-                    &trait_type_params,
-                )
+                self.resolve_trait_method_type(&param.ty, &recv_ty, &env, &trait_type_params)
             })
             .collect::<Vec<_>>();
         let param_names = method.params.iter().map(|p| p.name).collect::<Vec<_>>();
@@ -2271,9 +2265,7 @@ impl<'a> InferenceCtx<'a> {
         method
             .ret_type
             .as_ref()
-            .map(|ret| {
-                self.resolve_trait_method_type(ret, &recv_ty, &env, &trait_type_params)
-            })
+            .map(|ret| self.resolve_trait_method_type(ret, &recv_ty, &env, &trait_type_params))
             .unwrap_or(Ty::Unit)
     }
 

--- a/crates/hir-ty/src/lib.rs
+++ b/crates/hir-ty/src/lib.rs
@@ -24,6 +24,7 @@ use kyokara_hir_def::body::lower::{
     lower_body, lower_impl_method_body, lower_property_body, lower_top_level_let_body,
 };
 use kyokara_hir_def::item_tree::{FnItemIdx, ItemTree, LetItemIdx};
+use kyokara_hir_def::name::Name;
 use kyokara_hir_def::resolver::ModuleScope;
 use kyokara_hir_def::type_ref::TypeRef;
 use kyokara_intern::Interner;
@@ -32,7 +33,6 @@ use kyokara_stdx::FxHashMap;
 use kyokara_syntax::SyntaxNode;
 use kyokara_syntax::ast::AstNode;
 use kyokara_syntax::ast::nodes::{FnDef, ImplMethodDef, LetBinding, PropertyDef};
-use kyokara_hir_def::name::Name;
 
 use crate::diagnostics::TyDiagnosticData;
 use crate::infer::InferenceResult;
@@ -443,8 +443,8 @@ mod tests {
 
         let beta = &fn_defs[1];
         let beta_range = beta.syntax().text_range();
-        let by_range = lookup_fn_def(&index, Some(beta_range))
-            .expect("range lookup should prefer exact node");
+        let by_range =
+            lookup_fn_def(&index, Some(beta_range)).expect("range lookup should prefer exact node");
         assert_eq!(by_range.syntax().text_range(), beta_range);
     }
 

--- a/crates/hir/src/lib.rs
+++ b/crates/hir/src/lib.rs
@@ -533,13 +533,12 @@ fn resolve_project_imports(
                 importing_info.scope.imported_modules.remove(&visible_name);
                 let mut namespace = kyokara_hir_def::resolver::NamespaceScope::default();
                 for item in pub_data {
-                    import_pub_item_into_namespace(
-                        importing_info,
-                        &mut namespace,
-                        item,
-                    );
+                    import_pub_item_into_namespace(importing_info, &mut namespace, item);
                 }
-                importing_info.scope.namespaces.insert(visible_name, namespace);
+                importing_info
+                    .scope
+                    .namespaces
+                    .insert(visible_name, namespace);
             }
             ImportKind::Members { members } => {
                 for member in members {

--- a/crates/kir/src/lower/expr.rs
+++ b/crates/kir/src/lower/expr.rs
@@ -2,7 +2,9 @@
 
 use rustc_hash::FxHashSet;
 
-use kyokara_hir_def::call_family::{CallFamilySelection, bind_call_args_to_params, select_call_family_candidate};
+use kyokara_hir_def::call_family::{
+    CallFamilySelection, bind_call_args_to_params, select_call_family_candidate,
+};
 use kyokara_hir_def::expr::{BinaryOp, CallArg, Expr, ExprIdx, Literal, MatchArm, Stmt};
 use kyokara_hir_def::item_tree::TypeDefKind;
 use kyokara_hir_def::name::Name;
@@ -50,8 +52,7 @@ impl<'a> LoweringCtx<'a> {
             }
             Expr::Call { callee, args } => self.lower_call(callee, args, ty),
             Expr::Field { base, field } => {
-                if let Some(value) =
-                    self.try_lower_constructor_field_value(base, field, ty.clone())
+                if let Some(value) = self.try_lower_constructor_field_value(base, field, ty.clone())
                 {
                     return value;
                 }
@@ -164,7 +165,10 @@ impl<'a> LoweringCtx<'a> {
                 if !is_nullary {
                     return None;
                 }
-                Some(this.builder.push_adt_construct(type_idx, field, vec![], ty.clone()))
+                Some(
+                    this.builder
+                        .push_adt_construct(type_idx, field, vec![], ty.clone()),
+                )
             };
 
         if let Expr::Path(path) = &self.body.exprs[base_idx]
@@ -419,7 +423,9 @@ impl<'a> LoweringCtx<'a> {
             if let Some((type_idx, _)) = self.module_scope.resolve_constructor_path(path) {
                 let arg_vals = self.lower_call_args_source_order(&args);
                 let ctor_name = *path.segments.last().unwrap_or(&name);
-                return self.builder.push_adt_construct(type_idx, ctor_name, arg_vals, ty);
+                return self
+                    .builder
+                    .push_adt_construct(type_idx, ctor_name, arg_vals, ty);
             }
 
             // 3. Module-level function (direct call — user-defined takes precedence).
@@ -477,10 +483,15 @@ impl<'a> LoweringCtx<'a> {
                 let module_name = module_path.segments[0];
                 if let Some(namespace) = self.module_scope.visible_namespace(module_name)
                     && let Some(&type_idx) = namespace.types.get(&type_name)
-                    && self.module_scope.type_variants.contains_key(&(type_idx, field))
+                    && self
+                        .module_scope
+                        .type_variants
+                        .contains_key(&(type_idx, field))
                 {
                     let arg_vals = self.lower_call_args_source_order(&args);
-                    return self.builder.push_adt_construct(type_idx, field, arg_vals, ty);
+                    return self
+                        .builder
+                        .push_adt_construct(type_idx, field, arg_vals, ty);
                 }
                 if self.module_scope.imported_modules.contains(&module_name)
                     && let Some(&fn_idx) = self.module_scope.synthetic_module_static_methods.get(&(
@@ -507,10 +518,15 @@ impl<'a> LoweringCtx<'a> {
                 let seg = path.segments[0];
 
                 if let Some(&type_idx) = self.module_scope.types.get(&seg)
-                    && self.module_scope.type_variants.contains_key(&(type_idx, field))
+                    && self
+                        .module_scope
+                        .type_variants
+                        .contains_key(&(type_idx, field))
                 {
                     let arg_vals = self.lower_call_args_source_order(&args);
-                    return self.builder.push_adt_construct(type_idx, field, arg_vals, ty);
+                    return self
+                        .builder
+                        .push_adt_construct(type_idx, field, arg_vals, ty);
                 }
 
                 // Module-qualified call: io.println(s), math.min(a, b)
@@ -598,7 +614,9 @@ impl<'a> LoweringCtx<'a> {
                             .get(&(ReceiverKey::Any, field))
                             .map(Vec::as_slice)
                     })
-                    .map(|candidates| self.select_method_candidate_by_call_shape(candidates, &args));
+                    .map(|candidates| {
+                        self.select_method_candidate_by_call_shape(candidates, &args)
+                    });
                 match selection {
                     Some(CallFamilySelection::Selected { candidate, .. }) => Some(candidate),
                     _ => None,

--- a/crates/lsp/src/position.rs
+++ b/crates/lsp/src/position.rs
@@ -246,12 +246,9 @@ pub fn symbol_at_offset_with_scope(
                     .types
                     .iter()
                     .find(|(name, _)| name.resolve(interner) == type_name)
-                && module_scope
-                    .type_variants
-                    .keys()
-                    .any(|(owner, variant)| {
-                        *owner == type_idx && variant.resolve(interner) == field_name
-                    })
+                && module_scope.type_variants.keys().any(|(owner, variant)| {
+                    *owner == type_idx && variant.resolve(interner) == field_name
+                })
             {
                 return SymbolAtPosition::Variant {
                     name: field_name.clone(),

--- a/crates/lsp/src/server.rs
+++ b/crates/lsp/src/server.rs
@@ -81,11 +81,7 @@ impl KyokaraLanguageServer {
 
     #[cfg(test)]
     async fn maybe_delay_before_publish(&self, text: &str) {
-        let delay_yields = self
-            .test_pre_publish_delay_yields
-            .lock()
-            .get(text)
-            .copied();
+        let delay_yields = self.test_pre_publish_delay_yields.lock().get(text).copied();
         if let Some(ticks) = delay_yields {
             for _ in 0..ticks {
                 tokio::task::yield_now().await;
@@ -132,7 +128,10 @@ impl KyokaraLanguageServer {
             #[cfg(test)]
             self.maybe_delay_before_publish(&text).await;
 
-            self.documents.write().await.insert(uri.clone(), analysis.clone());
+            self.documents
+                .write()
+                .await
+                .insert(uri.clone(), analysis.clone());
 
             // Publish diagnostics.
             let diags = crate::diagnostics::to_lsp_diagnostics(&analysis, &analysis.source);

--- a/crates/parser/src/grammar/expressions.rs
+++ b/crates/parser/src/grammar/expressions.rs
@@ -15,9 +15,9 @@
 //! - Prefix `!` `-` `~`: right_bp 23
 //! - Postfix `?` `.` `()` `[]` : left_bp 25
 
+use crate::SyntaxKind::*;
 use crate::parser::{CompletedMarker, IdentifierRole, Parser};
 use crate::token_set::TokenSet;
-use crate::SyntaxKind::*;
 
 /// Tokens that signal we should stop parsing an expression (recovery).
 const EXPR_RECOVERY: TokenSet = TokenSet::new(&[
@@ -365,7 +365,7 @@ fn match_arm(p: &mut Parser<'_>) {
 fn return_expr(p: &mut Parser<'_>) -> CompletedMarker {
     let m = p.open();
     p.bump(); // return
-              // Parse expression if the next token can start one.
+    // Parse expression if the next token can start one.
     if can_start_expr_or_keyword(p.current()) {
         expr(p);
     }

--- a/crates/parser/src/grammar/items.rs
+++ b/crates/parser/src/grammar/items.rs
@@ -335,7 +335,10 @@ fn trait_def(p: &mut Parser<'_>, is_pub: bool) -> CompletedMarker {
         if p.at(FnKw) {
             trait_method_sig(p);
         } else {
-            p.error_recover("expected trait method signature", TokenSet::new(&[FnKw, RBrace]));
+            p.error_recover(
+                "expected trait method signature",
+                TokenSet::new(&[FnKw, RBrace]),
+            );
         }
     }
     p.expect(RBrace);
@@ -388,7 +391,10 @@ fn impl_def(p: &mut Parser<'_>) -> CompletedMarker {
         if p.at(FnKw) {
             impl_method_def(p);
         } else {
-            p.error_recover("expected impl method definition", TokenSet::new(&[FnKw, RBrace]));
+            p.error_recover(
+                "expected impl method definition",
+                TokenSet::new(&[FnKw, RBrace]),
+            );
         }
     }
     p.expect(RBrace);

--- a/crates/parser/src/parser.rs
+++ b/crates/parser/src/parser.rs
@@ -3,10 +3,10 @@
 //! Provides [`Parser`], [`Marker`], and [`CompletedMarker`] — the core
 //! API used by grammar modules to build the event stream.
 
+use crate::SyntaxKind;
 use crate::event::Event;
 use crate::input::Input;
 use crate::token_set::TokenSet;
-use crate::SyntaxKind;
 
 /// A parse error message with location info.
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/parser/tests/parser_tests.rs
+++ b/crates/parser/tests/parser_tests.rs
@@ -1,8 +1,8 @@
 //! Parser unit tests — verify event structure for various constructs.
 #![allow(clippy::unwrap_used)]
 
-use kyokara_parser::{parse, Event, Input, ParseError, SyntaxKind};
 use SyntaxKind::*;
+use kyokara_parser::{Event, Input, ParseError, SyntaxKind, parse};
 
 /// Helper: lex token kinds from a list (simulating a lexer), build Input, parse.
 fn parse_tokens(kinds: &[SyntaxKind]) -> (Vec<Event>, Vec<ParseError>) {
@@ -50,7 +50,9 @@ fn source_file_rejects_top_level_module_decl_without_cascade() {
     let (events, errors) = parse_tokens(&[ModuleKw, Ident, Dot, Ident, ImportKw, Ident]);
     assert_eq!(errors.len(), 1, "expected one parse error, got: {errors:?}");
     assert!(
-        errors[0].message.contains("unexpected `module` at top level"),
+        errors[0]
+            .message
+            .contains("unexpected `module` at top level"),
         "expected targeted top-level module diagnostic, got: {errors:?}"
     );
     assert!(has_node(&events, SourceFile));
@@ -68,9 +70,8 @@ fn import_decl() {
 
 #[test]
 fn from_import_decl() {
-    let (events, errors) = parse_tokens(&[
-        FromKw, Ident, ImportKw, Ident, Comma, Ident, AsKw, Ident,
-    ]);
+    let (events, errors) =
+        parse_tokens(&[FromKw, Ident, ImportKw, Ident, Comma, Ident, AsKw, Ident]);
     assert!(has_no_errors(&errors));
     assert!(has_node(&events, ImportDecl));
     assert!(has_node(&events, ImportMemberList));
@@ -155,7 +156,10 @@ fn let_binding_with_type() {
 #[test]
 fn let_binding_named_module_parses() {
     let (events, errors) = parse_tokens(&[LetKw, ModuleKw, Eq, IntLiteral]);
-    assert!(has_no_errors(&errors), "expected no parse errors: {errors:?}");
+    assert!(
+        has_no_errors(&errors),
+        "expected no parse errors: {errors:?}"
+    );
     assert!(has_node(&events, LetBinding));
 }
 
@@ -1085,7 +1089,10 @@ fn malformed_range_until_reports_single_targeted_error() {
 #[test]
 fn range_until_module_rhs_parses() {
     let (events, errors) = parse_tokens(&[LetKw, Ident, Eq, IntLiteral, DotDotLt, ModuleKw]);
-    assert!(has_no_errors(&errors), "expected no parse errors: {errors:?}");
+    assert!(
+        has_no_errors(&errors),
+        "expected no parse errors: {errors:?}"
+    );
     assert!(has_node(&events, BinaryExpr));
 }
 
@@ -1352,7 +1359,10 @@ fn return_expr() {
 #[test]
 fn bare_module_expression_parses() {
     let (events, errors) = parse_tokens(&[FnKw, Ident, LParen, RParen, LBrace, ModuleKw, RBrace]);
-    assert!(has_no_errors(&errors), "expected no parse errors: {errors:?}");
+    assert!(
+        has_no_errors(&errors),
+        "expected no parse errors: {errors:?}"
+    );
     assert!(has_node(&events, PathExpr));
 }
 
@@ -1361,7 +1371,10 @@ fn return_module_expression_parses() {
     let (events, errors) = parse_tokens(&[
         FnKw, Ident, LParen, RParen, LBrace, ReturnKw, ModuleKw, RBrace,
     ]);
-    assert!(has_no_errors(&errors), "expected no parse errors: {errors:?}");
+    assert!(
+        has_no_errors(&errors),
+        "expected no parse errors: {errors:?}"
+    );
     assert!(has_node(&events, ReturnExpr));
 }
 

--- a/crates/refactor/src/rename.rs
+++ b/crates/refactor/src/rename.rs
@@ -9,9 +9,9 @@ use kyokara_hir::{CheckResult, ProjectCheckResult};
 use kyokara_intern::Interner;
 use kyokara_parser::SyntaxKind;
 use kyokara_span::FileId;
-use kyokara_syntax::{SyntaxNode, SyntaxToken};
 use kyokara_syntax::ast::AstNode;
 use kyokara_syntax::ast::nodes::ImportMember;
+use kyokara_syntax::{SyntaxNode, SyntaxToken};
 
 use crate::{RefactorError, RefactorResult, SymbolKind, TextEdit};
 
@@ -250,7 +250,10 @@ fn name_exists_in_scope(
         SymbolKind::Type => scope.types.keys().any(|n| n.resolve(interner) == name),
         SymbolKind::Capability => scope.effects.keys().any(|n| n.resolve(interner) == name),
         SymbolKind::Variant => {
-            scope.constructors.keys().any(|n| n.resolve(interner) == name)
+            scope
+                .constructors
+                .keys()
+                .any(|n| n.resolve(interner) == name)
                 || scope
                     .type_variants
                     .keys()
@@ -340,8 +343,7 @@ fn collect_rename_edits(
             continue;
         };
 
-        if parent.kind() == SyntaxKind::ImportMember
-            && is_import_member_name_token(&token, &parent)
+        if parent.kind() == SyntaxKind::ImportMember && is_import_member_name_token(&token, &parent)
         {
             edits.push(TextEdit {
                 file_id,

--- a/crates/syntax/tests/integration_tests.rs
+++ b/crates/syntax/tests/integration_tests.rs
@@ -2,7 +2,9 @@
 #![allow(clippy::unwrap_used)]
 
 use kyokara_syntax::ast::AstNode;
-use kyokara_syntax::ast::nodes::{ElseBranch, FnDef, ForStmt, IfExpr, ImplDef, SourceFile, TraitDef, TypeDef};
+use kyokara_syntax::ast::nodes::{
+    ElseBranch, FnDef, ForStmt, IfExpr, ImplDef, SourceFile, TraitDef, TypeDef,
+};
 use kyokara_syntax::ast::traits::{HasName, HasTypeParams};
 use kyokara_syntax::{SyntaxKind, parse};
 
@@ -129,7 +131,18 @@ fn parse_trait_impl_and_derive_roundtrip_and_ast_access() {
         .descendants()
         .find_map(ImplDef::cast)
         .expect("impl def");
-    assert_eq!(impl_def.trait_ref().unwrap().path().unwrap().segments().next().unwrap().text(), "Show");
+    assert_eq!(
+        impl_def
+            .trait_ref()
+            .unwrap()
+            .path()
+            .unwrap()
+            .segments()
+            .next()
+            .unwrap()
+            .text(),
+        "Show"
+    );
     assert_eq!(impl_def.methods().count(), 1);
 }
 


### PR DESCRIPTION
## Summary
- run  across the workspace
- keep the tree aligned with current rustfmt output
- confirm strict clippy is clean after formatting

## Validation
- cargo fmt --all
- cargo clippy --workspace --tests -- -D warnings